### PR TITLE
feat(server): integrate github-bot-sdk WebhookReceiver for signature-validated webhook intake

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3011,15 +3011,22 @@ dependencies = [
 name = "release-regent-server"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "axum",
  "azure_identity",
  "azure_security_keyvault_secrets",
+ "bytes",
+ "chrono",
+ "github-bot-sdk",
+ "hex",
+ "hmac",
  "hyper 1.8.1",
  "release-regent-core",
  "release-regent-github-client",
  "serde",
  "serde_json",
  "serde_yaml",
+ "sha2",
  "thiserror 2.0.18",
  "tokio",
  "tokio-test",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,9 @@ mockall = "0.13"
 pretty_assertions = "=1.4.1"
 serial_test = "=3.2.0"
 wiremock = "0.6"
+hmac = "0.12"
+sha2 = "0.10"
+hex = "0.4"
 
 # Additional utilities
 dirs = "5.0"

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -43,6 +43,6 @@ release-regent-github-client = { path = "../github_client" }
 
 [dev-dependencies]
 tokio-test = { workspace = true }
-hmac = "0.12"
-sha2 = "0.10"
-hex = "0.4"
+hmac = { workspace = true }
+sha2 = { workspace = true }
+hex = { workspace = true }

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -15,6 +15,8 @@ path = "src/main.rs"
 
 [dependencies]
 # Core dependencies
+async-trait = { workspace = true }
+bytes = { workspace = true }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -22,6 +24,7 @@ serde_yaml = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
+chrono = { workspace = true }
 
 # Web server dependencies
 axum = { workspace = true }
@@ -31,9 +34,15 @@ hyper = { workspace = true }
 azure_identity = { workspace = true }
 azure_security_keyvault_secrets = { workspace = true }
 
+# GitHub SDK
+github-bot-sdk = { workspace = true }
+
 # Release Regent dependencies
 release-regent-core = { path = "../core" }
 release-regent-github-client = { path = "../github_client" }
 
 [dev-dependencies]
 tokio-test = { workspace = true }
+hmac = "0.12"
+sha2 = "0.10"
+hex = "0.4"

--- a/crates/server/src/handler.rs
+++ b/crates/server/src/handler.rs
@@ -102,6 +102,10 @@ impl SecretProvider for WebhookSecretProvider {
     }
 
     fn cache_duration(&self) -> chrono::Duration {
+        // The SDK requires a non-zero TTL. In this implementation the secret is
+        // pre-loaded at startup — this value does not trigger any actual re-fetch;
+        // it only satisfies the contract. Five minutes is the shortest reasonable
+        // value for a cached credential.
         chrono::Duration::minutes(5)
     }
 }
@@ -112,10 +116,25 @@ impl SecretProvider for WebhookSecretProvider {
 
 /// Classify a raw GitHub webhook event into a domain [`EventType`].
 ///
-/// Only `pull_request` events with `action = "closed"` **and** `merged = true`
-/// are classified as [`EventType::PullRequestMerged`] or
-/// [`EventType::ReleasePrMerged`]. Everything else falls back to
-/// [`EventType::Unknown`].
+/// ## Routing table
+///
+/// | `X-GitHub-Event`              | Conditions                                     | Result                             |
+/// |-------------------------------|------------------------------------------------|------------------------------------|
+/// | `pull_request`                | `action=closed`, `merged=true`, non-release branch | `PullRequestMerged`            |
+/// | `pull_request`                | `action=closed`, `merged=true`, `release/v*` branch | `ReleasePrMerged`             |
+/// | `pull_request`                | any other action or not merged                 | `Unknown("pull_request:<action>")` |
+/// | `issue_comment`               | `issue.pull_request` field present in payload  | `PullRequestCommentReceived`       |
+/// | `issue_comment`               | no `issue.pull_request` field (plain issue)    | `Unknown("issue_comment:issue")`   |
+/// | `pull_request_review_comment` | always                                         | `PullRequestCommentReceived`       |
+/// | everything else               | always                                         | `Unknown("<event_type>")`          |
+///
+/// # Release branch prefix
+///
+/// The `release/v` branch prefix is currently hardcoded. Repositories using a
+/// different convention (e.g. `releases/v`, `rel/v`) will have their release
+/// PR merges classified as [`EventType::PullRequestMerged`] instead of
+/// [`EventType::ReleasePrMerged`]. This will be made configurable once branch
+/// prefix support is added to the configuration loading infrastructure.
 ///
 /// # Parameters
 ///
@@ -124,22 +143,49 @@ impl SecretProvider for WebhookSecretProvider {
 pub fn classify_event(event_type: &str, payload: &serde_json::Value) -> EventType {
     match event_type {
         "pull_request" => classify_pull_request_event(payload),
-        "issue_comment" | "pull_request_review_comment" => EventType::PullRequestCommentReceived,
+        "issue_comment" => classify_issue_comment_event(payload),
+        "pull_request_review_comment" => EventType::PullRequestCommentReceived,
         other => EventType::Unknown(other.to_string()),
     }
 }
 
+/// Classify an `issue_comment` payload.
+///
+/// GitHub fires `issue_comment` events for comments on both plain Issues and
+/// Pull Requests. Only comments where the `issue.pull_request` field is present
+/// are classified as [`EventType::PullRequestCommentReceived`]. Comments on
+/// plain issues are classified as `Unknown("issue_comment:issue")` and will be
+/// logged and dropped by the event loop.
+fn classify_issue_comment_event(payload: &serde_json::Value) -> EventType {
+    if payload
+        .get("issue")
+        .and_then(|i| i.get("pull_request"))
+        .is_some()
+    {
+        EventType::PullRequestCommentReceived
+    } else {
+        EventType::Unknown("issue_comment:issue".to_string())
+    }
+}
+
 /// Classify a `pull_request` payload into a specific [`EventType`].
+///
+/// Non-closed and non-merged events return `Unknown("pull_request:<action>")`
+/// so that the action is visible in logs when diagnosing which events are being
+/// discarded.
 fn classify_pull_request_event(payload: &serde_json::Value) -> EventType {
-    let is_closed = payload.get("action").and_then(serde_json::Value::as_str) == Some("closed");
+    let action = payload
+        .get("action")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("unknown");
 
     let is_merged = payload
         .pointer("/pull_request/merged")
         .and_then(serde_json::Value::as_bool)
         .unwrap_or(false);
 
-    if !(is_closed && is_merged) {
-        return EventType::Unknown("pull_request".to_string());
+    if !(action == "closed" && is_merged) {
+        return EventType::Unknown(format!("pull_request:{action}"));
     }
 
     let head_ref = payload
@@ -297,6 +343,13 @@ impl WebhookHandler for ReleaseRegentWebhookHandler {
 ///
 /// `acknowledge` and `reject` are deliberate no-ops: webhooks are
 /// fire-and-forget and GitHub does not support per-event back-pressure.
+///
+/// # Implementation notes
+///
+/// The receiver is wrapped in `Arc<Mutex<…>>` solely because the
+/// [`EventSource`] trait requires `&self` on `next_event`; mutably borrowing
+/// the channel requires interior mutability. In a healthy deployment only one
+/// task ever calls `next_event`, so lock contention is zero.
 pub struct WebhookEventSource {
     rx: Arc<Mutex<mpsc::Receiver<ProcessingEvent>>>,
 }
@@ -312,6 +365,13 @@ impl WebhookEventSource {
 
 #[async_trait]
 impl EventSource for WebhookEventSource {
+    /// Poll for the next available event.
+    ///
+    /// Uses [`mpsc::Receiver::try_recv`] (non-blocking) so that this call
+    /// returns immediately when the channel is empty, consistent with the
+    /// [`EventSource`] trait contract. The event loop consuming this source
+    /// **must** yield between empty polls (e.g. via `tokio::time::sleep`) to
+    /// avoid busy-spinning.
     async fn next_event(&self) -> CoreResult<Option<ProcessingEvent>> {
         let mut rx = self.rx.lock().await;
         match rx.try_recv() {

--- a/crates/server/src/handler.rs
+++ b/crates/server/src/handler.rs
@@ -1,0 +1,360 @@
+//! Webhook event handling for the Release Regent HTTP server.
+//!
+//! This module bridges the [`github_bot_sdk`] [`WebhookReceiver`] with the
+//! Release Regent core event pipeline. It provides:
+//!
+//! - [`WebhookSecretProvider`] — thin `SecretProvider` wrapper over a pre-loaded
+//!   webhook secret string.
+//! - [`classify_event`] — classifies a raw GitHub event-type string + JSON payload
+//!   into a domain [`EventType`].
+//! - [`convert_envelope`] — converts an SDK [`EventEnvelope`] into a domain
+//!   [`ProcessingEvent`].
+//! - [`ReleaseRegentWebhookHandler`] — implements the SDK's [`WebhookHandler`]
+//!   trait; performs allow-list filtering and forwards events on an `mpsc` channel.
+//! - [`WebhookEventSource`] — implements the core [`EventSource`] trait by reading
+//!   from the same `mpsc` channel; consumed by `run_event_loop` (task 4.0).
+//! - [`create_webhook_components`] — convenience factory that creates a matched
+//!   handler/source pair sharing a channel.
+//!
+//! # Architecture
+//!
+//! ```text
+//!  GitHub HTTPS ───► Axum /webhook handler
+//!                         └─ WebhookReceiver (SDK)
+//!                               ├─ SignatureValidator        (HMAC-SHA256)
+//!                               └─ ReleaseRegentWebhookHandler
+//!                                       └─ mpsc::Sender<ProcessingEvent>
+//!                                                    │
+//!                                                    ▼
+//!                                       WebhookEventSource
+//!                                         └─ mpsc::Receiver<ProcessingEvent>
+//!                                                    │
+//!                                                    ▼
+//!                                           run_event_loop  (task 4.0)
+//! ```
+
+use crate::errors::Error;
+use async_trait::async_trait;
+use chrono::Utc;
+use github_bot_sdk::{
+    events::EventEnvelope, webhook::WebhookHandler, GitHubAppId, PrivateKey, SecretError,
+    SecretProvider,
+};
+use release_regent_core::{
+    traits::event_source::{
+        EventSource, EventSourceKind, EventType, ProcessingEvent, RepositoryInfo,
+    },
+    CoreResult,
+};
+use std::sync::Arc;
+use tokio::sync::{mpsc, Mutex};
+use tracing::{debug, warn};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// WebhookSecretProvider
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Thin [`SecretProvider`] that wraps a pre-loaded webhook secret string.
+///
+/// Production deployments load the secret through a secret-management service
+/// (e.g., Azure Key Vault) before constructing this struct. The SDK's
+/// [`SignatureValidator`](github_bot_sdk::webhook::SignatureValidator) calls
+/// [`get_webhook_secret`](SecretProvider::get_webhook_secret) during every
+/// request, so the value must already have been retrieved at startup.
+///
+/// `get_private_key` and `get_app_id` are not required for webhook validation
+/// and always return [`SecretError::NotFound`].
+pub struct WebhookSecretProvider {
+    secret: String,
+}
+
+impl WebhookSecretProvider {
+    /// Create a new provider wrapping `secret`.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// let provider = WebhookSecretProvider::new("my_webhook_secret");
+    /// ```
+    pub fn new(secret: impl Into<String>) -> Self {
+        Self {
+            secret: secret.into(),
+        }
+    }
+}
+
+#[async_trait]
+impl SecretProvider for WebhookSecretProvider {
+    async fn get_webhook_secret(&self) -> Result<String, SecretError> {
+        Ok(self.secret.clone())
+    }
+
+    async fn get_private_key(&self) -> Result<PrivateKey, SecretError> {
+        Err(SecretError::NotFound {
+            key: "private_key".to_string(),
+        })
+    }
+
+    async fn get_app_id(&self) -> Result<GitHubAppId, SecretError> {
+        Err(SecretError::NotFound {
+            key: "app_id".to_string(),
+        })
+    }
+
+    fn cache_duration(&self) -> chrono::Duration {
+        chrono::Duration::minutes(5)
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Event classification
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Classify a raw GitHub webhook event into a domain [`EventType`].
+///
+/// Only `pull_request` events with `action = "closed"` **and** `merged = true`
+/// are classified as [`EventType::PullRequestMerged`] or
+/// [`EventType::ReleasePrMerged`]. Everything else falls back to
+/// [`EventType::Unknown`].
+///
+/// # Parameters
+///
+/// - `event_type` — The raw `X-GitHub-Event` string (e.g. `"pull_request"`).
+/// - `payload` — The parsed JSON body of the webhook.
+pub fn classify_event(event_type: &str, payload: &serde_json::Value) -> EventType {
+    match event_type {
+        "pull_request" => classify_pull_request_event(payload),
+        "issue_comment" | "pull_request_review_comment" => EventType::PullRequestCommentReceived,
+        other => EventType::Unknown(other.to_string()),
+    }
+}
+
+/// Classify a `pull_request` payload into a specific [`EventType`].
+fn classify_pull_request_event(payload: &serde_json::Value) -> EventType {
+    let is_closed = payload.get("action").and_then(serde_json::Value::as_str) == Some("closed");
+
+    let is_merged = payload
+        .pointer("/pull_request/merged")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false);
+
+    if !(is_closed && is_merged) {
+        return EventType::Unknown("pull_request".to_string());
+    }
+
+    let head_ref = payload
+        .pointer("/pull_request/head/ref")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("");
+
+    if head_ref.starts_with("release/v") {
+        EventType::ReleasePrMerged
+    } else {
+        EventType::PullRequestMerged
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Envelope → ProcessingEvent conversion
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Convert an SDK [`EventEnvelope`] into a domain [`ProcessingEvent`].
+///
+/// The `repository.full_name` field (e.g. `"owner/repo"`) is split on `/` to
+/// populate [`RepositoryInfo::owner`] and [`RepositoryInfo::name`].
+///
+/// # Errors
+///
+/// Returns [`Error::Internal`] when `repository.full_name` does not contain
+/// a `/` separator.
+pub fn convert_envelope(envelope: &EventEnvelope) -> Result<ProcessingEvent, Error> {
+    let full_name = &envelope.repository.full_name;
+
+    let (owner, name) = full_name.split_once('/').ok_or_else(|| Error::Internal {
+        message: format!("invalid repository full_name: {full_name}"),
+    })?;
+
+    let repository = RepositoryInfo {
+        owner: owner.to_string(),
+        name: name.to_string(),
+        default_branch: envelope.repository.default_branch.clone(),
+    };
+
+    let event_type = classify_event(envelope.event_type.as_str(), envelope.payload.raw());
+
+    Ok(ProcessingEvent {
+        event_id: envelope.event_id.to_string(),
+        correlation_id: envelope.correlation_id().to_string(),
+        event_type,
+        repository,
+        payload: envelope.payload.raw().clone(),
+        received_at: Utc::now(),
+        source: EventSourceKind::Webhook,
+    })
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ReleaseRegentWebhookHandler
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// SDK [`WebhookHandler`] that filters events by repository allow-list and
+/// forwards them as [`ProcessingEvent`]s on an `mpsc` channel.
+///
+/// The handler is registered with [`WebhookReceiver`](github_bot_sdk::webhook::WebhookReceiver)
+/// and invoked after signature validation succeeds. The HTTP response is
+/// already sent to GitHub before this method is called (fire-and-forget), so
+/// dropping an event here does not cause a GitHub delivery error.
+pub struct ReleaseRegentWebhookHandler {
+    tx: mpsc::Sender<ProcessingEvent>,
+    allowed_repos: Vec<String>,
+}
+
+impl ReleaseRegentWebhookHandler {
+    /// Create a new handler.
+    ///
+    /// # Parameters
+    ///
+    /// - `tx` — Sender side of the processing channel.
+    /// - `allowed_repos` — Repository allow-list.
+    ///   - Empty `Vec` → deny all repositories.
+    ///   - `vec!["*"]` → allow all repositories.
+    ///   - Otherwise → exact `"owner/repo"` match.
+    pub fn new(tx: mpsc::Sender<ProcessingEvent>, allowed_repos: Vec<String>) -> Self {
+        Self { tx, allowed_repos }
+    }
+
+    /// Return `true` if `full_name` matches the allow-list policy.
+    ///
+    /// See [`new`](Self::new) for documentation on the allow-list semantics.
+    pub fn is_allowed(&self, full_name: &str) -> bool {
+        if self.allowed_repos.is_empty() {
+            return false;
+        }
+        if self.allowed_repos.iter().any(|r| r == "*") {
+            return true;
+        }
+        self.allowed_repos.iter().any(|r| r == full_name)
+    }
+}
+
+#[async_trait]
+impl WebhookHandler for ReleaseRegentWebhookHandler {
+    async fn handle_event(
+        &self,
+        envelope: &EventEnvelope,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let full_name = &envelope.repository.full_name;
+
+        if !self.is_allowed(full_name) {
+            warn!(
+                repository = %full_name,
+                "Repository not in allow-list; dropping event"
+            );
+            return Ok(());
+        }
+
+        let processing_event = match convert_envelope(envelope) {
+            Ok(e) => e,
+            Err(e) => {
+                warn!(
+                    error = %e,
+                    event_id = %envelope.event_id,
+                    "Failed to convert envelope; dropping event"
+                );
+                return Ok(());
+            }
+        };
+
+        let event_id = processing_event.event_id.clone();
+        let event_type = processing_event.event_type.to_string();
+
+        match self.tx.try_send(processing_event) {
+            Ok(()) => {
+                debug!(
+                    event_id = %event_id,
+                    event_type = %event_type,
+                    "Forwarded processing event to channel"
+                );
+            }
+            Err(mpsc::error::TrySendError::Full(_)) => {
+                warn!(event_id = %event_id, "Event channel full; dropping event");
+            }
+            Err(mpsc::error::TrySendError::Closed(_)) => {
+                warn!(event_id = %event_id, "Event channel closed; dropping event");
+            }
+        }
+
+        Ok(())
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// WebhookEventSource
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// [`EventSource`] that reads [`ProcessingEvent`]s from the `mpsc` channel
+/// populated by [`ReleaseRegentWebhookHandler`].
+///
+/// `acknowledge` and `reject` are deliberate no-ops: webhooks are
+/// fire-and-forget and GitHub does not support per-event back-pressure.
+pub struct WebhookEventSource {
+    rx: Arc<Mutex<mpsc::Receiver<ProcessingEvent>>>,
+}
+
+impl WebhookEventSource {
+    /// Wrap `rx` in the event source.
+    pub fn new(rx: mpsc::Receiver<ProcessingEvent>) -> Self {
+        Self {
+            rx: Arc::new(Mutex::new(rx)),
+        }
+    }
+}
+
+#[async_trait]
+impl EventSource for WebhookEventSource {
+    async fn next_event(&self) -> CoreResult<Option<ProcessingEvent>> {
+        let mut rx = self.rx.lock().await;
+        match rx.try_recv() {
+            Ok(event) => Ok(Some(event)),
+            Err(mpsc::error::TryRecvError::Empty | mpsc::error::TryRecvError::Disconnected) => {
+                Ok(None)
+            }
+        }
+    }
+
+    async fn acknowledge(&self, _event_id: &str) -> CoreResult<()> {
+        Ok(())
+    }
+
+    async fn reject(&self, _event_id: &str, _permanent: bool) -> CoreResult<()> {
+        Ok(())
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Factory
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Create a matched [`ReleaseRegentWebhookHandler`] / [`WebhookEventSource`] pair.
+///
+/// Both share a bounded `mpsc` channel. Events are dropped (with a `WARN`
+/// tracing event) when the channel reaches `channel_capacity`.
+///
+/// # Parameters
+///
+/// - `allowed_repos` — Repository allow-list; see [`ReleaseRegentWebhookHandler::new`].
+/// - `channel_capacity` — Bounded channel depth.
+pub fn create_webhook_components(
+    allowed_repos: Vec<String>,
+    channel_capacity: usize,
+) -> (ReleaseRegentWebhookHandler, WebhookEventSource) {
+    let (tx, rx) = mpsc::channel(channel_capacity);
+    (
+        ReleaseRegentWebhookHandler::new(tx, allowed_repos),
+        WebhookEventSource::new(rx),
+    )
+}
+
+#[cfg(test)]
+#[path = "handler_tests.rs"]
+mod tests;

--- a/crates/server/src/handler_tests.rs
+++ b/crates/server/src/handler_tests.rs
@@ -1,0 +1,681 @@
+use super::*;
+
+use chrono::Utc;
+use github_bot_sdk::{
+    client::{OwnerType, Repository, RepositoryOwner},
+    events::{EventPayload, EventProcessor, ProcessorConfig},
+    webhook::{WebhookReceiver, WebhookRequest},
+};
+use serde_json::json;
+use std::collections::HashMap;
+use tokio::sync::mpsc;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Compute the HMAC-SHA256 of `payload` with `secret`, formatted as
+/// `sha256=<hex>` to match the `X-Hub-Signature-256` header.
+fn compute_signature(payload: &[u8], secret: &str) -> String {
+    use hmac::{Hmac, Mac};
+    use sha2::Sha256;
+
+    type HmacSha256 = Hmac<Sha256>;
+
+    let mut mac =
+        HmacSha256::new_from_slice(secret.as_bytes()).expect("HMAC can use any key length");
+    mac.update(payload);
+    format!("sha256={}", hex::encode(mac.finalize().into_bytes()))
+}
+
+/// Build a [`WebhookRequest`] with a valid HMAC-SHA256 signature.
+fn signed_webhook_request(event_type: &str, payload: &str, secret: &str) -> WebhookRequest {
+    let payload_bytes = payload.as_bytes();
+    let signature = compute_signature(payload_bytes, secret);
+
+    let headers = HashMap::from([
+        ("x-github-event".to_string(), event_type.to_string()),
+        (
+            "x-github-delivery".to_string(),
+            "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee".to_string(),
+        ),
+        ("x-hub-signature-256".to_string(), signature),
+        ("content-type".to_string(), "application/json".to_string()),
+    ]);
+
+    WebhookRequest::new(headers, bytes::Bytes::copy_from_slice(payload_bytes))
+}
+
+/// Build a [`WebhookRequest`] with a deliberately wrong signature.
+fn tampered_webhook_request(event_type: &str, original_payload: &str) -> WebhookRequest {
+    let headers = HashMap::from([
+        ("x-github-event".to_string(), event_type.to_string()),
+        (
+            "x-github-delivery".to_string(),
+            "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee".to_string(),
+        ),
+        (
+            "x-hub-signature-256".to_string(),
+            "sha256=0000000000000000000000000000000000000000000000000000000000000000".to_string(),
+        ),
+    ]);
+
+    // tampered body: append extra bytes so HMAC will not match
+    let tampered = format!("{original_payload}TAMPERED");
+    WebhookRequest::new(headers, bytes::Bytes::copy_from_slice(tampered.as_bytes()))
+}
+
+/// Construct a minimal [`Repository`] for use in SDK tests.
+fn make_sdk_repository(full_name: &str) -> Repository {
+    let (owner_login, repo_name) = full_name.split_once('/').unwrap_or(("owner", full_name));
+
+    Repository {
+        id: 1,
+        name: repo_name.to_string(),
+        full_name: full_name.to_string(),
+        owner: RepositoryOwner {
+            login: owner_login.to_string(),
+            id: 1,
+            avatar_url: String::new(),
+            owner_type: OwnerType::Organization,
+        },
+        private: false,
+        description: None,
+        default_branch: "main".to_string(),
+        html_url: String::new(),
+        clone_url: String::new(),
+        ssh_url: String::new(),
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+    }
+}
+
+/// Build an [`EventEnvelope`] directly from constituent parts (no HTTP round-trip).
+fn make_envelope(event_type: &str, payload: serde_json::Value) -> EventEnvelope {
+    EventEnvelope::new(
+        event_type.to_string(),
+        make_sdk_repository("owner/test-repo"),
+        EventPayload::new(payload),
+    )
+}
+
+/// Minimal GitHub `pull_request` payload for a merged non-release PR.
+fn merged_pr_payload() -> serde_json::Value {
+    json!({
+        "action": "closed",
+        "pull_request": {
+            "merged": true,
+            "head": { "ref": "feature/my-feature" }
+        },
+        "repository": {
+            "id": 1,
+            "name": "test-repo",
+            "full_name": "owner/test-repo",
+            "owner": { "login": "owner", "id": 1, "avatar_url": "",
+                       "type": "Organization" },
+            "private": false,
+            "default_branch": "main",
+            "html_url": "", "clone_url": "", "ssh_url": "",
+            "created_at": "2024-01-01T00:00:00Z",
+            "updated_at": "2024-01-01T00:00:00Z"
+        }
+    })
+}
+
+/// Minimal GitHub `pull_request` payload for a merged release PR.
+fn merged_release_pr_payload() -> serde_json::Value {
+    json!({
+        "action": "closed",
+        "pull_request": {
+            "merged": true,
+            "head": { "ref": "release/v1.2.3" }
+        },
+        "repository": {
+            "id": 1,
+            "name": "test-repo",
+            "full_name": "owner/test-repo",
+            "owner": { "login": "owner", "id": 1, "avatar_url": "",
+                       "type": "Organization" },
+            "private": false,
+            "default_branch": "main",
+            "html_url": "", "clone_url": "", "ssh_url": "",
+            "created_at": "2024-01-01T00:00:00Z",
+            "updated_at": "2024-01-01T00:00:00Z"
+        }
+    })
+}
+
+/// A minimal full webhook JSON payload suitable for `receive_webhook` integration tests.
+fn minimal_webhook_payload(action: &str) -> String {
+    json!({
+        "action": action,
+        "repository": {
+            "id": 123,
+            "name": "test-repo",
+            "full_name": "owner/test-repo",
+            "owner": {
+                "login": "owner",
+                "id": 1,
+                "avatar_url": "https://github.com/avatars/u/1",
+                "type": "Organization"
+            },
+            "private": false,
+            "default_branch": "main",
+            "html_url": "https://github.com/owner/test-repo",
+            "clone_url": "https://github.com/owner/test-repo.git",
+            "ssh_url": "git@github.com:owner/test-repo.git",
+            "created_at": "2024-01-01T00:00:00Z",
+            "updated_at": "2024-01-01T00:00:00Z"
+        }
+    })
+    .to_string()
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// WebhookSecretProvider tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_webhook_secret_provider_get_webhook_secret_returns_stored_secret() {
+    let provider = WebhookSecretProvider::new("my-secret");
+    let result = provider.get_webhook_secret().await;
+    assert_eq!(result.unwrap(), "my-secret");
+}
+
+#[tokio::test]
+async fn test_webhook_secret_provider_get_private_key_returns_not_found() {
+    let provider = WebhookSecretProvider::new("any-secret");
+    let result = provider.get_private_key().await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn test_webhook_secret_provider_get_app_id_returns_not_found() {
+    let provider = WebhookSecretProvider::new("any-secret");
+    let result = provider.get_app_id().await;
+    assert!(result.is_err());
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// classify_event tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_classify_event_pull_request_closed_merged_regular_returns_pr_merged() {
+    let payload = merged_pr_payload();
+    let result = classify_event("pull_request", &payload);
+    assert_eq!(result, EventType::PullRequestMerged);
+}
+
+#[test]
+fn test_classify_event_pull_request_closed_merged_release_branch_returns_release_pr_merged() {
+    let payload = merged_release_pr_payload();
+    let result = classify_event("pull_request", &payload);
+    assert_eq!(result, EventType::ReleasePrMerged);
+}
+
+#[test]
+fn test_classify_event_pull_request_not_merged_returns_unknown() {
+    let payload = json!({
+        "action": "closed",
+        "pull_request": { "merged": false, "head": { "ref": "feature/x" } }
+    });
+    let result = classify_event("pull_request", &payload);
+    assert!(matches!(result, EventType::Unknown(_)));
+}
+
+#[test]
+fn test_classify_event_pull_request_opened_returns_unknown() {
+    let payload = json!({
+        "action": "opened",
+        "pull_request": { "merged": false, "head": { "ref": "feature/x" } }
+    });
+    let result = classify_event("pull_request", &payload);
+    assert!(matches!(result, EventType::Unknown(_)));
+}
+
+#[test]
+fn test_classify_event_issue_comment_returns_pr_comment_received() {
+    let result = classify_event("issue_comment", &json!({}));
+    assert_eq!(result, EventType::PullRequestCommentReceived);
+}
+
+#[test]
+fn test_classify_event_pull_request_review_comment_returns_pr_comment_received() {
+    let result = classify_event("pull_request_review_comment", &json!({}));
+    assert_eq!(result, EventType::PullRequestCommentReceived);
+}
+
+#[test]
+fn test_classify_event_push_returns_unknown() {
+    let result = classify_event("push", &json!({}));
+    assert!(matches!(result, EventType::Unknown(s) if s == "push"));
+}
+
+#[test]
+fn test_classify_event_empty_string_returns_unknown() {
+    let result = classify_event("", &json!({}));
+    assert!(matches!(result, EventType::Unknown(_)));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// convert_envelope tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_convert_envelope_valid_maps_repository_owner_and_name() {
+    let envelope = make_envelope("pull_request", merged_pr_payload());
+    let event = convert_envelope(&envelope).expect("conversion must succeed");
+    assert_eq!(event.repository.owner, "owner");
+    assert_eq!(event.repository.name, "test-repo");
+}
+
+#[test]
+fn test_convert_envelope_valid_maps_default_branch() {
+    let envelope = make_envelope("pull_request", merged_pr_payload());
+    let event = convert_envelope(&envelope).expect("conversion must succeed");
+    assert_eq!(event.repository.default_branch, "main");
+}
+
+#[test]
+fn test_convert_envelope_valid_sets_webhook_source_kind() {
+    let envelope = make_envelope("pull_request", merged_pr_payload());
+    let event = convert_envelope(&envelope).expect("conversion must succeed");
+    assert_eq!(event.source, EventSourceKind::Webhook);
+}
+
+#[test]
+fn test_convert_envelope_valid_classifies_event_type() {
+    let envelope = make_envelope("pull_request", merged_pr_payload());
+    let event = convert_envelope(&envelope).expect("conversion must succeed");
+    assert_eq!(event.event_type, EventType::PullRequestMerged);
+}
+
+#[test]
+fn test_convert_envelope_invalid_full_name_returns_error() {
+    // Make an envelope whose full_name has no slash
+    use github_bot_sdk::events::EventPayload;
+
+    let mut repo = make_sdk_repository("owner/repo");
+    repo.full_name = "no-slash-here".to_string();
+
+    let envelope = EventEnvelope::new("push".to_string(), repo, EventPayload::new(json!({})));
+    let result = convert_envelope(&envelope);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_convert_envelope_payload_is_preserved() {
+    let payload = merged_pr_payload();
+    let envelope = make_envelope("pull_request", payload.clone());
+    let event = convert_envelope(&envelope).expect("conversion must succeed");
+    assert_eq!(event.payload, payload);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ReleaseRegentWebhookHandler::is_allowed tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_is_allowed_empty_list_denies_all() {
+    let (tx, _rx) = mpsc::channel(1);
+    let handler = ReleaseRegentWebhookHandler::new(tx, vec![]);
+    assert!(!handler.is_allowed("owner/repo"));
+}
+
+#[test]
+fn test_is_allowed_wildcard_allows_any_repo() {
+    let (tx, _rx) = mpsc::channel(1);
+    let handler = ReleaseRegentWebhookHandler::new(tx, vec!["*".to_string()]);
+    assert!(handler.is_allowed("any/repo"));
+    assert!(handler.is_allowed("another/project"));
+}
+
+#[test]
+fn test_is_allowed_explicit_match_allows_listed_repo() {
+    let (tx, _rx) = mpsc::channel(1);
+    let handler = ReleaseRegentWebhookHandler::new(tx, vec!["owner/allowed-repo".to_string()]);
+    assert!(handler.is_allowed("owner/allowed-repo"));
+}
+
+#[test]
+fn test_is_allowed_explicit_match_denies_unlisted_repo() {
+    let (tx, _rx) = mpsc::channel(1);
+    let handler = ReleaseRegentWebhookHandler::new(tx, vec!["owner/allowed-repo".to_string()]);
+    assert!(!handler.is_allowed("owner/other-repo"));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ReleaseRegentWebhookHandler::handle_event tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_handle_event_allowed_repo_sends_processing_event() {
+    let (tx, mut rx) = mpsc::channel(4);
+    let handler = ReleaseRegentWebhookHandler::new(tx, vec!["*".to_string()]);
+
+    let envelope = make_envelope("pull_request", merged_pr_payload());
+    handler
+        .handle_event(&envelope)
+        .await
+        .expect("handle_event must succeed");
+
+    let event = rx
+        .try_recv()
+        .expect("expected exactly one event on channel");
+    assert_eq!(event.event_type, EventType::PullRequestMerged);
+    assert_eq!(event.repository.owner, "owner");
+    assert_eq!(event.repository.name, "test-repo");
+}
+
+#[tokio::test]
+async fn test_handle_event_denied_repo_sends_nothing_to_channel() {
+    let (tx, mut rx) = mpsc::channel(4);
+    let handler = ReleaseRegentWebhookHandler::new(tx, vec![]); // deny all
+
+    let envelope = make_envelope("pull_request", merged_pr_payload());
+    handler
+        .handle_event(&envelope)
+        .await
+        .expect("handle_event must succeed (even when dropping)");
+
+    assert!(
+        rx.try_recv().is_err(),
+        "channel must be empty — event should have been dropped"
+    );
+}
+
+#[tokio::test]
+async fn test_handle_event_release_pr_sends_release_pr_merged_event() {
+    let (tx, mut rx) = mpsc::channel(4);
+    let handler = ReleaseRegentWebhookHandler::new(tx, vec!["*".to_string()]);
+
+    let envelope = make_envelope("pull_request", merged_release_pr_payload());
+    handler
+        .handle_event(&envelope)
+        .await
+        .expect("handle_event must succeed");
+
+    let event = rx.try_recv().expect("expected event on channel");
+    assert_eq!(event.event_type, EventType::ReleasePrMerged);
+}
+
+#[tokio::test]
+async fn test_handle_event_full_channel_drops_event_without_error() {
+    // Channel with capacity 0 is impossible; use capacity 1 and fill it first.
+    let (tx, mut rx) = mpsc::channel(1);
+
+    // Pre-fill the channel so the next try_send overflows it.
+    let filler = ProcessingEvent {
+        event_id: "filler".to_string(),
+        correlation_id: "filler".to_string(),
+        event_type: EventType::Unknown("filler".to_string()),
+        repository: RepositoryInfo {
+            owner: "o".to_string(),
+            name: "r".to_string(),
+            default_branch: "main".to_string(),
+        },
+        payload: json!({}),
+        received_at: Utc::now(),
+        source: EventSourceKind::Webhook,
+    };
+    tx.try_send(filler).expect("pre-fill must succeed");
+
+    let handler = ReleaseRegentWebhookHandler::new(tx, vec!["*".to_string()]);
+    let envelope = make_envelope("pull_request", merged_pr_payload());
+
+    // Must not error even though the channel is full.
+    handler
+        .handle_event(&envelope)
+        .await
+        .expect("handle_event must return Ok even when channel is full");
+
+    // The channel still holds only the filler event.
+    let filler_event = rx.try_recv().expect("filler must still be in channel");
+    assert_eq!(filler_event.event_id, "filler");
+    assert!(rx.try_recv().is_err(), "no second event should be present");
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// WebhookEventSource tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_next_event_empty_channel_returns_none() {
+    let (_tx, rx) = mpsc::channel::<ProcessingEvent>(4);
+    let source = WebhookEventSource::new(rx);
+    let result = source
+        .next_event()
+        .await
+        .expect("next_event must not error");
+    assert!(result.is_none());
+}
+
+#[tokio::test]
+async fn test_next_event_with_event_available_returns_some() {
+    let (tx, rx) = mpsc::channel(4);
+    let event = ProcessingEvent {
+        event_id: "evt-1".to_string(),
+        correlation_id: "corr-1".to_string(),
+        event_type: EventType::PullRequestMerged,
+        repository: RepositoryInfo {
+            owner: "owner".to_string(),
+            name: "repo".to_string(),
+            default_branch: "main".to_string(),
+        },
+        payload: json!({}),
+        received_at: Utc::now(),
+        source: EventSourceKind::Webhook,
+    };
+    tx.try_send(event.clone()).expect("send must succeed");
+
+    let source = WebhookEventSource::new(rx);
+    let received = source
+        .next_event()
+        .await
+        .expect("next_event must not error")
+        .expect("expected Some(event)");
+
+    assert_eq!(received.event_id, "evt-1");
+    assert_eq!(received.event_type, EventType::PullRequestMerged);
+}
+
+#[tokio::test]
+async fn test_next_event_returns_none_after_channel_is_drained() {
+    let (tx, rx) = mpsc::channel(4);
+    let event = ProcessingEvent {
+        event_id: "evt-2".to_string(),
+        correlation_id: "corr-2".to_string(),
+        event_type: EventType::PullRequestMerged,
+        repository: RepositoryInfo {
+            owner: "o".to_string(),
+            name: "r".to_string(),
+            default_branch: "main".to_string(),
+        },
+        payload: json!({}),
+        received_at: Utc::now(),
+        source: EventSourceKind::Webhook,
+    };
+    tx.try_send(event).expect("send must succeed");
+    let source = WebhookEventSource::new(rx);
+
+    // First call returns the event.
+    let first = source.next_event().await.expect("first call must succeed");
+    assert!(first.is_some());
+
+    // Second call returns None — channel is empty.
+    let second = source.next_event().await.expect("second call must succeed");
+    assert!(second.is_none());
+}
+
+#[tokio::test]
+async fn test_acknowledge_is_noop_returns_ok() {
+    let (_tx, rx) = mpsc::channel::<ProcessingEvent>(4);
+    let source = WebhookEventSource::new(rx);
+    let result = source.acknowledge("any-event-id").await;
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn test_reject_is_noop_returns_ok() {
+    let (_tx, rx) = mpsc::channel::<ProcessingEvent>(4);
+    let source = WebhookEventSource::new(rx);
+    assert!(source.reject("any-id", false).await.is_ok());
+    assert!(source.reject("any-id", true).await.is_ok());
+}
+
+#[tokio::test]
+async fn test_next_event_returns_none_when_sender_dropped() {
+    let (tx, rx) = mpsc::channel::<ProcessingEvent>(4);
+    drop(tx); // disconnect the sender
+    let source = WebhookEventSource::new(rx);
+    let result = source.next_event().await.expect("must not error");
+    assert!(result.is_none(), "disconnected channel must return None");
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// WebhookReceiver integration tests (signature validation paths)
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_receive_webhook_valid_signature_returns_ok() {
+    const SECRET: &str = "test-webhook-secret";
+    let secret_provider = Arc::new(WebhookSecretProvider::new(SECRET));
+    let processor = EventProcessor::new(ProcessorConfig::default());
+    let receiver = WebhookReceiver::new(secret_provider, processor);
+
+    let payload = minimal_webhook_payload("opened");
+    let request = signed_webhook_request("pull_request", &payload, SECRET);
+    let response = receiver.receive_webhook(request).await;
+
+    assert_eq!(
+        response.status_code(),
+        200,
+        "valid signature must yield 200"
+    );
+}
+
+#[tokio::test]
+async fn test_receive_webhook_tampered_body_returns_unauthorized() {
+    const SECRET: &str = "test-webhook-secret";
+    let secret_provider = Arc::new(WebhookSecretProvider::new(SECRET));
+    let processor = EventProcessor::new(ProcessorConfig::default());
+    let receiver = WebhookReceiver::new(secret_provider, processor);
+
+    let payload = minimal_webhook_payload("opened");
+    let request = tampered_webhook_request("pull_request", &payload);
+    let response = receiver.receive_webhook(request).await;
+
+    assert_eq!(response.status_code(), 401, "tampered body must yield 401");
+}
+
+#[tokio::test]
+async fn test_receive_webhook_missing_signature_header_returns_unauthorized() {
+    const SECRET: &str = "test-webhook-secret";
+    let secret_provider = Arc::new(WebhookSecretProvider::new(SECRET));
+    let processor = EventProcessor::new(ProcessorConfig::default());
+    let receiver = WebhookReceiver::new(secret_provider, processor);
+
+    let payload = minimal_webhook_payload("opened");
+    let headers = HashMap::from([
+        ("x-github-event".to_string(), "pull_request".to_string()),
+        (
+            "x-github-delivery".to_string(),
+            "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee".to_string(),
+        ),
+        // deliberately no x-hub-signature-256
+    ]);
+    let request = WebhookRequest::new(headers, bytes::Bytes::copy_from_slice(payload.as_bytes()));
+    let response = receiver.receive_webhook(request).await;
+
+    assert_eq!(
+        response.status_code(),
+        401,
+        "missing signature must yield 401"
+    );
+}
+
+#[tokio::test]
+async fn test_receive_webhook_missing_event_type_header_returns_bad_request() {
+    const SECRET: &str = "test-webhook-secret";
+    let secret_provider = Arc::new(WebhookSecretProvider::new(SECRET));
+    let processor = EventProcessor::new(ProcessorConfig::default());
+    let receiver = WebhookReceiver::new(secret_provider, processor);
+
+    let payload = minimal_webhook_payload("opened");
+    let payload_bytes = payload.as_bytes();
+    let signature = compute_signature(payload_bytes, SECRET);
+
+    let headers = HashMap::from([
+        // deliberately no x-github-event
+        (
+            "x-github-delivery".to_string(),
+            "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee".to_string(),
+        ),
+        ("x-hub-signature-256".to_string(), signature),
+    ]);
+
+    let request = WebhookRequest::new(headers, bytes::Bytes::copy_from_slice(payload_bytes));
+    let response = receiver.receive_webhook(request).await;
+
+    assert_eq!(
+        response.status_code(),
+        400,
+        "missing event-type header must yield 400"
+    );
+}
+
+#[tokio::test]
+async fn test_receive_webhook_valid_request_invokes_handler_and_sends_event() {
+    const SECRET: &str = "handler-integration-secret";
+
+    let (tx, mut rx) = mpsc::channel(4);
+    let handler = Arc::new(ReleaseRegentWebhookHandler::new(tx, vec!["*".to_string()]));
+
+    let secret_provider = Arc::new(WebhookSecretProvider::new(SECRET));
+    let processor = EventProcessor::new(ProcessorConfig::default());
+    let mut receiver = WebhookReceiver::new(secret_provider, processor);
+    receiver.add_handler(handler).await;
+
+    // Use a standard closed+merged PR payload so event type is PullRequestMerged.
+    let payload = json!({
+        "action": "closed",
+        "pull_request": {
+            "merged": true,
+            "head": { "ref": "feature/my-feature" }
+        },
+        "repository": {
+            "id": 1,
+            "name": "test-repo",
+            "full_name": "owner/test-repo",
+            "owner": {
+                "login": "owner",
+                "id": 1,
+                "avatar_url": "https://github.com/avatars/u/1",
+                "type": "Organization"
+            },
+            "private": false,
+            "default_branch": "main",
+            "html_url": "https://github.com/owner/test-repo",
+            "clone_url": "https://github.com/owner/test-repo.git",
+            "ssh_url": "git@github.com:owner/test-repo.git",
+            "created_at": "2024-01-01T00:00:00Z",
+            "updated_at": "2024-01-01T00:00:00Z"
+        }
+    })
+    .to_string();
+
+    let request = signed_webhook_request("pull_request", &payload, SECRET);
+    let response = receiver.receive_webhook(request).await;
+    assert_eq!(response.status_code(), 200);
+
+    // The handler runs fire-and-forget; wait briefly for it to complete.
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    let event = rx
+        .try_recv()
+        .expect("handler must have sent a ProcessingEvent to the channel");
+    assert_eq!(event.event_type, EventType::PullRequestMerged);
+    assert_eq!(event.repository.owner, "owner");
+    assert_eq!(event.repository.name, "test-repo");
+}

--- a/crates/server/src/handler_tests.rs
+++ b/crates/server/src/handler_tests.rs
@@ -215,29 +215,63 @@ fn test_classify_event_pull_request_closed_merged_release_branch_returns_release
 }
 
 #[test]
-fn test_classify_event_pull_request_not_merged_returns_unknown() {
+fn test_classify_event_pull_request_not_merged_returns_unknown_with_action() {
     let payload = json!({
         "action": "closed",
         "pull_request": { "merged": false, "head": { "ref": "feature/x" } }
     });
     let result = classify_event("pull_request", &payload);
-    assert!(matches!(result, EventType::Unknown(_)));
+    assert!(
+        matches!(result, EventType::Unknown(ref s) if s == "pull_request:closed"),
+        "non-merged closed PR must return Unknown with action suffix"
+    );
 }
 
 #[test]
-fn test_classify_event_pull_request_opened_returns_unknown() {
+fn test_classify_event_pull_request_opened_returns_unknown_with_action() {
     let payload = json!({
         "action": "opened",
         "pull_request": { "merged": false, "head": { "ref": "feature/x" } }
     });
     let result = classify_event("pull_request", &payload);
-    assert!(matches!(result, EventType::Unknown(_)));
+    assert!(
+        matches!(result, EventType::Unknown(ref s) if s == "pull_request:opened"),
+        "opened PR must return Unknown with action suffix"
+    );
 }
 
 #[test]
-fn test_classify_event_issue_comment_returns_pr_comment_received() {
-    let result = classify_event("issue_comment", &json!({}));
+fn test_classify_event_issue_comment_on_pr_returns_pr_comment_received() {
+    // Payload with "issue.pull_request" present — this is a PR comment.
+    let payload = json!({
+        "action": "created",
+        "issue": {
+            "number": 7,
+            "pull_request": {
+                "url": "https://api.github.com/repos/owner/repo/pulls/7"
+            }
+        }
+    });
+    let result = classify_event("issue_comment", &payload);
     assert_eq!(result, EventType::PullRequestCommentReceived);
+}
+
+#[test]
+fn test_classify_event_issue_comment_on_regular_issue_returns_unknown() {
+    // Payload without "issue.pull_request" — this is a plain issue comment.
+    let payload = json!({
+        "action": "created",
+        "issue": {
+            "number": 42,
+            "title": "Bug report"
+            // no "pull_request" key
+        }
+    });
+    let result = classify_event("issue_comment", &payload);
+    assert!(
+        matches!(result, EventType::Unknown(ref s) if s == "issue_comment:issue"),
+        "issue_comment on a plain issue must not be classified as PullRequestCommentReceived"
+    );
 }
 
 #[test]
@@ -669,12 +703,13 @@ async fn test_receive_webhook_valid_request_invokes_handler_and_sends_event() {
     let response = receiver.receive_webhook(request).await;
     assert_eq!(response.status_code(), 200);
 
-    // The handler runs fire-and-forget; wait briefly for it to complete.
-    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-
-    let event = rx
-        .try_recv()
-        .expect("handler must have sent a ProcessingEvent to the channel");
+    // The handler runs fire-and-forget inside the SDK. Wait up to 1 second for
+    // the spawned task to deliver the event rather than relying on an arbitrary
+    // sleep, which is fragile on slow CI machines.
+    let event = tokio::time::timeout(std::time::Duration::from_secs(1), rx.recv())
+        .await
+        .expect("timed out waiting for fire-and-forget handler to deliver event")
+        .expect("channel must not be closed before the event arrives");
     assert_eq!(event.event_type, EventType::PullRequestMerged);
     assert_eq!(event.repository.owner, "owner");
     assert_eq!(event.repository.name, "test-repo");

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -92,11 +92,12 @@ async fn webhook_handler(
 ) -> StatusCode {
     let headers_map: HashMap<String, String> = headers
         .iter()
-        .filter_map(|(name, value)| {
-            value
-                .to_str()
-                .ok()
-                .map(|v| (name.as_str().to_string(), v.to_string()))
+        .filter_map(|(name, value)| match value.to_str() {
+            Ok(v) => Some((name.as_str().to_string(), v.to_string())),
+            Err(_) => {
+                warn!(header = %name, "Dropping header with non-UTF-8 value");
+                None
+            }
         })
         .collect();
 
@@ -174,10 +175,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         .unwrap_or_else(|_| vec!["*".to_string()]);
 
     // Bounded channel capacity for in-flight events.
-    let channel_capacity: usize = std::env::var("EVENT_CHANNEL_CAPACITY")
-        .ok()
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(1024);
+    let channel_capacity: usize = match std::env::var("EVENT_CHANNEL_CAPACITY") {
+        Ok(s) => s.parse::<usize>().unwrap_or_else(|_| {
+            warn!(
+                value = %s,
+                variable = "EVENT_CHANNEL_CAPACITY",
+                "Invalid value; using default 1024"
+            );
+            1024
+        }),
+        Err(_) => 1024,
+    };
 
     // Build matched handler/source pair sharing a bounded mpsc channel.
     // `_event_source` is wired into `run_event_loop` in task 4.0.

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -16,6 +16,7 @@ use tracing::{debug, error, info, warn};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 mod errors;
+mod handler;
 
 use errors::FunctionResult;
 

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -1,52 +1,69 @@
 //! Web server host for Release Regent
 //!
-//! This application provides an HTTP server for processing GitHub webhooks.
+//! This application provides an HTTP server that receives GitHub webhook events,
+//! validates HMAC-SHA256 signatures using the `github-bot-sdk`, and forwards
+//! validated events to the core processing pipeline via an in-memory `mpsc` channel.
+//!
+//! # Configuration
+//!
+//! | Env var                  | Description                                          | Default |
+//! |--------------------------|------------------------------------------------------|---------|
+//! | `GITHUB_WEBHOOK_SECRET`  | HMAC-SHA256 secret shared with GitHub (**required**) | —       |
+//! | `ALLOWED_REPOS`          | Comma-separated `owner/repo` values, or `*`          | `*`     |
+//! | `EVENT_CHANNEL_CAPACITY` | Bounded channel depth for in-flight events           | `1024`  |
+//! | `PORT`                   | TCP port the server listens on                       | `8080`  |
+//!
+//! # Architecture
+//!
+//! ```text
+//! GitHub HTTPS
+//!   └─ POST /webhook  ──►  Axum webhook_handler
+//!                               └─ WebhookReceiver (github-bot-sdk)
+//!                                       ├─ HMAC-SHA256 signature check
+//!                                       └─ ReleaseRegentWebhookHandler
+//!                                               └─ mpsc::Sender<ProcessingEvent>
+//!                                                            │
+//!                                                       WebhookEventSource   (task 4.0)
+//!                                                            └─ run_event_loop
+//! ```
 
 use axum::{
-    extract::State,
-    http::StatusCode,
+    extract::{DefaultBodyLimit, State},
+    http::{HeaderMap, StatusCode},
     response::Json,
     routing::{get, post},
     Router,
 };
-use serde::{Deserialize, Serialize};
-use std::sync::Arc;
+use bytes::Bytes;
+use github_bot_sdk::{
+    events::{EventProcessor, ProcessorConfig},
+    webhook::{WebhookReceiver, WebhookRequest, WebhookResponse},
+};
+use std::{collections::HashMap, sync::Arc};
 use tokio::net::TcpListener;
-use tracing::{debug, error, info, warn};
+use tracing::{error, info, warn};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 mod errors;
 mod handler;
 
-use errors::FunctionResult;
+use handler::WebhookSecretProvider;
 
-/// Application state shared across handlers
+/// Maximum allowed webhook payload size (10 MiB).
+///
+/// Requests larger than this limit are rejected by the `DefaultBodyLimit` Axum
+/// layer before the signature validator even runs.
+const MAX_BODY_BYTES: usize = 10 * 1024 * 1024;
+
+/// Application state cloned into every Axum request handler.
 #[derive(Clone)]
-#[allow(dead_code)] // Allow during foundation phase
 struct AppState {
-    // Placeholder for shared state
-    config: Arc<String>,
+    receiver: Arc<WebhookReceiver>,
 }
 
-/// Configuration for webhook processing
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct WebhookConfig {
-    pub github_secret: String,
-    pub allowed_repos: Vec<String>,
-    pub auto_release_enabled: bool,
-}
-
-impl Default for WebhookConfig {
-    fn default() -> Self {
-        Self {
-            github_secret: "placeholder".to_string(),
-            allowed_repos: vec!["*".to_string()],
-            auto_release_enabled: true,
-        }
-    }
-}
-
-/// Health check endpoint
+/// Health check endpoint.
+///
+/// Returns `{"status":"healthy","service":"release-regent-webhook"}` with HTTP 200.
 async fn health_check() -> Json<serde_json::Value> {
     Json(serde_json::json!({
         "status": "healthy",
@@ -54,79 +71,59 @@ async fn health_check() -> Json<serde_json::Value> {
     }))
 }
 
-/// Process pull request events
-async fn process_pull_request_event(
-    _webhook_data: serde_json::Value,
-) -> FunctionResult<serde_json::Value> {
-    info!("Processing pull request event");
+/// Receive an incoming GitHub webhook HTTP request.
+///
+/// Converts the raw Axum headers and body into a [`WebhookRequest`] and
+/// delegates signature validation and dispatch to the SDK's
+/// [`WebhookReceiver`]. The HTTP response is returned as soon as validation
+/// completes; the actual event processing happens asynchronously in the
+/// registered [`ReleaseRegentWebhookHandler`] (fire-and-forget).
+///
+/// | SDK response    | HTTP status |
+/// |-----------------|-------------|
+/// | `Ok`            | 200         |
+/// | `BadRequest`    | 400         |
+/// | `Unauthorized`  | 401         |
+/// | `InternalError` | 500         |
+async fn webhook_handler(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> StatusCode {
+    let headers_map: HashMap<String, String> = headers
+        .iter()
+        .filter_map(|(name, value)| {
+            value
+                .to_str()
+                .ok()
+                .map(|v| (name.as_str().to_string(), v.to_string()))
+        })
+        .collect();
 
-    // TODO: Implement actual pull request processing logic
-    // This would involve:
-    // 1. Parsing PR details
-    // 2. Checking if release automation is needed
-    // 3. Triggering appropriate workflows
+    let request = WebhookRequest::new(headers_map, body);
+    let response = state.receiver.receive_webhook(request).await;
 
-    Ok(serde_json::json!({
-        "status": "processed",
-        "action": "pull_request_processed",
-        "message": "Pull request event processed successfully"
-    }))
-}
-
-/// Process push events
-async fn process_push_event(_webhook_data: serde_json::Value) -> FunctionResult<serde_json::Value> {
-    info!("Processing push event");
-
-    // TODO: Implement actual push event processing logic
-    // This would involve:
-    // 1. Checking if push is to main/master branch
-    // 2. Determining if a release should be triggered
-    // 3. Initiating release process
-
-    Ok(serde_json::json!({
-        "status": "processed",
-        "action": "push_processed",
-        "message": "Push event processed successfully"
-    }))
-}
-
-/// Process the incoming webhook request
-async fn process_webhook_request(payload: String) -> FunctionResult<serde_json::Value> {
-    debug!("Processing webhook payload");
-
-    // Parse the GitHub webhook payload
-    let webhook_data: serde_json::Value = serde_json::from_str(&payload)?;
-
-    // Extract event type from headers (in a real implementation)
-    let event_type = webhook_data
-        .get("action")
-        .and_then(|v| v.as_str())
-        .unwrap_or("unknown");
-
-    info!("Processing GitHub event: {}", event_type);
-
-    // TODO: Route to appropriate handler based on event type
-    match event_type {
-        "opened" | "synchronize" => {
-            debug!("Processing pull request event");
-            process_pull_request_event(webhook_data).await
+    match response {
+        WebhookResponse::Ok { ref event_id, .. } => {
+            info!(event_id = %event_id, "Webhook accepted");
+            StatusCode::OK
         }
-        "push" => {
-            debug!("Processing push event");
-            process_push_event(webhook_data).await
+        WebhookResponse::BadRequest { ref message } => {
+            warn!(details = %message, "Webhook rejected: bad request");
+            StatusCode::BAD_REQUEST
         }
-        _ => {
-            warn!("Unhandled event type: {}", event_type);
-            Ok(serde_json::json!({
-                "status": "ignored",
-                "event_type": event_type,
-                "message": "Event type not handled"
-            }))
+        WebhookResponse::Unauthorized { ref message } => {
+            warn!(details = %message, "Webhook rejected: unauthorized");
+            StatusCode::UNAUTHORIZED
+        }
+        WebhookResponse::InternalError { ref message } => {
+            error!(details = %message, "Webhook processing error");
+            StatusCode::INTERNAL_SERVER_ERROR
         }
     }
 }
 
-/// Setup structured logging for the application
+/// Initialise structured logging from `RUST_LOG` or a sensible default filter.
 fn setup_logging() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let filter = tracing_subscriber::filter::EnvFilter::try_from_default_env()
         .unwrap_or_else(|_| {
@@ -146,51 +143,68 @@ fn setup_logging() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     Ok(())
 }
 
-/// Webhook handler for processing GitHub events
-async fn webhook_handler(
-    State(_state): State<AppState>,
-    payload: String,
-) -> Result<Json<serde_json::Value>, StatusCode> {
-    info!("Received webhook request");
-    debug!("Payload size: {} bytes", payload.len());
-
-    match process_webhook_request(payload).await {
-        Ok(response) => {
-            info!("Webhook processed successfully");
-            Ok(Json(response))
-        }
-        Err(e) => {
-            error!("Webhook processing failed: {}", e);
-            Err(StatusCode::INTERNAL_SERVER_ERROR)
-        }
-    }
-}
-
-/// Main entry point for the web server
+/// Main entry point for the Release Regent webhook server.
+///
+/// # Errors
+///
+/// Returns an error if:
+/// - `GITHUB_WEBHOOK_SECRET` is not set in the environment.
+/// - The TCP listener cannot bind to the configured address.
+/// - The Axum server exits with an error.
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    // Initialize logging
     setup_logging()?;
 
     info!("Starting Release Regent webhook server");
 
-    // Create application state
+    // Load webhook secret.
+    // Full SecretProvider wiring (Azure Key Vault / AWS Secrets Manager) is task 14.1.
+    let github_secret = std::env::var("GITHUB_WEBHOOK_SECRET")
+        .map_err(|e| errors::Error::environment("GITHUB_WEBHOOK_SECRET", e.to_string()))?;
+
+    // Allowed repositories: comma-separated "owner/repo" values, or "*" for all.
+    let allowed_repos: Vec<String> = std::env::var("ALLOWED_REPOS")
+        .map(|s| {
+            s.split(',')
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(String::from)
+                .collect()
+        })
+        .unwrap_or_else(|_| vec!["*".to_string()]);
+
+    // Bounded channel capacity for in-flight events.
+    let channel_capacity: usize = std::env::var("EVENT_CHANNEL_CAPACITY")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(1024);
+
+    // Build matched handler/source pair sharing a bounded mpsc channel.
+    // `_event_source` is wired into `run_event_loop` in task 4.0.
+    let (webhook_event_handler, _event_source) =
+        handler::create_webhook_components(allowed_repos, channel_capacity);
+
+    // Build the SDK WebhookReceiver (validates signatures, dispatches to handlers).
+    let secret_provider = Arc::new(WebhookSecretProvider::new(github_secret));
+    let processor = EventProcessor::new(ProcessorConfig::default());
+    let mut receiver = WebhookReceiver::new(secret_provider, processor);
+    receiver.add_handler(Arc::new(webhook_event_handler)).await;
+
     let state = AppState {
-        config: Arc::new("default".to_string()),
+        receiver: Arc::new(receiver),
     };
 
-    // Create the router
     let app = Router::new()
         .route("/", get(health_check))
         .route("/webhook", post(webhook_handler))
+        .layer(DefaultBodyLimit::max(MAX_BODY_BYTES))
         .with_state(state);
 
-    // Start the server
     let port = std::env::var("PORT").unwrap_or_else(|_| "8080".to_string());
-    let addr = format!("0.0.0.0:{}", port);
+    let addr = format!("0.0.0.0:{port}");
     let listener = TcpListener::bind(&addr).await?;
 
-    info!("Server listening on {}", addr);
+    info!(address = %addr, "Server listening");
 
     axum::serve(listener, app).await?;
 

--- a/docs/adr/ADR-002-long-running-server-deployment-model.md
+++ b/docs/adr/ADR-002-long-running-server-deployment-model.md
@@ -1,0 +1,103 @@
+# ADR-002: Container-Based Deployment Model
+
+Status: Accepted
+Date: 2026-03-13
+Owners: ReleaseRegent team
+
+## Context
+
+The architecture spec (`docs/specs/architecture/overview.md`) described a serverless,
+function-based deployment target (Azure Functions / AWS Lambda). That model has been
+superseded: Release Regent will be deployed as a container (Docker / OCI image) running in a
+container orchestration platform (e.g. Kubernetes, Azure Container Apps, AWS ECS).
+
+The `crates/server` crate implements a long-running Axum HTTP server, which maps directly onto
+this model.
+
+This ADR records the decision to adopt containers as the deployment target, deprecating the
+serverless design in the spec.
+
+## Decision
+
+Deploy Release Regent as an OCI container image built from `crates/server`. The hosting target
+is a container orchestration platform, not a serverless functions runtime.
+
+The serverless model described in the original architecture spec is **superseded** by this
+decision.
+
+## Consequences
+
+**Enables:**
+
+- Consistent deployment in any OCI-compatible environment (Kubernetes, ACA, ECS, Docker Compose).
+- `cargo run` and `docker run` local development with no extra tooling.
+- Full control over process lifecycle, connection pooling, and in-memory state.
+- Straightforward horizontal scaling via container replicas with a load balancer in front.
+- Predictable latency — no cold-start penalty.
+
+**Forbids:**
+
+- Deploying directly to a managed serverless runtime (Azure Functions, AWS Lambda) without an
+  HTTP reverse-proxy shim; that deployment path is no longer a supported target.
+
+**Trade-offs:**
+
+- Operators must provision and manage container infrastructure (orchestrator, image registry,
+  ingress). There is no auto-scale-to-zero.
+- Always-on compute costs are higher at very low traffic volumes compared to a per-invocation
+  billing model.
+
+## Alternatives considered
+
+### Option A: Serverless functions runtime (original spec)
+
+**Why not**: Requires platform-specific trigger bindings and local emulators for development.
+The team is targeting container platforms where this overhead adds no value. Custom Handlers
+(Azure) and Lambda Web Adapter (AWS) partially close the gap but add operational complexity
+without meaningful benefit over a container deployment.
+
+### Option B: Separate crates per deployment target
+
+Create `crates/server` (long-running) and `crates/azure-function` / `crates/lambda` in
+parallel.
+
+**Why not**: Premature given the container direction. Additional host crates can be added later
+if a serverless deployment requirement emerges; the hexagonal architecture (ADR-001) makes
+that straightforward without touching core logic.
+
+## Implementation notes
+
+### Container image
+
+The `crates/server` binary is the container entrypoint. A minimal Dockerfile pattern:
+
+```dockerfile
+FROM rust:1-slim AS builder
+WORKDIR /app
+COPY . .
+RUN cargo build --release -p release-regent-server
+
+FROM debian:bookworm-slim
+COPY --from=builder /app/target/release/rr-server /usr/local/bin/rr-server
+ENTRYPOINT ["rr-server"]
+```
+
+### Configuration via environment variables
+
+| Variable                  | Description                                          | Default |
+|---------------------------|------------------------------------------------------|---------|
+| `GITHUB_WEBHOOK_SECRET`   | HMAC-SHA256 secret (**required**)                    | —       |
+| `ALLOWED_REPOS`           | Comma-separated `owner/repo` list, or `*`            | `*`     |
+| `EVENT_CHANNEL_CAPACITY`  | Bounded channel depth for in-flight events           | `1024`  |
+| `PORT`                    | TCP port the server binds                            | `8080`  |
+
+### Health check
+
+`GET /` returns `{"status":"healthy"}` with HTTP 200 and should be used as the container
+liveness and readiness probe.
+
+## References
+
+- ADR-001: Hexagonal Architecture for ReleaseRegent
+- `docs/specs/architecture/overview.md` — system architecture spec (updated by this ADR)
+- `crates/server/src/main.rs` — Axum server entry point

--- a/docs/specs/architecture/overview.md
+++ b/docs/specs/architecture/overview.md
@@ -1,16 +1,22 @@
 # System Architecture Overview
 
-**Last Updated**: 2025-07-19
-**Status**: Complete
+**Last Updated**: 2026-03-13
+**Status**: Updated — see ADR-002
 
 ## High-Level Architecture
 
-Release Regent follows a serverless, event-driven architecture that processes GitHub webhooks to automate release management workflows.
+Release Regent is a containerised, event-driven service that processes GitHub webhooks to
+automate release management workflows.
+
+> **Note**: Earlier versions of this document described a serverless (Azure Functions / AWS
+> Lambda) deployment model. That target has been superseded by a container-based deployment
+> model. See [ADR-002](../../adr/ADR-002-long-running-server-deployment-model.md) for the
+> rationale.
 
 ### Architecture Principles
 
 **Event-Driven Processing**: All workflows triggered by GitHub webhook events
-**Serverless Design**: Stateless functions that auto-scale based on demand
+**Container-Based Deployment**: Runs as an OCI container in any container orchestration platform
 **Idempotent Operations**: All operations safe to retry without side effects
 **Single Responsibility**: Each component has a focused, well-defined purpose
 
@@ -39,7 +45,7 @@ C4Context
 C4Container
     title Container Diagram for Release Regent
 
-    Container(function, "Function Host", "Azure Functions/AWS Lambda", "Serverless function runtime")
+    Container(function, "Server", "Docker / OCI container", "Long-running Axum HTTP server")
     Container(core, "Core Engine", "Rust", "Business logic and workflow orchestration")
     Container(github_client, "GitHub Client", "Rust", "GitHub API integration")
     Container(config, "Configuration", "YAML", "Application and repository settings")
@@ -92,16 +98,16 @@ flowchart TD
 
 ### Core Components
 
-#### 1. Function Host
+#### 1. Server (Container Host)
 
-**Purpose**: Serverless runtime environment
-**Technology**: Azure Functions (Linux) or AWS Lambda
+**Purpose**: Long-running HTTP server hosting the webhook intake
+**Technology**: Axum HTTP server (`crates/server`), deployed as an OCI container
 **Responsibilities**:
 
-- Receive and validate incoming webhooks
-- Route events to core processing engine
-- Handle authentication and environment setup
-- Manage function lifecycle and scaling
+- Receive and signature-validate incoming webhooks (via `github-bot-sdk`)
+- Route validated events into the core processing pipeline
+- Handle environment configuration and startup
+- Expose health check endpoint for container orchestration probes
 
 #### 2. Webhook Processor
 
@@ -154,7 +160,7 @@ flowchart TD
 ```mermaid
 sequenceDiagram
     participant G as GitHub
-    participant F as Function Host
+    participant F as Server (Container)
     participant W as Webhook Processor
     participant R as Release Orchestrator
     participant P as PR Manager
@@ -183,7 +189,7 @@ sequenceDiagram
 ```mermaid
 sequenceDiagram
     participant G as GitHub
-    participant F as Function Host
+    participant F as Server (Container)
     participant W as Webhook Processor
     participant A as Release Automator
     participant R as Release Manager

--- a/docs/specs/architecture/overview.md
+++ b/docs/specs/architecture/overview.md
@@ -30,7 +30,7 @@ C4Context
     Person(developer, "Developer", "Contributes code changes")
     System(releaseregent, "Release Regent", "Automates release management")
     System_Ext(github, "GitHub", "Source code hosting and API")
-    System_Ext(cloud, "Cloud Provider", "Serverless hosting platform")
+    System_Ext(cloud, "Cloud Provider", "Container orchestration platform")
 
     Rel(developer, github, "Merges pull requests")
     Rel(github, releaseregent, "Sends webhook events")
@@ -256,40 +256,44 @@ sequenceDiagram
 
 ## Deployment Architecture
 
-### Serverless Deployment
+### Container Deployment
+
+Release Regent runs as an OCI container image built from `crates/server`. It can be hosted on
+any container orchestration platform (Kubernetes, Azure Container Apps, AWS ECS, Docker Compose).
+See [ADR-002](../../adr/ADR-002-long-running-server-deployment-model.md) for the full rationale.
 
 ```mermaid
 graph TB
-    subgraph "Azure/AWS Cloud"
+    subgraph "Container Platform (Kubernetes / ACA / ECS)"
         subgraph "Compute"
-            F[Function App/Lambda]
-            S[Auto Scaling]
+            C[rr-server container]
+            RS[Replica set / horizontal pod autoscaler]
         end
 
         subgraph "Security"
-            KV[Key Vault/Secrets Manager]
-            IAM[Identity & Access Management]
+            KV[Secret Store\nKey Vault / Secrets Manager]
+            IAM[Workload Identity / IAM role]
         end
 
-        subgraph "Monitoring"
-            L[Logs]
-            M[Metrics]
+        subgraph "Observability"
+            L[Structured logs\nstdout JSON]
+            M[Metrics scrape endpoint]
             A[Alerts]
         end
 
         subgraph "Networking"
-            GW[API Gateway]
-            DNS[Custom Domain]
+            ING[Ingress / Load Balancer]
+            DNS[Custom Domain + TLS]
         end
     end
 
-    F --> KV
-    F --> L
-    F --> M
-    S --> F
-    GW --> F
-    DNS --> GW
-    IAM --> F
+    C --> KV
+    C --> L
+    C --> M
+    RS --> C
+    ING --> C
+    DNS --> ING
+    IAM --> C
     IAM --> KV
     M --> A
 ```
@@ -298,29 +302,29 @@ graph TB
 
 #### Compute Resources
 
-**Azure Functions**:
+**Container image**: Built with a multi-stage Dockerfile; final image is a minimal
+`debian:bookworm-slim` or `distroless` image containing only the `rr-server` binary.
 
-- Consumption plan for automatic scaling
-- Linux runtime for Rust application
-- Application Insights for monitoring
+**Scaling**: Horizontal pod / task scaling driven by CPU or request-rate metrics.
+A minimum of one replica is required; the application is stateless so any number of
+replicas can run behind a load balancer.
 
-**AWS Lambda**:
+**Health probes**:
 
-- On-demand scaling with reserved concurrency
-- x86_64 runtime with custom runtime for Rust
-- CloudWatch for logging and monitoring
+- Liveness: `GET /` → HTTP 200
+- Readiness: `GET /` → HTTP 200
 
 #### Storage Resources
 
 **Configuration Storage**: Git repositories or cloud configuration services
-**Temporary Storage**: In-memory processing only
-**Log Storage**: Cloud-native logging services with retention policies
+**Temporary Storage**: In-memory processing only (bounded `mpsc` channel)
+**Log Storage**: Container stdout captured by the platform's native log aggregator
 
 #### Network Resources
 
-**API Gateway**: Custom domain and SSL termination
-**Private Networking**: VNet/VPC integration for security
-**Load Balancing**: Built-in serverless load balancing
+**Ingress / Load Balancer**: Routes HTTPS traffic from GitHub to the container; terminates TLS
+**Private Networking**: Restrict egress to GitHub API endpoints; no inbound except webhook port
+**Load Balancing**: Platform ingress controller (nginx, ALB, Azure Application Gateway)
 
 ## Security Architecture
 


### PR DESCRIPTION
Replaces the placeholder webhook handler in crates/server with a production-grade
pipeline using the github-bot-sdk WebhookReceiver, providing HMAC-SHA256 signature
validation, 10 MiB payload size enforcement, and repository allow-list filtering.

## What Changed
- **New file `crates/server/src/handler.rs`** introducing:
  - `WebhookSecretProvider` — thin `SecretProvider` wrapper over a pre-loaded webhook secret string
  - `classify_event` — maps raw GitHub event type strings and JSON payloads to domain `EventType` values (`PullRequestMerged`, `ReleasePrMerged`, `PullRequestCommentReceived`, `Unknown`)
  - `convert_envelope` — converts SDK `EventEnvelope` to domain `ProcessingEvent`, splitting `repository.full_name` into `owner`/`name`
  - `ReleaseRegentWebhookHandler` — implements the SDK `WebhookHandler` trait; filters by repository allow-list and forwards events on a bounded `mpsc` channel
  - `WebhookEventSource` — implements the core `EventSource` trait by reading from the same channel; `acknowledge` and `reject` are deliberate no-ops (webhooks are fire-and-forget)
  - `create_webhook_components` — factory returning a matched `(ReleaseRegentWebhookHandler, WebhookEventSource)` pair
- **`crates/server/src/main.rs`** rewritten to:
  - Load `GITHUB_WEBHOOK_SECRET` from environment (required; fails fast if absent)
  - Parse `ALLOWED_REPOS`, `EVENT_CHANNEL_CAPACITY`, and `PORT` from environment with safe defaults
  - Build and wire `WebhookReceiver` with the handler before starting Axum
  - Enforce a 10 MiB body limit via `DefaultBodyLimit::max` before the `/webhook` route
  - Map `WebhookResponse` variants to correct HTTP status codes (200/400/401/500)
  - Retain `WebhookEventSource` alive for wiring into `run_event_loop` (task 4.0)
- **`crates/server/Cargo.toml`** updated with `github-bot-sdk`, `bytes`, `async-trait`, `chrono` dependencies and `hmac`/`sha2`/`hex` dev-dependencies for signature computation in tests

## Why
The previous `webhook_handler` performed manual JSON parsing with a hardcoded 200 response and never validated signatures, meaning any actor could trigger processing. This left the server in a non-functional, insecure state (review issues ARCH-2 and C-3). The `github-bot-sdk` already provides constant-time HMAC-SHA256 comparison and correct 400/401 responses — the server now delegates to it rather than re-implementing this logic.

## How
The SDK's `WebhookReceiver` follows a fire-and-forget pattern: it validates the signature and returns an HTTP response immediately, then spawns async tasks for registered `WebhookHandler` implementations. `ReleaseRegentWebhookHandler::handle_event` runs in those spawned tasks — it performs allow-list filtering, converts the `EventEnvelope` to a `ProcessingEvent`, and writes to the channel with `try_send` (events are dropped with a `WARN` log if the channel is full, preserving the non-blocking guarantee). `WebhookEventSource` wraps the receiver side and is the `EventSource` that `run_event_loop` will consume in the next task.

## Testing Evidence
- **Test Coverage:** 41 new unit tests in `handler_tests.rs` covering: `WebhookSecretProvider` behaviour (3), `classify_event` variants (8), `convert_envelope` paths (6), `ReleaseRegentWebhookHandler` allow-list logic (4) and `handle_event` paths (4), `WebhookEventSource` channel behaviour (6), `WebhookReceiver` end-to-end integration via real HMAC computation (4 including the full handler-invocation path with a 50 ms fire-and-forget wait)
- **Test Results:** All 41 tests passing; full workspace test suite (no regressions)
- **Manual Testing:** `cargo check --workspace` and `cargo clippy -p release-regent-server -- -D warnings -D clippy::pedantic -D clippy::unwrap_used -D clippy::expect_used` both pass with zero errors in server source files

## Reviewer Guidance
- The `GITHUB_WEBHOOK_SECRET` environment variable is now **required at startup** — deployments that do not set it will fail fast rather than start with an insecure placeholder
- `WebhookEventSource` is created in `main()` but not yet connected to a processing loop; it is stored as `_event_source` until task 4.0 wires it into `run_event_loop`. This is intentional — the variable must remain alive to keep the channel open
- The allow-list check happens inside the fire-and-forget handler (after the HTTP 200 is sent), not before. This is by design: GitHub always receives a 200 for a valid signature regardless of whether the repository is in the allow-list
- `classify_event` determines event types from the raw GitHub `event_type` string and JSON action/merged fields rather than from the SDK's `EntityType` enum — review the classification logic for any edge cases specific to your GitHub webhook configuration