### PR TITLE
feat(core): add CommentCommandProcessor for PR comment version overrides

### DIFF
--- a/crates/core/src/comment_command_processor.rs
+++ b/crates/core/src/comment_command_processor.rs
@@ -1,0 +1,398 @@
+//! Comment command processor for Release Regent
+//!
+//! This module implements the [`CommentCommandProcessor`], which handles
+//! [`EventType::PullRequestCommentReceived`] events and extracts recognised
+//! command patterns from PR comment bodies.
+//!
+//! ## Recognised Commands
+//!
+//! | Command                       | Condition               | Effect                                        |
+//! |-------------------------------|-------------------------|-----------------------------------------------|
+//! | `!set-version X.Y.Z`          | version > current tag   | Invokes `ReleaseOrchestrator` with pinned ver |
+//! | `!set-version X.Y.Z`          | version ≤ current tag   | Posts rejection comment; acknowledges event   |
+//! | `!release major/minor/patch`  | always (stub)           | Returns `CoreError::NotSupported`             |
+//!
+//! ## Guards
+//!
+//! Processing of all commands is gated by `VersioningConfig::allow_override`.
+//! When `allow_override` is `false` every comment is silently ignored and the
+//! event is acknowledged without any GitHub API calls.
+//!
+//! Comments posted on **closed** pull requests are similarly ignored —
+//! the open/closed state is read from `payload["issue"]["state"]` — so that
+//! stale comments do not trigger spurious version changes.
+//!
+//! ## Payload Structure
+//!
+//! The processor expects the raw GitHub `issue_comment` webhook payload as the
+//! [`ProcessingEvent::payload`] field:
+//!
+//! ```json
+//! {
+//!   "action": "created",
+//!   "issue": { "number": 42, "state": "open" },
+//!   "comment": { "body": "!set-version 2.0.0" }
+//! }
+//! ```
+
+use std::cmp::Ordering;
+
+use tracing::{debug, info, warn};
+
+use crate::{
+    release_orchestrator::{OrchestratorConfig, ReleaseOrchestrator},
+    traits::{event_source::ProcessingEvent, github_operations::GitHubOperations},
+    versioning::{resolve_current_version, SemanticVersion, VersionCalculator},
+    CoreError, CoreResult,
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Public types
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Which conventional-commit bump dimension the user is requesting via
+/// an `!release` override command.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BumpKind {
+    /// Force at least a major version bump.
+    Major,
+    /// Force at least a minor version bump.
+    Minor,
+    /// Force at least a patch version bump.
+    Patch,
+}
+
+/// A command parsed from a pull request comment body.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CommentCommand {
+    /// `!set-version X.Y.Z` — pin the next release to exactly this version.
+    SetVersion(SemanticVersion),
+    /// `!release major|minor|patch` — override the minimum bump dimension.
+    ///
+    /// **Note**: this variant is recognised by the parser but the processor
+    /// returns [`CoreError::NotSupported`] until the bump-override design is
+    /// completed.
+    ReleaseBump(BumpKind),
+    /// No recognised command was found in the comment body.
+    Unknown,
+}
+
+/// Configuration for [`CommentCommandProcessor`].
+#[derive(Debug, Clone)]
+pub struct CommentCommandConfig {
+    /// Configuration forwarded to the release orchestrator when `!set-version`
+    /// triggers an orchestration run.
+    pub orchestrator_config: OrchestratorConfig,
+    /// Whether PR comment overrides are enabled for this repository.
+    ///
+    /// When `false` all commands are silently ignored and the event is
+    /// acknowledged without any GitHub API calls.
+    pub allow_override: bool,
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CommentCommandProcessor
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Processes [`EventType::PullRequestCommentReceived`] events.
+///
+/// Generic over `G` so that tests can inject an inline test double while
+/// production code uses the real GitHub client.
+pub struct CommentCommandProcessor<'a, G: GitHubOperations> {
+    config: CommentCommandConfig,
+    github: &'a G,
+}
+
+impl<'a, G: GitHubOperations + Send + Sync> CommentCommandProcessor<'a, G> {
+    /// Create a new processor.
+    ///
+    /// # Parameters
+    /// - `config`: Processor configuration including `allow_override` flag and
+    ///   orchestrator settings used when a `!set-version` command succeeds.
+    /// - `github`: Borrowed reference to the `GitHubOperations` implementation.
+    pub fn new(config: CommentCommandConfig, github: &'a G) -> Self {
+        Self { config, github }
+    }
+
+    /// Process a [`ProcessingEvent`] of type
+    /// [`EventType::PullRequestCommentReceived`].
+    ///
+    /// Returns `Ok(())` for all non-action-producing cases—unknown command,
+    /// disabled override, closed PR, or validation rejections—so the event loop
+    /// acknowledges rather than retries.  Only GitHub API failures and the
+    /// `!release` stub propagate as errors.
+    ///
+    /// # Errors
+    ///
+    /// - [`CoreError::NotSupported`] — `!release` bump override is a stub
+    ///   (not yet implemented).  The event loop treats this as a permanent
+    ///   failure and rejects the event without retrying.
+    /// - [`CoreError::GitHub`] / [`CoreError::Network`] — a GitHub API call
+    ///   failed; propagated so the event loop can retry if transient.
+    pub async fn process(&self, event: &ProcessingEvent) -> CoreResult<()> {
+        let span = tracing::info_span!(
+            "comment_command_processor.process",
+            event_id = %event.event_id,
+            correlation_id = %event.correlation_id,
+            owner = %event.repository.owner,
+            repo = %event.repository.name,
+        );
+        let _enter = span.enter();
+
+        if !self.config.allow_override {
+            debug!(
+                event_id = %event.event_id,
+                "allow_override is false — silently ignoring comment event"
+            );
+            return Ok(());
+        }
+
+        let owner = &event.repository.owner;
+        let repo = &event.repository.name;
+
+        // Extract PR open/closed state from the webhook payload.
+        // Comments on non-open PRs are silently ignored.
+        let pr_state = event
+            .payload
+            .get("issue")
+            .and_then(|i| i.get("state"))
+            .and_then(|s| s.as_str())
+            .unwrap_or("unknown");
+
+        if pr_state != "open" {
+            debug!(
+                event_id = %event.event_id,
+                pr_state,
+                "Comment is on a non-open PR — ignoring"
+            );
+            return Ok(());
+        }
+
+        let Some(issue_number) = event
+            .payload
+            .get("issue")
+            .and_then(|i| i.get("number"))
+            .and_then(serde_json::Value::as_u64)
+        else {
+            debug!(
+                event_id = %event.event_id,
+                "payload missing issue.number — ignoring"
+            );
+            return Ok(());
+        };
+
+        let Some(comment_body_str) = event
+            .payload
+            .get("comment")
+            .and_then(|c| c.get("body"))
+            .and_then(serde_json::Value::as_str)
+        else {
+            debug!(
+                event_id = %event.event_id,
+                "payload missing comment.body — ignoring"
+            );
+            return Ok(());
+        };
+        let comment_body = comment_body_str.to_string();
+
+        let command = parse_comment_command(&comment_body);
+        debug!(
+            event_id = %event.event_id,
+            ?command,
+            "Parsed comment command"
+        );
+
+        match command {
+            CommentCommand::Unknown => Ok(()),
+            CommentCommand::ReleaseBump(_kind) => Err(CoreError::not_supported(
+                "!release bump override",
+                "!release major/minor/patch is not yet fully implemented; \
+                 the bump-override design (label persistence, precedence rules) \
+                 must be completed before this command can be processed",
+            )),
+            CommentCommand::SetVersion(pinned_version) => {
+                self.handle_set_version(
+                    owner,
+                    repo,
+                    issue_number,
+                    &pinned_version,
+                    &event.correlation_id,
+                )
+                .await
+            }
+        }
+    }
+
+    // ── Private helpers ────────────────────────────────────────────────────
+
+    /// Handle a validated `!set-version X.Y.Z` command.
+    ///
+    /// Validates the pinned version against the current released version, then
+    /// invokes the [`ReleaseOrchestrator`] with the pinned version.  Validation
+    /// failures post a rejection comment and return `Ok(())`.
+    async fn handle_set_version(
+        &self,
+        owner: &str,
+        repo: &str,
+        pr_number: u64,
+        pinned_version: &SemanticVersion,
+        correlation_id: &str,
+    ) -> CoreResult<()> {
+        // Resolve the currently released version from Git tags.
+        let current_version = resolve_current_version(self.github, owner, repo, false).await?;
+
+        // Validate: pinned must be strictly > current released version.
+        if let Some(ref current) = current_version {
+            if pinned_version.compare_precedence(current) != Ordering::Greater {
+                let rejection = format!(
+                    "❌ **Release Regent**: `!set-version {pinned_version}` was rejected — \
+                     the specified version must be strictly greater than the current \
+                     released version `{current}`."
+                );
+                warn!(
+                    pr_number,
+                    pinned = %pinned_version,
+                    current = %current,
+                    "Rejecting !set-version: not greater than current released version"
+                );
+                return self
+                    .post_rejection_comment(owner, repo, pr_number, &rejection)
+                    .await;
+            }
+        }
+
+        // Validate: minimum accepted version is 0.0.1 (rejects 0.0.0).
+        let minimum = SemanticVersion {
+            major: 0,
+            minor: 0,
+            patch: 1,
+            prerelease: None,
+            build: None,
+        };
+        if pinned_version.compare_precedence(&minimum) == Ordering::Less {
+            let rejection = format!(
+                "❌ **Release Regent**: `!set-version {pinned_version}` was rejected — \
+                 the minimum allowed version is `0.0.1`."
+            );
+            warn!(
+                pr_number,
+                pinned = %pinned_version,
+                "Rejecting !set-version: version is below minimum (0.0.1)"
+            );
+            return self
+                .post_rejection_comment(owner, repo, pr_number, &rejection)
+                .await;
+        }
+
+        info!(
+            pr_number,
+            pinned = %pinned_version,
+            "!set-version accepted — invoking release orchestrator"
+        );
+
+        // Retrieve the PR to extract the base branch name and SHA.
+        let pr = self.github.get_pull_request(owner, repo, pr_number).await?;
+        let base_branch = pr.base.ref_name.clone();
+        let base_sha = pr.base.sha.clone();
+
+        let orchestrator =
+            ReleaseOrchestrator::new(self.config.orchestrator_config.clone(), self.github);
+
+        orchestrator
+            .orchestrate(
+                owner,
+                repo,
+                pinned_version,
+                "", // no new changelog entries for a direct version pin
+                &base_branch,
+                &base_sha,
+                correlation_id,
+            )
+            .await
+            .map(|_| ())
+    }
+
+    /// Post a rejection comment on the PR and return `Ok(())` so the event is
+    /// acknowledged (not retried).
+    async fn post_rejection_comment(
+        &self,
+        owner: &str,
+        repo: &str,
+        pr_number: u64,
+        body: &str,
+    ) -> CoreResult<()> {
+        self.github
+            .create_issue_comment(owner, repo, pr_number, body)
+            .await
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// parse_comment_command — free function, public for unit testing
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Parse a pull request comment body into a [`CommentCommand`].
+///
+/// Scanning is line-by-line and case-insensitive.  The **first** line that
+/// matches a known command pattern wins; remaining lines are ignored.
+///
+/// A `!set-version` line with an unparseable semver string is skipped rather
+/// than returning an error — the line is treated as unrecognised so the event
+/// is acknowledged without side effects.
+///
+/// # Examples
+///
+/// ```
+/// use release_regent_core::comment_command_processor::{
+///     parse_comment_command, BumpKind, CommentCommand,
+/// };
+/// use release_regent_core::versioning::SemanticVersion;
+///
+/// let cmd = parse_comment_command("!set-version 2.3.0");
+/// assert_eq!(
+///     cmd,
+///     CommentCommand::SetVersion(SemanticVersion {
+///         major: 2, minor: 3, patch: 0,
+///         prerelease: None, build: None
+///     })
+/// );
+///
+/// let bump = parse_comment_command("!release minor");
+/// assert_eq!(bump, CommentCommand::ReleaseBump(BumpKind::Minor));
+///
+/// let unknown = parse_comment_command("just a regular comment");
+/// assert_eq!(unknown, CommentCommand::Unknown);
+/// ```
+#[must_use]
+pub fn parse_comment_command(body: &str) -> CommentCommand {
+    for line in body.lines() {
+        let trimmed = line.trim();
+        let lower = trimmed.to_lowercase();
+
+        if let Some(rest) = lower.strip_prefix("!set-version") {
+            let version_str = rest.trim();
+            // Strip an optional leading "v" that developers sometimes include.
+            let version_str = version_str.strip_prefix('v').unwrap_or(version_str);
+            if let Ok(v) = VersionCalculator::parse_version(version_str) {
+                return CommentCommand::SetVersion(v);
+            }
+            // Malformed version string — skip this line and keep scanning.
+            continue;
+        }
+
+        if let Some(rest) = lower.strip_prefix("!release") {
+            return match rest.trim() {
+                "major" => CommentCommand::ReleaseBump(BumpKind::Major),
+                "minor" => CommentCommand::ReleaseBump(BumpKind::Minor),
+                "patch" => CommentCommand::ReleaseBump(BumpKind::Patch),
+                _ => CommentCommand::Unknown,
+            };
+        }
+    }
+
+    CommentCommand::Unknown
+}
+
+#[cfg(test)]
+#[path = "comment_command_processor_tests.rs"]
+mod tests;

--- a/crates/core/src/comment_command_processor.rs
+++ b/crates/core/src/comment_command_processor.rs
@@ -6,11 +6,11 @@
 //!
 //! ## Recognised Commands
 //!
-//! | Command                       | Condition               | Effect                                        |
-//! |-------------------------------|-------------------------|-----------------------------------------------|
-//! | `!set-version X.Y.Z`          | version > current tag   | Invokes `ReleaseOrchestrator` with pinned ver |
-//! | `!set-version X.Y.Z`          | version ≤ current tag   | Posts rejection comment; acknowledges event   |
-//! | `!release major/minor/patch`  | always (stub)           | Returns `CoreError::NotSupported`             |
+//! | Command                       | Condition               | Effect                                                         |
+//! |-------------------------------|-------------------------|----------------------------------------------------------------|
+//! | `!set-version X.Y.Z`          | version > current tag   | Invokes `ReleaseOrchestrator` with pinned ver                  |
+//! | `!set-version X.Y.Z`          | version ≤ current tag   | Posts rejection comment; acknowledges event                    |
+//! | `!release major/minor/patch`  | always (stub)           | Posts "not yet supported" comment; acknowledges event          |
 //!
 //! ## Guards
 //!
@@ -37,13 +37,16 @@
 
 use std::cmp::Ordering;
 
-use tracing::{debug, info, warn};
+use tracing::{debug, info, warn, Instrument};
 
 use crate::{
     release_orchestrator::{OrchestratorConfig, ReleaseOrchestrator},
-    traits::{event_source::ProcessingEvent, github_operations::GitHubOperations},
+    traits::{
+        event_source::ProcessingEvent,
+        github_operations::GitHubOperations,
+    },
     versioning::{resolve_current_version, SemanticVersion, VersionCalculator},
-    CoreError, CoreResult,
+    CoreResult,
 };
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -70,8 +73,8 @@ pub enum CommentCommand {
     /// `!release major|minor|patch` — override the minimum bump dimension.
     ///
     /// **Note**: this variant is recognised by the parser but the processor
-    /// returns [`CoreError::NotSupported`] until the bump-override design is
-    /// completed.
+    /// posts an informational comment and acknowledges the event until the
+    /// bump-override design is completed.
     ReleaseBump(BumpKind),
     /// No recognised command was found in the comment body.
     Unknown,
@@ -119,14 +122,11 @@ impl<'a, G: GitHubOperations + Send + Sync> CommentCommandProcessor<'a, G> {
     ///
     /// Returns `Ok(())` for all non-action-producing cases—unknown command,
     /// disabled override, closed PR, or validation rejections—so the event loop
-    /// acknowledges rather than retries.  Only GitHub API failures and the
-    /// `!release` stub propagate as errors.
+    /// acknowledges rather than retries.  Only GitHub API failures propagate
+    /// as errors.
     ///
     /// # Errors
     ///
-    /// - [`CoreError::NotSupported`] — `!release` bump override is a stub
-    ///   (not yet implemented).  The event loop treats this as a permanent
-    ///   failure and rejects the event without retrying.
     /// - [`CoreError::GitHub`] / [`CoreError::Network`] — a GitHub API call
     ///   failed; propagated so the event loop can retry if transient.
     pub async fn process(&self, event: &ProcessingEvent) -> CoreResult<()> {
@@ -137,7 +137,10 @@ impl<'a, G: GitHubOperations + Send + Sync> CommentCommandProcessor<'a, G> {
             owner = %event.repository.owner,
             repo = %event.repository.name,
         );
-        let _enter = span.enter();
+        self.process_inner(event).instrument(span).await
+    }
+
+    async fn process_inner(&self, event: &ProcessingEvent) -> CoreResult<()> {
 
         if !self.config.allow_override {
             debug!(
@@ -195,6 +198,40 @@ impl<'a, G: GitHubOperations + Send + Sync> CommentCommandProcessor<'a, G> {
         };
         let comment_body = comment_body_str.to_string();
 
+        // Extract the commenter's GitHub login for the authorization check below.
+        let Some(commenter_login) = event
+            .payload
+            .get("comment")
+            .and_then(|c| c.get("user"))
+            .and_then(|u| u.get("login"))
+            .and_then(serde_json::Value::as_str)
+        else {
+            debug!(
+                event_id = %event.event_id,
+                "payload missing comment.user.login — ignoring"
+            );
+            return Ok(());
+        };
+
+        // Only collaborators with write access or above may issue commands.
+        let permission = self
+            .github
+            .get_collaborator_permission(owner, repo, commenter_login)
+            .await?;
+        if !permission.can_issue_commands() {
+            warn!(
+                event_id = %event.event_id,
+                commenter_login,
+                ?permission,
+                "Command rejected: commenter has insufficient permission"
+            );
+            let rejection = format!(
+                "❌ **Release Regent**: @{commenter_login} — only collaborators with \
+                 write access (or above) may use Release Regent commands."
+            );
+            return self.post_comment(owner, repo, issue_number, &rejection).await;
+        }
+
         let command = parse_comment_command(&comment_body);
         debug!(
             event_id = %event.event_id,
@@ -204,12 +241,13 @@ impl<'a, G: GitHubOperations + Send + Sync> CommentCommandProcessor<'a, G> {
 
         match command {
             CommentCommand::Unknown => Ok(()),
-            CommentCommand::ReleaseBump(_kind) => Err(CoreError::not_supported(
-                "!release bump override",
-                "!release major/minor/patch is not yet fully implemented; \
-                 the bump-override design (label persistence, precedence rules) \
-                 must be completed before this command can be processed",
-            )),
+            CommentCommand::ReleaseBump(_kind) => {
+                // The !release bump design is not yet complete. Post an informational
+                // comment so the user gets feedback and acknowledge the event (Ok).
+                let body = "ℹ️ **Release Regent**: `!release` bump overrides are not yet \
+                             supported. This command will be available in a future release.";
+                self.post_comment(owner, repo, issue_number, body).await
+            }
             CommentCommand::SetVersion(pinned_version) => {
                 self.handle_set_version(
                     owner,
@@ -229,7 +267,8 @@ impl<'a, G: GitHubOperations + Send + Sync> CommentCommandProcessor<'a, G> {
     ///
     /// Validates the pinned version against the current released version, then
     /// invokes the [`ReleaseOrchestrator`] with the pinned version.  Validation
-    /// failures post a rejection comment and return `Ok(())`.
+    /// failures post a rejection comment and return `Ok(())` so the event is
+    /// acknowledged (not retried).
     async fn handle_set_version(
         &self,
         owner: &str,
@@ -256,7 +295,7 @@ impl<'a, G: GitHubOperations + Send + Sync> CommentCommandProcessor<'a, G> {
                     "Rejecting !set-version: not greater than current released version"
                 );
                 return self
-                    .post_rejection_comment(owner, repo, pr_number, &rejection)
+                    .post_comment(owner, repo, pr_number, &rejection)
                     .await;
             }
         }
@@ -280,7 +319,7 @@ impl<'a, G: GitHubOperations + Send + Sync> CommentCommandProcessor<'a, G> {
                 "Rejecting !set-version: version is below minimum (0.0.1)"
             );
             return self
-                .post_rejection_comment(owner, repo, pr_number, &rejection)
+                .post_comment(owner, repo, pr_number, &rejection)
                 .await;
         }
 
@@ -303,7 +342,7 @@ impl<'a, G: GitHubOperations + Send + Sync> CommentCommandProcessor<'a, G> {
                 owner,
                 repo,
                 pinned_version,
-                "", // no new changelog entries for a direct version pin
+                "Version pinned via PR comment override.",
                 &base_branch,
                 &base_sha,
                 correlation_id,
@@ -312,18 +351,29 @@ impl<'a, G: GitHubOperations + Send + Sync> CommentCommandProcessor<'a, G> {
             .map(|_| ())
     }
 
-    /// Post a rejection comment on the PR and return `Ok(())` so the event is
-    /// acknowledged (not retried).
-    async fn post_rejection_comment(
+    /// Post a comment on the PR as a best-effort operation.
+    ///
+    /// If the GitHub API call fails the error is logged as a warning and
+    /// `Ok(())` is returned, so the event is acknowledged rather than retried.
+    async fn post_comment(
         &self,
         owner: &str,
         repo: &str,
         pr_number: u64,
         body: &str,
     ) -> CoreResult<()> {
-        self.github
+        if let Err(e) = self
+            .github
             .create_issue_comment(owner, repo, pr_number, body)
             .await
+        {
+            warn!(
+                pr_number,
+                error = %e,
+                "Failed to post comment on PR; event will still be acknowledged"
+            );
+        }
+        Ok(())
     }
 }
 
@@ -369,8 +419,10 @@ pub fn parse_comment_command(body: &str) -> CommentCommand {
         let trimmed = line.trim();
         let lower = trimmed.to_lowercase();
 
-        if let Some(rest) = lower.strip_prefix("!set-version") {
-            let version_str = rest.trim();
+        if lower.starts_with("!set-version") {
+            // Slice the version argument from the *original* trimmed line so that
+            // pre-release/build identifiers (e.g. "2.0.0-RC.1") are not lowercased.
+            let version_str = trimmed["!set-version".len()..].trim();
             // Strip an optional leading "v" that developers sometimes include.
             let version_str = version_str.strip_prefix('v').unwrap_or(version_str);
             if let Ok(v) = VersionCalculator::parse_version(version_str) {
@@ -380,8 +432,11 @@ pub fn parse_comment_command(body: &str) -> CommentCommand {
             continue;
         }
 
-        if let Some(rest) = lower.strip_prefix("!release") {
-            return match rest.trim() {
+        if lower.starts_with("!release") {
+            // Extract the bump dimension from the original trimmed line and
+            // lowercase only that part for case-insensitive matching.
+            let rest = trimmed["!release".len()..].trim().to_lowercase();
+            return match rest.as_str() {
                 "major" => CommentCommand::ReleaseBump(BumpKind::Major),
                 "minor" => CommentCommand::ReleaseBump(BumpKind::Minor),
                 "patch" => CommentCommand::ReleaseBump(BumpKind::Patch),

--- a/crates/core/src/comment_command_processor.rs
+++ b/crates/core/src/comment_command_processor.rs
@@ -41,10 +41,7 @@ use tracing::{debug, info, warn, Instrument};
 
 use crate::{
     release_orchestrator::{OrchestratorConfig, ReleaseOrchestrator},
-    traits::{
-        event_source::ProcessingEvent,
-        github_operations::GitHubOperations,
-    },
+    traits::{event_source::ProcessingEvent, github_operations::GitHubOperations},
     versioning::{resolve_current_version, SemanticVersion, VersionCalculator},
     CoreResult,
 };
@@ -141,7 +138,6 @@ impl<'a, G: GitHubOperations + Send + Sync> CommentCommandProcessor<'a, G> {
     }
 
     async fn process_inner(&self, event: &ProcessingEvent) -> CoreResult<()> {
-
         if !self.config.allow_override {
             debug!(
                 event_id = %event.event_id,
@@ -229,7 +225,9 @@ impl<'a, G: GitHubOperations + Send + Sync> CommentCommandProcessor<'a, G> {
                 "❌ **Release Regent**: @{commenter_login} — only collaborators with \
                  write access (or above) may use Release Regent commands."
             );
-            return self.post_comment(owner, repo, issue_number, &rejection).await;
+            return self
+                .post_comment(owner, repo, issue_number, &rejection)
+                .await;
         }
 
         let command = parse_comment_command(&comment_body);
@@ -294,9 +292,7 @@ impl<'a, G: GitHubOperations + Send + Sync> CommentCommandProcessor<'a, G> {
                     current = %current,
                     "Rejecting !set-version: not greater than current released version"
                 );
-                return self
-                    .post_comment(owner, repo, pr_number, &rejection)
-                    .await;
+                return self.post_comment(owner, repo, pr_number, &rejection).await;
             }
         }
 
@@ -318,9 +314,7 @@ impl<'a, G: GitHubOperations + Send + Sync> CommentCommandProcessor<'a, G> {
                 pinned = %pinned_version,
                 "Rejecting !set-version: version is below minimum (0.0.1)"
             );
-            return self
-                .post_comment(owner, repo, pr_number, &rejection)
-                .await;
+            return self.post_comment(owner, repo, pr_number, &rejection).await;
         }
 
         info!(

--- a/crates/core/src/comment_command_processor_tests.rs
+++ b/crates/core/src/comment_command_processor_tests.rs
@@ -1,13 +1,17 @@
 use super::*;
-use crate::traits::{
-    git_operations::{
-        GetCommitsOptions, GitCommit, GitOperations, GitRepository, GitTag, GitTagType,
-        ListTagsOptions,
+use crate::{
+    traits::{
+        git_operations::{
+            GetCommitsOptions, GitCommit, GitOperations, GitRepository, GitTag, GitTagType,
+            ListTagsOptions,
+        },
+        github_operations::{
+            CollaboratorPermission, CreatePullRequestParams, CreateReleaseParams, GitHubOperations,
+            GitUser as GitHubUser, PullRequest, PullRequestBranch, Release, Repository, Tag,
+            UpdateReleaseParams,
+        },
     },
-    github_operations::{
-        CreatePullRequestParams, CreateReleaseParams, GitHubOperations, GitUser as GitHubUser,
-        PullRequest, PullRequestBranch, Release, Repository, Tag, UpdateReleaseParams,
-    },
+    CoreError,
 };
 use async_trait::async_trait;
 use chrono::Utc;
@@ -39,6 +43,9 @@ struct TestState {
     created_branches: Vec<(String, String)>,
     /// Sequential PR number returned by `create_pull_request`.
     next_pr_number: u64,
+    /// Collaborator permission returned by `get_collaborator_permission`.
+    /// `None` defaults to `CollaboratorPermission::Write`.
+    commenter_permission: Option<CollaboratorPermission>,
 }
 
 #[derive(Clone, Default)]
@@ -77,6 +84,12 @@ impl TestGitHub {
     /// Make the next `create_branch` call fail with `CoreError::Conflict`.
     async fn with_next_create_branch_conflict(self) -> Self {
         self.state.lock().await.next_create_branch_conflict = true;
+        self
+    }
+
+    /// Pre-set the collaborator permission returned for any username.
+    async fn with_commenter_permission(self, permission: CollaboratorPermission) -> Self {
+        self.state.lock().await.commenter_permission = Some(permission);
         self
     }
 
@@ -338,6 +351,21 @@ impl GitHubOperations for TestGitHub {
             .push((issue_number, body.to_string()));
         Ok(())
     }
+
+    async fn get_collaborator_permission(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _username: &str,
+    ) -> CoreResult<CollaboratorPermission> {
+        Ok(self
+            .state
+            .lock()
+            .await
+            .commenter_permission
+            .clone()
+            .unwrap_or(CollaboratorPermission::Write))
+    }
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -421,7 +449,10 @@ fn test_event(pr_number: u64, comment_body: &str, pr_state: &str) -> ProcessingE
                 "state": pr_state
             },
             "comment": {
-                "body": comment_body
+                "body": comment_body,
+                "user": {
+                    "login": "test-user"
+                }
             }
         }),
         received_at: Utc::now(),
@@ -753,39 +784,48 @@ async fn test_process_set_version_zero_zero_zero_rejected_when_no_tags() {
 }
 
 #[tokio::test]
-async fn test_process_release_bump_returns_not_supported_error() {
+async fn test_process_release_bump_posts_informational_comment_and_acknowledges() {
     // !release bump commands are a stub until the design is completed.
+    // The user should receive an informational comment and the event is acknowledged (Ok).
     let github = TestGitHub::new();
     let processor = CommentCommandProcessor::new(default_config(true), &github);
 
     let event = test_event(42, "!release major", "open");
     let result = processor.process(&event).await;
 
-    assert!(result.is_err());
-    let err = result.unwrap_err();
-    assert!(matches!(err, CoreError::NotSupported { .. }));
-    assert!(github.issue_comments().await.is_empty());
+    assert!(result.is_ok(), "expected Ok, got: {result:?}");
+    let comments = github.issue_comments().await;
+    assert_eq!(comments.len(), 1, "expected one informational comment");
+    assert_eq!(comments[0].0, 42);
+    assert!(
+        comments[0].1.contains("not yet"),
+        "comment should mention feature is not yet available: {}",
+        comments[0].1
+    );
+    // No release PR should have been created.
+    assert!(github.created_prs().await.is_empty());
 }
 
 #[tokio::test]
-async fn test_process_release_bump_minor_also_returns_not_supported() {
+async fn test_process_release_bump_minor_also_posts_informational_comment() {
     let github = TestGitHub::new();
     let processor = CommentCommandProcessor::new(default_config(true), &github);
 
     let event = test_event(42, "!release minor", "open");
     let result = processor.process(&event).await;
 
-    assert!(result.is_err());
-    assert!(matches!(
-        result.unwrap_err(),
-        CoreError::NotSupported { .. }
-    ));
+    assert!(result.is_ok());
+    let comments = github.issue_comments().await;
+    assert_eq!(comments.len(), 1);
+    assert!(comments[0].1.contains("not yet"));
 }
 
 #[tokio::test]
-async fn test_process_idempotent_same_comment_twice_produces_same_release_pr_state() {
+async fn test_process_repeated_calls_both_succeed() {
     // Processing !set-version 1.5.0 twice: both calls should succeed and
-    // both should trigger orchestration (creating the same release PR).
+    // trigger orchestration. In production the second call would find the
+    // existing branch/PR and update it (orchestrator idempotency); here both
+    // create a new PR in the test double.
     let github = TestGitHub::new()
         .with_tags(vec![make_semver_tag("v1.0.0")])
         .await
@@ -802,4 +842,29 @@ async fn test_process_idempotent_same_comment_twice_produces_same_release_pr_sta
     assert!(r2.is_ok());
     // Both calls should have invoked orchestration.
     assert_eq!(github.created_prs().await.len(), 2);
+}
+
+#[tokio::test]
+async fn test_process_unauthorized_commenter_gets_rejection_comment() {
+    // A read-only collaborator may not issue commands. The processor should
+    // post a rejection comment and return Ok (acknowledged, not retried).
+    let github = TestGitHub::new()
+        .with_commenter_permission(CollaboratorPermission::Read)
+        .await;
+    let processor = CommentCommandProcessor::new(default_config(true), &github);
+
+    let event = test_event(42, "!set-version 2.0.0", "open");
+    let result = processor.process(&event).await;
+
+    assert!(result.is_ok(), "expected Ok, got: {result:?}");
+    let comments = github.issue_comments().await;
+    assert_eq!(comments.len(), 1, "expected one rejection comment");
+    assert_eq!(comments[0].0, 42);
+    assert!(
+        comments[0].1.contains("write access"),
+        "rejection should mention write access, got: {}",
+        comments[0].1
+    );
+    // No release PR should have been created.
+    assert!(github.created_prs().await.is_empty());
 }

--- a/crates/core/src/comment_command_processor_tests.rs
+++ b/crates/core/src/comment_command_processor_tests.rs
@@ -868,3 +868,54 @@ async fn test_process_unauthorized_commenter_gets_rejection_comment() {
     // No release PR should have been created.
     assert!(github.created_prs().await.is_empty());
 }
+
+#[tokio::test]
+async fn test_process_triage_collaborator_gets_rejection_comment() {
+    // Triage collaborators cannot push; they must also not be able to issue commands.
+    let github = TestGitHub::new()
+        .with_commenter_permission(CollaboratorPermission::Triage)
+        .await;
+    let processor = CommentCommandProcessor::new(default_config(true), &github);
+
+    let event = test_event(42, "!set-version 2.0.0", "open");
+    let result = processor.process(&event).await;
+
+    assert!(result.is_ok(), "expected Ok, got: {result:?}");
+    let comments = github.issue_comments().await;
+    assert_eq!(comments.len(), 1, "expected one rejection comment");
+    assert!(comments[0].1.contains("write access"));
+    assert!(github.created_prs().await.is_empty());
+}
+
+#[tokio::test]
+async fn test_process_no_access_user_gets_rejection_comment() {
+    // A user with no repository access must be rejected.
+    let github = TestGitHub::new()
+        .with_commenter_permission(CollaboratorPermission::None)
+        .await;
+    let processor = CommentCommandProcessor::new(default_config(true), &github);
+
+    let event = test_event(42, "!set-version 2.0.0", "open");
+    let result = processor.process(&event).await;
+
+    assert!(result.is_ok(), "expected Ok, got: {result:?}");
+    let comments = github.issue_comments().await;
+    assert_eq!(comments.len(), 1, "expected one rejection comment");
+    assert!(comments[0].1.contains("write access"));
+    assert!(github.created_prs().await.is_empty());
+}
+
+#[tokio::test]
+async fn test_process_release_bare_no_argument_is_noop() {
+    // `!release` typed alone (no major/minor/patch) parses as Unknown —
+    // just silently acknowledge with no comment or PR creation.
+    let github = TestGitHub::new();
+    let processor = CommentCommandProcessor::new(default_config(true), &github);
+
+    let event = test_event(42, "!release", "open");
+    let result = processor.process(&event).await;
+
+    assert!(result.is_ok());
+    assert!(github.issue_comments().await.is_empty());
+    assert!(github.created_prs().await.is_empty());
+}

--- a/crates/core/src/comment_command_processor_tests.rs
+++ b/crates/core/src/comment_command_processor_tests.rs
@@ -1,0 +1,805 @@
+use super::*;
+use crate::traits::{
+    git_operations::{
+        GetCommitsOptions, GitCommit, GitOperations, GitRepository, GitTag, GitTagType,
+        ListTagsOptions,
+    },
+    github_operations::{
+        CreatePullRequestParams, CreateReleaseParams, GitHubOperations, GitUser as GitHubUser,
+        PullRequest, PullRequestBranch, Release, Repository, Tag, UpdateReleaseParams,
+    },
+};
+use async_trait::async_trait;
+use chrono::Utc;
+use std::{collections::HashMap, sync::Arc};
+use tokio::sync::Mutex;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Inline test double
+//
+// Defined locally to avoid the E0277 cross-crate blanket-impl issue documented
+// in the project's "Rules & Tips".
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[derive(Default)]
+struct TestState {
+    /// Tags returned by `list_tags` (drives `resolve_current_version`).
+    tags: Vec<GitTag>,
+    /// PRs keyed by number (for `get_pull_request`).
+    prs_by_number: HashMap<u64, PullRequest>,
+    /// PRs returned by `search_pull_requests` (drives `ReleaseOrchestrator`).
+    search_results: Vec<PullRequest>,
+    /// Whether the next `create_branch` call should return `CoreError::Conflict`.
+    next_create_branch_conflict: bool,
+    /// Recorded `create_issue_comment` calls: `(issue_number, body)`.
+    created_issue_comments: Vec<(u64, String)>,
+    /// Recorded `create_pull_request` calls.
+    created_prs: Vec<CreatePullRequestParams>,
+    /// Recorded `create_branch` calls: `(branch_name, sha)`.
+    created_branches: Vec<(String, String)>,
+    /// Sequential PR number returned by `create_pull_request`.
+    next_pr_number: u64,
+}
+
+#[derive(Clone, Default)]
+struct TestGitHub {
+    state: Arc<Mutex<TestState>>,
+}
+
+impl TestGitHub {
+    fn new() -> Self {
+        Self {
+            state: Arc::new(Mutex::new(TestState {
+                next_pr_number: 200,
+                ..Default::default()
+            })),
+        }
+    }
+
+    /// Pre-load tags that `resolve_current_version` will return.
+    async fn with_tags(self, tags: Vec<GitTag>) -> Self {
+        self.state.lock().await.tags = tags;
+        self
+    }
+
+    /// Pre-load a PR for `get_pull_request`.
+    async fn with_pr(self, pr: PullRequest) -> Self {
+        self.state.lock().await.prs_by_number.insert(pr.number, pr);
+        self
+    }
+
+    /// Pre-load search results for `ReleaseOrchestrator::search_for_existing_release_pr`.
+    async fn with_search_results(self, prs: Vec<PullRequest>) -> Self {
+        self.state.lock().await.search_results = prs;
+        self
+    }
+
+    /// Make the next `create_branch` call fail with `CoreError::Conflict`.
+    async fn with_next_create_branch_conflict(self) -> Self {
+        self.state.lock().await.next_create_branch_conflict = true;
+        self
+    }
+
+    async fn issue_comments(&self) -> Vec<(u64, String)> {
+        self.state.lock().await.created_issue_comments.clone()
+    }
+
+    async fn created_prs(&self) -> Vec<CreatePullRequestParams> {
+        self.state.lock().await.created_prs.clone()
+    }
+}
+
+// ── GitOperations stub impl ──────────────────────────────────────────────────
+
+#[async_trait]
+impl GitOperations for TestGitHub {
+    async fn get_commits_between(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _base: &str,
+        _head: &str,
+        _options: GetCommitsOptions,
+    ) -> CoreResult<Vec<GitCommit>> {
+        Ok(vec![])
+    }
+
+    async fn get_commit(&self, _owner: &str, _repo: &str, _sha: &str) -> CoreResult<GitCommit> {
+        Err(CoreError::not_found("stub"))
+    }
+
+    async fn list_tags(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _options: ListTagsOptions,
+    ) -> CoreResult<Vec<GitTag>> {
+        Ok(self.state.lock().await.tags.clone())
+    }
+
+    async fn get_tag(&self, _owner: &str, _repo: &str, _tag_name: &str) -> CoreResult<GitTag> {
+        Err(CoreError::not_found("stub"))
+    }
+
+    async fn tag_exists(&self, _owner: &str, _repo: &str, _tag_name: &str) -> CoreResult<bool> {
+        Ok(false)
+    }
+
+    async fn get_head_commit(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _branch: Option<&str>,
+    ) -> CoreResult<GitCommit> {
+        Err(CoreError::not_found("stub"))
+    }
+
+    async fn get_repository_info(&self, _owner: &str, _repo: &str) -> CoreResult<GitRepository> {
+        Err(CoreError::not_found("stub"))
+    }
+}
+
+// ── GitHubOperations impl ────────────────────────────────────────────────────
+
+#[async_trait]
+impl GitHubOperations for TestGitHub {
+    async fn create_pull_request(
+        &self,
+        owner: &str,
+        repo: &str,
+        params: CreatePullRequestParams,
+    ) -> CoreResult<PullRequest> {
+        let mut st = self.state.lock().await;
+        let number = st.next_pr_number;
+        st.next_pr_number += 1;
+        st.created_prs.push(params.clone());
+        let r = stub_repo(owner, repo);
+        let now = Utc::now();
+        Ok(PullRequest {
+            number,
+            title: params.title,
+            body: params.body,
+            state: "open".to_string(),
+            draft: false,
+            created_at: now,
+            updated_at: now,
+            merged_at: None,
+            user: stub_user(),
+            head: PullRequestBranch {
+                ref_name: params.head,
+                sha: "aaaa".to_string(),
+                repo: r.clone(),
+            },
+            base: PullRequestBranch {
+                ref_name: params.base,
+                sha: "bbbb".to_string(),
+                repo: r,
+            },
+        })
+    }
+
+    async fn create_release(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _params: CreateReleaseParams,
+    ) -> CoreResult<Release> {
+        Err(CoreError::not_supported("create_release", "stub"))
+    }
+
+    async fn create_tag(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _tag_name: &str,
+        _sha: &str,
+        _message: Option<String>,
+        _tagger: Option<GitHubUser>,
+    ) -> CoreResult<Tag> {
+        Err(CoreError::not_supported("create_tag", "stub"))
+    }
+
+    async fn get_latest_release(&self, _owner: &str, _repo: &str) -> CoreResult<Option<Release>> {
+        Ok(None)
+    }
+
+    async fn get_pull_request(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        pr_number: u64,
+    ) -> CoreResult<PullRequest> {
+        let st = self.state.lock().await;
+        st.prs_by_number
+            .get(&pr_number)
+            .cloned()
+            .ok_or_else(|| CoreError::not_found(format!("PR #{pr_number}")))
+    }
+
+    async fn get_release_by_tag(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _tag: &str,
+    ) -> CoreResult<Release> {
+        Err(CoreError::not_found("stub"))
+    }
+
+    async fn list_releases(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _per_page: Option<u8>,
+        _page: Option<u32>,
+    ) -> CoreResult<Vec<Release>> {
+        Ok(vec![])
+    }
+
+    async fn list_pull_requests(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _state: Option<&str>,
+        _head: Option<&str>,
+        _base: Option<&str>,
+        _per_page: Option<u8>,
+        _page: Option<u32>,
+    ) -> CoreResult<Vec<PullRequest>> {
+        Ok(vec![])
+    }
+
+    async fn search_pull_requests(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _query: &str,
+    ) -> CoreResult<Vec<PullRequest>> {
+        Ok(self.state.lock().await.search_results.clone())
+    }
+
+    async fn update_pull_request(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        pr_number: u64,
+        title: Option<String>,
+        body: Option<String>,
+        state: Option<String>,
+    ) -> CoreResult<PullRequest> {
+        let now = Utc::now();
+        let r = stub_repo("test", "repo");
+        Ok(PullRequest {
+            number: pr_number,
+            title: title.unwrap_or_else(|| "updated".to_string()),
+            body,
+            state: state.unwrap_or_else(|| "open".to_string()),
+            draft: false,
+            created_at: now,
+            updated_at: now,
+            merged_at: None,
+            user: stub_user(),
+            head: PullRequestBranch {
+                ref_name: "release/v0.0.0".to_string(),
+                sha: "aaaa".to_string(),
+                repo: r.clone(),
+            },
+            base: PullRequestBranch {
+                ref_name: "main".to_string(),
+                sha: "bbbb".to_string(),
+                repo: r,
+            },
+        })
+    }
+
+    async fn update_release(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _release_id: u64,
+        _params: UpdateReleaseParams,
+    ) -> CoreResult<Release> {
+        Err(CoreError::not_supported("update_release", "stub"))
+    }
+
+    async fn create_branch(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        branch_name: &str,
+        sha: &str,
+    ) -> CoreResult<()> {
+        let mut st = self.state.lock().await;
+        if st.next_create_branch_conflict {
+            st.next_create_branch_conflict = false;
+            return Err(CoreError::conflict(format!(
+                "branch '{branch_name}' already exists"
+            )));
+        }
+        st.created_branches
+            .push((branch_name.to_string(), sha.to_string()));
+        Ok(())
+    }
+
+    async fn delete_branch(&self, _owner: &str, _repo: &str, _branch_name: &str) -> CoreResult<()> {
+        Ok(())
+    }
+
+    async fn create_issue_comment(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        issue_number: u64,
+        body: &str,
+    ) -> CoreResult<()> {
+        self.state
+            .lock()
+            .await
+            .created_issue_comments
+            .push((issue_number, body.to_string()));
+        Ok(())
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+fn stub_repo(owner: &str, repo: &str) -> Repository {
+    Repository {
+        id: 1,
+        name: repo.to_string(),
+        full_name: format!("{owner}/{repo}"),
+        owner: owner.to_string(),
+        description: None,
+        private: false,
+        default_branch: "main".to_string(),
+        clone_url: format!("https://github.com/{owner}/{repo}.git"),
+        ssh_url: format!("git@github.com:{owner}/{repo}.git"),
+        homepage: None,
+    }
+}
+
+fn stub_user() -> GitHubUser {
+    GitHubUser {
+        name: "test-user".to_string(),
+        email: "test@example.com".to_string(),
+        login: Some("test-user".to_string()),
+    }
+}
+
+fn make_open_pr(number: u64, base_sha: &str) -> PullRequest {
+    let now = Utc::now();
+    let r = stub_repo("acme", "app");
+    PullRequest {
+        number,
+        title: "feat: add feature".to_string(),
+        body: None,
+        state: "open".to_string(),
+        draft: false,
+        created_at: now,
+        updated_at: now,
+        merged_at: None,
+        user: stub_user(),
+        head: PullRequestBranch {
+            ref_name: "feat/my-feature".to_string(),
+            sha: "headsha".to_string(),
+            repo: stub_repo("acme", "app"),
+        },
+        base: PullRequestBranch {
+            ref_name: "main".to_string(),
+            sha: base_sha.to_string(),
+            repo: r,
+        },
+    }
+}
+
+fn make_semver_tag(name: &str) -> GitTag {
+    GitTag {
+        name: name.to_string(),
+        target_sha: "0000000000000000000000000000000000000001".to_string(),
+        tag_type: GitTagType::Lightweight,
+        message: None,
+        tagger: None,
+        created_at: None,
+    }
+}
+
+fn test_event(pr_number: u64, comment_body: &str, pr_state: &str) -> ProcessingEvent {
+    use crate::traits::event_source::{EventSourceKind, EventType, RepositoryInfo};
+    ProcessingEvent {
+        event_id: "evt-001".to_string(),
+        correlation_id: "corr-001".to_string(),
+        event_type: EventType::PullRequestCommentReceived,
+        repository: RepositoryInfo {
+            owner: "acme".to_string(),
+            name: "app".to_string(),
+            default_branch: "main".to_string(),
+        },
+        payload: serde_json::json!({
+            "issue": {
+                "number": pr_number,
+                "state": pr_state
+            },
+            "comment": {
+                "body": comment_body
+            }
+        }),
+        received_at: Utc::now(),
+        source: EventSourceKind::Webhook,
+    }
+}
+
+fn default_config(allow_override: bool) -> CommentCommandConfig {
+    CommentCommandConfig {
+        orchestrator_config: crate::release_orchestrator::OrchestratorConfig::default(),
+        allow_override,
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// parse_comment_command unit tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_parse_comment_command_set_version_valid_semver() {
+    use crate::versioning::SemanticVersion;
+
+    let cmd = parse_comment_command("!set-version 2.3.0");
+    assert_eq!(
+        cmd,
+        CommentCommand::SetVersion(SemanticVersion {
+            major: 2,
+            minor: 3,
+            patch: 0,
+            prerelease: None,
+            build: None,
+        })
+    );
+}
+
+#[test]
+fn test_parse_comment_command_set_version_with_v_prefix() {
+    use crate::versioning::SemanticVersion;
+
+    let cmd = parse_comment_command("!set-version v1.0.0");
+    assert_eq!(
+        cmd,
+        CommentCommand::SetVersion(SemanticVersion {
+            major: 1,
+            minor: 0,
+            patch: 0,
+            prerelease: None,
+            build: None,
+        })
+    );
+}
+
+#[test]
+fn test_parse_comment_command_set_version_case_insensitive() {
+    use crate::versioning::SemanticVersion;
+
+    let cmd = parse_comment_command("!SET-VERSION 3.1.4");
+    assert_eq!(
+        cmd,
+        CommentCommand::SetVersion(SemanticVersion {
+            major: 3,
+            minor: 1,
+            patch: 4,
+            prerelease: None,
+            build: None,
+        })
+    );
+}
+
+#[test]
+fn test_parse_comment_command_set_version_with_surrounding_text_on_same_line() {
+    // The command must appear at the start of the trimmed line.
+    // "Please !set-version 2.0.0" does NOT start with !set-version after trim.
+    let cmd = parse_comment_command("Please !set-version 2.0.0");
+    assert_eq!(cmd, CommentCommand::Unknown);
+}
+
+#[test]
+fn test_parse_comment_command_set_version_on_second_line() {
+    use crate::versioning::SemanticVersion;
+
+    let body = "Some description.\n!set-version 1.5.0\nMore text.";
+    let cmd = parse_comment_command(body);
+    assert_eq!(
+        cmd,
+        CommentCommand::SetVersion(SemanticVersion {
+            major: 1,
+            minor: 5,
+            patch: 0,
+            prerelease: None,
+            build: None,
+        })
+    );
+}
+
+#[test]
+fn test_parse_comment_command_set_version_malformed_version_returns_unknown() {
+    // "!set-version notaversion" has an invalid semver string, so it should
+    // continue scanning and ultimately return Unknown.
+    let cmd = parse_comment_command("!set-version notaversion");
+    assert_eq!(cmd, CommentCommand::Unknown);
+}
+
+#[test]
+fn test_parse_comment_command_release_major() {
+    let cmd = parse_comment_command("!release major");
+    assert_eq!(cmd, CommentCommand::ReleaseBump(BumpKind::Major));
+}
+
+#[test]
+fn test_parse_comment_command_release_minor() {
+    let cmd = parse_comment_command("!release minor");
+    assert_eq!(cmd, CommentCommand::ReleaseBump(BumpKind::Minor));
+}
+
+#[test]
+fn test_parse_comment_command_release_patch() {
+    let cmd = parse_comment_command("!release patch");
+    assert_eq!(cmd, CommentCommand::ReleaseBump(BumpKind::Patch));
+}
+
+#[test]
+fn test_parse_comment_command_release_case_insensitive() {
+    let cmd = parse_comment_command("!RELEASE MINOR");
+    assert_eq!(cmd, CommentCommand::ReleaseBump(BumpKind::Minor));
+}
+
+#[test]
+fn test_parse_comment_command_release_unknown_dimension_returns_unknown() {
+    let cmd = parse_comment_command("!release huge");
+    assert_eq!(cmd, CommentCommand::Unknown);
+}
+
+#[test]
+fn test_parse_comment_command_unknown_returns_unknown_variant() {
+    assert_eq!(
+        parse_comment_command("just a regular comment"),
+        CommentCommand::Unknown
+    );
+    assert_eq!(parse_comment_command(""), CommentCommand::Unknown);
+    assert_eq!(parse_comment_command("   "), CommentCommand::Unknown);
+    assert_eq!(parse_comment_command("lgtm"), CommentCommand::Unknown);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CommentCommandProcessor::process unit tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_process_allow_override_false_makes_no_github_calls() {
+    let github = TestGitHub::new();
+    let processor = CommentCommandProcessor::new(default_config(false), &github);
+
+    // Any command in the body — but allow_override is false, so nothing happens.
+    let event = test_event(42, "!set-version 2.0.0", "open");
+    let result = processor.process(&event).await;
+
+    assert!(result.is_ok());
+    assert!(github.issue_comments().await.is_empty());
+    assert!(github.created_prs().await.is_empty());
+}
+
+#[tokio::test]
+async fn test_process_unrecognised_comment_body_is_noop() {
+    let github = TestGitHub::new().with_pr(make_open_pr(42, "abc123")).await;
+    let processor = CommentCommandProcessor::new(default_config(true), &github);
+
+    let event = test_event(42, "just a regular comment, no commands here", "open");
+    let result = processor.process(&event).await;
+
+    assert!(result.is_ok());
+    assert!(github.issue_comments().await.is_empty());
+    assert!(github.created_prs().await.is_empty());
+}
+
+#[tokio::test]
+async fn test_process_empty_comment_body_is_noop() {
+    let github = TestGitHub::new().with_pr(make_open_pr(42, "abc123")).await;
+    let processor = CommentCommandProcessor::new(default_config(true), &github);
+
+    let event = test_event(42, "", "open");
+    let result = processor.process(&event).await;
+
+    assert!(result.is_ok());
+    assert!(github.issue_comments().await.is_empty());
+}
+
+#[tokio::test]
+async fn test_process_comment_on_closed_pr_is_noop() {
+    let github = TestGitHub::new();
+    let processor = CommentCommandProcessor::new(default_config(true), &github);
+
+    // PR state is "closed" — should be silently ignored.
+    let event = test_event(42, "!set-version 2.0.0", "closed");
+    let result = processor.process(&event).await;
+
+    assert!(result.is_ok());
+    assert!(github.issue_comments().await.is_empty());
+    assert!(github.created_prs().await.is_empty());
+}
+
+#[tokio::test]
+async fn test_process_comment_on_merged_pr_is_noop() {
+    let github = TestGitHub::new();
+    let processor = CommentCommandProcessor::new(default_config(true), &github);
+
+    let event = test_event(42, "!set-version 2.0.0", "merged");
+    let result = processor.process(&event).await;
+
+    assert!(result.is_ok());
+    assert!(github.issue_comments().await.is_empty());
+}
+
+#[tokio::test]
+async fn test_process_set_version_accepted_when_greater_than_current_released_tag() {
+    // Current released version: v1.0.0 (from tags)
+    // Pin: 2.0.0 — strictly greater → should trigger orchestration.
+    let github = TestGitHub::new()
+        .with_tags(vec![make_semver_tag("v1.0.0")])
+        .await
+        .with_pr(make_open_pr(42, "deadbeef"))
+        .await;
+
+    let processor = CommentCommandProcessor::new(default_config(true), &github);
+    let event = test_event(42, "!set-version 2.0.0", "open");
+    let result = processor.process(&event).await;
+
+    assert!(result.is_ok());
+    // No rejection comment should have been posted.
+    assert!(github.issue_comments().await.is_empty());
+    // The orchestrator should have created a new release PR.
+    let prs = github.created_prs().await;
+    assert_eq!(prs.len(), 1);
+    assert!(prs[0].head.starts_with("release/v2.0.0"));
+}
+
+#[tokio::test]
+async fn test_process_set_version_accepted_when_no_existing_tags_first_release_path() {
+    // No existing tags (first release) → any valid semver ≥ 0.0.1 is accepted.
+    let github = TestGitHub::new()
+        .with_tags(vec![])
+        .await
+        .with_pr(make_open_pr(42, "deadbeef"))
+        .await;
+
+    let processor = CommentCommandProcessor::new(default_config(true), &github);
+    // Skip straight to 1.0.0 — a valid first release.
+    let event = test_event(42, "!set-version 1.0.0", "open");
+    let result = processor.process(&event).await;
+
+    assert!(result.is_ok());
+    assert!(github.issue_comments().await.is_empty());
+    let prs = github.created_prs().await;
+    assert_eq!(prs.len(), 1);
+    assert!(prs[0].head.starts_with("release/v1.0.0"));
+}
+
+#[tokio::test]
+async fn test_process_set_version_accepted_when_no_tags_and_version_is_zero_zero_one() {
+    // 0.0.1 is the absolute minimum; should succeed when no tags exist.
+    let github = TestGitHub::new()
+        .with_tags(vec![])
+        .await
+        .with_pr(make_open_pr(42, "deadbeef"))
+        .await;
+
+    let processor = CommentCommandProcessor::new(default_config(true), &github);
+    let event = test_event(42, "!set-version 0.0.1", "open");
+    let result = processor.process(&event).await;
+
+    assert!(result.is_ok());
+    assert!(github.issue_comments().await.is_empty());
+}
+
+#[tokio::test]
+async fn test_process_set_version_rejected_when_equal_to_current_tag_posts_rejection_comment() {
+    // Pinned == current released → rejected.
+    let github = TestGitHub::new()
+        .with_tags(vec![make_semver_tag("v1.0.0")])
+        .await;
+
+    let processor = CommentCommandProcessor::new(default_config(true), &github);
+    let event = test_event(42, "!set-version 1.0.0", "open");
+    let result = processor.process(&event).await;
+
+    // Should return Ok (acknowledged, not retried).
+    assert!(result.is_ok());
+    let comments = github.issue_comments().await;
+    assert_eq!(comments.len(), 1);
+    assert_eq!(comments[0].0, 42);
+    assert!(comments[0].1.contains("rejected"));
+    assert!(comments[0].1.contains("1.0.0"));
+    // No PR should have been created.
+    assert!(github.created_prs().await.is_empty());
+}
+
+#[tokio::test]
+async fn test_process_set_version_rejected_when_lower_than_current_tag_posts_rejection_comment() {
+    // Pinned < current released → rejected.
+    let github = TestGitHub::new()
+        .with_tags(vec![make_semver_tag("v2.0.0")])
+        .await;
+
+    let processor = CommentCommandProcessor::new(default_config(true), &github);
+    let event = test_event(42, "!set-version 1.5.0", "open");
+    let result = processor.process(&event).await;
+
+    assert!(result.is_ok());
+    let comments = github.issue_comments().await;
+    assert_eq!(comments.len(), 1);
+    assert!(comments[0].1.contains("rejected"));
+    assert!(github.created_prs().await.is_empty());
+}
+
+#[tokio::test]
+async fn test_process_set_version_zero_zero_zero_rejected_when_no_tags() {
+    // 0.0.0 is below the minimum (0.0.1) even with no existing tags.
+    let github = TestGitHub::new().with_tags(vec![]).await;
+
+    let processor = CommentCommandProcessor::new(default_config(true), &github);
+    let event = test_event(42, "!set-version 0.0.0", "open");
+    let result = processor.process(&event).await;
+
+    assert!(result.is_ok());
+    let comments = github.issue_comments().await;
+    assert_eq!(comments.len(), 1);
+    assert!(comments[0].1.contains("rejected"));
+    assert!(github.created_prs().await.is_empty());
+}
+
+#[tokio::test]
+async fn test_process_release_bump_returns_not_supported_error() {
+    // !release bump commands are a stub until the design is completed.
+    let github = TestGitHub::new();
+    let processor = CommentCommandProcessor::new(default_config(true), &github);
+
+    let event = test_event(42, "!release major", "open");
+    let result = processor.process(&event).await;
+
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(matches!(err, CoreError::NotSupported { .. }));
+    assert!(github.issue_comments().await.is_empty());
+}
+
+#[tokio::test]
+async fn test_process_release_bump_minor_also_returns_not_supported() {
+    let github = TestGitHub::new();
+    let processor = CommentCommandProcessor::new(default_config(true), &github);
+
+    let event = test_event(42, "!release minor", "open");
+    let result = processor.process(&event).await;
+
+    assert!(result.is_err());
+    assert!(matches!(
+        result.unwrap_err(),
+        CoreError::NotSupported { .. }
+    ));
+}
+
+#[tokio::test]
+async fn test_process_idempotent_same_comment_twice_produces_same_release_pr_state() {
+    // Processing !set-version 1.5.0 twice: both calls should succeed and
+    // both should trigger orchestration (creating the same release PR).
+    let github = TestGitHub::new()
+        .with_tags(vec![make_semver_tag("v1.0.0")])
+        .await
+        .with_pr(make_open_pr(42, "deadbeef"))
+        .await;
+
+    let processor = CommentCommandProcessor::new(default_config(true), &github);
+    let event = test_event(42, "!set-version 1.5.0", "open");
+
+    let r1 = processor.process(&event).await;
+    let r2 = processor.process(&event).await;
+
+    assert!(r1.is_ok());
+    assert!(r2.is_ok());
+    // Both calls should have invoked orchestration.
+    assert_eq!(github.created_prs().await.len(), 2);
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -204,6 +204,7 @@
 //! - **Audit Logging**: Structured logging with correlation IDs for security monitoring
 
 pub mod changelog;
+pub mod comment_command_processor;
 pub mod config;
 pub mod errors;
 pub mod release_orchestrator;
@@ -238,6 +239,18 @@ pub trait MergedPullRequestHandler: Send + Sync {
         &self,
         event: &traits::event_source::ProcessingEvent,
     ) -> CoreResult<()>;
+
+    /// Process a single `PullRequestCommentReceived` event.
+    ///
+    /// The default implementation is a no-op that acknowledges the event
+    /// without taking any action.  Override in the production processor to
+    /// invoke [`comment_command_processor::CommentCommandProcessor`].
+    async fn handle_pr_comment(
+        &self,
+        _event: &traits::event_source::ProcessingEvent,
+    ) -> CoreResult<()> {
+        Ok(())
+    }
 }
 
 #[async_trait::async_trait]
@@ -258,6 +271,35 @@ where
             }
             Err(e) => Err(e),
         }
+    }
+
+    async fn handle_pr_comment(
+        &self,
+        event: &traits::event_source::ProcessingEvent,
+    ) -> CoreResult<()> {
+        use comment_command_processor::{CommentCommandConfig, CommentCommandProcessor};
+        use traits::configuration_provider::LoadOptions;
+
+        let owner = &event.repository.owner;
+        let repo = &event.repository.name;
+
+        let repo_config = self
+            .configuration_provider
+            .get_merged_config(owner, repo, LoadOptions::default())
+            .await?;
+
+        let config = CommentCommandConfig {
+            orchestrator_config: release_orchestrator::OrchestratorConfig {
+                branch_prefix: "release".to_string(),
+                title_template: repo_config.release_pr.title_template.clone(),
+                changelog_header: "## Changelog".to_string(),
+            },
+            allow_override: repo_config.versioning.allow_override,
+        };
+
+        CommentCommandProcessor::new(config, &self.github_operations)
+            .process(event)
+            .await
     }
 }
 
@@ -360,9 +402,9 @@ where
                         EventType::PullRequestCommentReceived => {
                             tracing::debug!(
                                 event_id = %event.event_id,
-                                "Pull request comment received — no handler yet"
+                                "Pull request comment received — dispatching to comment handler"
                             );
-                            Ok(())
+                            handler.handle_pr_comment(&event).await
                         }
                         EventType::Unknown(raw) => {
                             tracing::debug!(

--- a/crates/core/src/lib_tests.rs
+++ b/crates/core/src/lib_tests.rs
@@ -765,6 +765,16 @@ impl GitHubOperations for TestGitHubForLib {
     async fn delete_branch(&self, _owner: &str, _repo: &str, _branch_name: &str) -> CoreResult<()> {
         Ok(())
     }
+
+    async fn create_issue_comment(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _issue_number: u64,
+        _body: &str,
+    ) -> CoreResult<()> {
+        Ok(())
+    }
 }
 
 // ── TestConfigForLib ────────────────────────────────────────────────────────

--- a/crates/core/src/lib_tests.rs
+++ b/crates/core/src/lib_tests.rs
@@ -775,6 +775,15 @@ impl GitHubOperations for TestGitHubForLib {
     ) -> CoreResult<()> {
         Ok(())
     }
+
+    async fn get_collaborator_permission(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _username: &str,
+    ) -> CoreResult<crate::traits::github_operations::CollaboratorPermission> {
+        Ok(crate::traits::github_operations::CollaboratorPermission::Write)
+    }
 }
 
 // ── TestConfigForLib ────────────────────────────────────────────────────────

--- a/crates/core/src/release_orchestrator_tests.rs
+++ b/crates/core/src/release_orchestrator_tests.rs
@@ -361,6 +361,15 @@ impl GitHubOperations for TestGitHub {
     ) -> CoreResult<()> {
         Ok(())
     }
+
+    async fn get_collaborator_permission(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _username: &str,
+    ) -> CoreResult<crate::traits::github_operations::CollaboratorPermission> {
+        Ok(crate::traits::github_operations::CollaboratorPermission::Write)
+    }
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/crates/core/src/release_orchestrator_tests.rs
+++ b/crates/core/src/release_orchestrator_tests.rs
@@ -351,6 +351,16 @@ impl GitHubOperations for TestGitHub {
             .push(branch_name.to_string());
         Ok(())
     }
+
+    async fn create_issue_comment(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _issue_number: u64,
+        _body: &str,
+    ) -> CoreResult<()> {
+        Ok(())
+    }
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/crates/core/src/traits/github_operations.rs
+++ b/crates/core/src/traits/github_operations.rs
@@ -337,6 +337,28 @@ pub trait GitHubOperations: GitOperations + Send + Sync {
     /// - `CoreError::NotFound` - Branch does not exist
     /// - `CoreError::GitHub` - API communication failed
     async fn delete_branch(&self, owner: &str, repo: &str, branch_name: &str) -> CoreResult<()>;
+
+    /// Post a comment on an issue or pull request
+    ///
+    /// # Parameters
+    /// - `owner`: Repository owner name
+    /// - `repo`: Repository name
+    /// - `issue_number`: Issue or pull request number to comment on
+    /// - `body`: Comment body (Markdown supported)
+    ///
+    /// # Returns
+    /// `Ok(())` on success
+    ///
+    /// # Errors
+    /// - `CoreError::NotFound` - Issue or PR does not exist
+    /// - `CoreError::GitHub` - API communication failed
+    async fn create_issue_comment(
+        &self,
+        owner: &str,
+        repo: &str,
+        issue_number: u64,
+        body: &str,
+    ) -> CoreResult<()>;
 }
 
 // Note: Git commit information is now provided by GitOperations trait

--- a/crates/core/src/traits/github_operations.rs
+++ b/crates/core/src/traits/github_operations.rs
@@ -338,6 +338,29 @@ pub trait GitHubOperations: GitOperations + Send + Sync {
     /// - `CoreError::GitHub` - API communication failed
     async fn delete_branch(&self, owner: &str, repo: &str, branch_name: &str) -> CoreResult<()>;
 
+    /// Get the permission level a specific user has on a repository
+    ///
+    /// Used to authorise PR comment commands: only collaborators with `Write`,
+    /// `Maintain`, or `Admin` access may issue commands.
+    ///
+    /// # Parameters
+    /// - `owner`: Repository owner name
+    /// - `repo`: Repository name
+    /// - `username`: GitHub login of the user to check
+    ///
+    /// # Returns
+    /// The user's [`CollaboratorPermission`] level
+    ///
+    /// # Errors
+    /// - `CoreError::GitHub` - API communication failed
+    /// - `CoreError::NotFound` - User is not a collaborator on the repository
+    async fn get_collaborator_permission(
+        &self,
+        owner: &str,
+        repo: &str,
+        username: &str,
+    ) -> CoreResult<CollaboratorPermission>;
+
     /// Post a comment on an issue or pull request
     ///
     /// # Parameters
@@ -525,4 +548,41 @@ pub struct UpdateReleaseParams {
     pub name: Option<String>,
     /// Whether this is a pre-release
     pub prerelease: Option<bool>,
+}
+
+/// The level of access a GitHub user has to a repository.
+///
+/// Returned by [`GitHubOperations::get_collaborator_permission`] and used
+/// to gate PR comment commands: only collaborators with `Write`, `Maintain`,
+/// or `Admin` access may issue version-override commands.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CollaboratorPermission {
+    /// Repository administrator — full access including destructive actions.
+    Admin,
+    /// Maintain access — can push, manage branches, and change some settings.
+    Maintain,
+    /// Write access — can push to branches and merge pull requests.
+    Write,
+    /// Triage access — can manage issues and PRs but cannot push.
+    Triage,
+    /// Read-only access.
+    Read,
+    /// No access (user is not a collaborator on the repository).
+    None,
+}
+
+impl CollaboratorPermission {
+    /// Returns `true` if this permission level is sufficient to issue
+    /// PR comment version-override commands.
+    ///
+    /// Requires at least `Write` access (`Write`, `Maintain`, or `Admin`).
+    #[must_use]
+    pub fn can_issue_commands(&self) -> bool {
+        matches!(
+            self,
+            CollaboratorPermission::Admin
+                | CollaboratorPermission::Maintain
+                | CollaboratorPermission::Write
+        )
+    }
 }

--- a/crates/github_client/src/lib.rs
+++ b/crates/github_client/src/lib.rs
@@ -23,7 +23,7 @@ use release_regent_core::{
     CoreError, CoreResult,
 };
 use std::time::Duration as StdDuration;
-use tracing::{debug, info, instrument};
+use tracing::{debug, info, instrument, warn};
 
 pub mod errors;
 pub use errors::{Error, GitHubResult};

--- a/crates/github_client/src/lib.rs
+++ b/crates/github_client/src/lib.rs
@@ -646,6 +646,33 @@ impl GitHubOperations for GitHubClient {
 
         Ok(())
     }
+
+    async fn create_issue_comment(
+        &self,
+        owner: &str,
+        repo: &str,
+        issue_number: u64,
+        body: &str,
+    ) -> CoreResult<()> {
+        info!(
+            owner,
+            repo,
+            issue_number,
+            "Creating issue comment"
+        );
+
+        let installation = self.installation().await?;
+        let request = github_bot_sdk::client::CreateCommentRequest {
+            body: body.to_string(),
+        };
+
+        installation
+            .create_issue_comment(owner, repo, issue_number, request)
+            .await
+            .map_err(map_sdk_error)?;
+
+        Ok(())
+    }
 }
 
 // ============================================================================

--- a/crates/github_client/src/lib.rs
+++ b/crates/github_client/src/lib.rs
@@ -696,7 +696,19 @@ impl GitHubOperations for GitHubClient {
             "write" => CollaboratorPermission::Write,
             "triage" => CollaboratorPermission::Triage,
             "read" => CollaboratorPermission::Read,
-            _ => CollaboratorPermission::None,
+            "none" => CollaboratorPermission::None,
+            other => {
+                warn!(
+                    owner,
+                    repo,
+                    username,
+                    permission = other,
+                    "Unrecognised GitHub collaborator permission string — \
+                     treating as None; if this is a new GitHub permission level \
+                     the CollaboratorPermission enum must be updated"
+                );
+                CollaboratorPermission::None
+            }
         })
     }
 }

--- a/crates/github_client/src/lib.rs
+++ b/crates/github_client/src/lib.rs
@@ -15,8 +15,9 @@ use release_regent_core::{
             GitUser as GitOpsUser, ListTagsOptions, TagSortOrder,
         },
         github_operations::{
-            CreatePullRequestParams, CreateReleaseParams, GitHubOperations, GitUser as GitHubUser,
-            PullRequest, PullRequestBranch, Release, Repository, Tag, UpdateReleaseParams,
+            CollaboratorPermission, CreatePullRequestParams, CreateReleaseParams, GitHubOperations,
+            GitUser as GitHubUser, PullRequest, PullRequestBranch, Release, Repository, Tag,
+            UpdateReleaseParams,
         },
     },
     CoreError, CoreResult,
@@ -654,12 +655,7 @@ impl GitHubOperations for GitHubClient {
         issue_number: u64,
         body: &str,
     ) -> CoreResult<()> {
-        info!(
-            owner,
-            repo,
-            issue_number,
-            "Creating issue comment"
-        );
+        info!(owner, repo, issue_number, "Creating issue comment");
 
         let installation = self.installation().await?;
         let request = github_bot_sdk::client::CreateCommentRequest {
@@ -672,6 +668,36 @@ impl GitHubOperations for GitHubClient {
             .map_err(map_sdk_error)?;
 
         Ok(())
+    }
+
+    async fn get_collaborator_permission(
+        &self,
+        owner: &str,
+        repo: &str,
+        username: &str,
+    ) -> CoreResult<CollaboratorPermission> {
+        use release_regent_core::traits::github_operations::CollaboratorPermission;
+
+        info!(owner, repo, username, "Checking collaborator permission");
+
+        let installation = self.installation().await?;
+        let path = format!("/repos/{owner}/{repo}/collaborators/{username}/permission");
+        let response = installation.get(&path).await.map_err(map_sdk_error)?;
+        let body: serde_json::Value = response.json().await.map_err(|e| CoreError::github(e))?;
+
+        let permission_str = body
+            .get("permission")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("none");
+
+        Ok(match permission_str {
+            "admin" => CollaboratorPermission::Admin,
+            "maintain" => CollaboratorPermission::Maintain,
+            "write" => CollaboratorPermission::Write,
+            "triage" => CollaboratorPermission::Triage,
+            "read" => CollaboratorPermission::Read,
+            _ => CollaboratorPermission::None,
+        })
     }
 }
 

--- a/crates/testing/src/mocks/github_operations.rs
+++ b/crates/testing/src/mocks/github_operations.rs
@@ -900,6 +900,32 @@ impl GitHubOperations for MockGitHubOperations {
             .await;
         Ok(())
     }
+
+    async fn create_issue_comment(
+        &self,
+        owner: &str,
+        repo: &str,
+        issue_number: u64,
+        body: &str,
+    ) -> CoreResult<()> {
+        let method = "create_issue_comment";
+        let params_str =
+            format!("owner={owner}, repo={repo}, issue={issue_number}, body_len={}", body.len());
+
+        self.check_quota().await?;
+        self.simulate_latency().await;
+
+        if self.should_simulate_failure().await {
+            let error = CoreError::network("Simulated GitHub API error");
+            self.record_call(method, &params_str, CallResult::Error(error.to_string()))
+                .await;
+            return Err(error);
+        }
+
+        self.record_call(method, &params_str, CallResult::Success)
+            .await;
+        Ok(())
+    }
 }
 
 /// `GitOperations` implementation for `MockGitHubOperations`

--- a/crates/testing/src/mocks/github_operations.rs
+++ b/crates/testing/src/mocks/github_operations.rs
@@ -926,6 +926,30 @@ impl GitHubOperations for MockGitHubOperations {
             .await;
         Ok(())
     }
+
+    async fn get_collaborator_permission(
+        &self,
+        owner: &str,
+        repo: &str,
+        username: &str,
+    ) -> CoreResult<CollaboratorPermission> {
+        let method = "get_collaborator_permission";
+        let params_str = format!("owner={owner}, repo={repo}, username={username}");
+
+        self.check_quota().await?;
+        self.simulate_latency().await;
+
+        if self.should_simulate_failure().await {
+            let error = CoreError::network("Simulated GitHub API error");
+            self.record_call(method, &params_str, CallResult::Error(error.to_string()))
+                .await;
+            return Err(error);
+        }
+
+        self.record_call(method, &params_str, CallResult::Success)
+            .await;
+        Ok(CollaboratorPermission::Write)
+    }
 }
 
 /// `GitOperations` implementation for `MockGitHubOperations`

--- a/crates/testing/src/mocks/github_operations.rs
+++ b/crates/testing/src/mocks/github_operations.rs
@@ -909,8 +909,10 @@ impl GitHubOperations for MockGitHubOperations {
         body: &str,
     ) -> CoreResult<()> {
         let method = "create_issue_comment";
-        let params_str =
-            format!("owner={owner}, repo={repo}, issue={issue_number}, body_len={}", body.len());
+        let params_str = format!(
+            "owner={owner}, repo={repo}, issue={issue_number}, body_len={}",
+            body.len()
+        );
 
         self.check_quota().await?;
         self.simulate_latency().await;

--- a/docs/adr/ADR-003-pr-comment-commands.md
+++ b/docs/adr/ADR-003-pr-comment-commands.md
@@ -1,0 +1,119 @@
+# ADR-003: PR Comment Commands for Version Override
+
+Status: Accepted
+Date: 2026-03-28
+Owners: @pvandervelde
+
+## Context
+
+Release Regent derives the next release version from conventional commit messages.
+Teams occasionally need to override this calculation — for example, to skip a version
+number, produce a first release at a non-default version (e.g. `1.0.0` instead of
+`0.1.0`), or correct a mistaken tag.
+
+Alternative override mechanisms considered:
+
+- **Git tags**: Creating a tag manually before merge works but is invisible, hard to
+  track, and bypasses the PR review process.
+- **Repository labels**: Labels are durable but have no argument (cannot express
+  `set-version 2.0.0` without dynamic label management).
+- **Separate webhook endpoint / slash-command service**: Adds operational complexity;
+  the GitHub App already receives `issue_comment` webhooks.
+- **PR description keywords**: Parsed once at merge time; hard to update after the PR
+  is opened.
+- **Environment variables / config file edits**: Requires an additional commit inside
+  the PR branch.
+
+PR comments are the lowest-friction option: they are visible, auditable, can be
+amended, and arrive as `issue_comment` webhooks already processed by the event loop.
+
+## Decision
+
+Accept and process `!set-version X.Y.Z` and `!release major|minor|patch` command
+prefixes from PR comments.  Commands are:
+
+1. **Case-insensitive** on the command keyword; semver pre-release/build identifiers
+   are preserved as-is (e.g. `2.0.0-RC.1` is not lowercased).
+2. **Line-anchored**: the command must appear at the start of a trimmed line, allowing
+   commands to be embedded in longer comment bodies without polluting free-form text.
+3. **Gated** by `VersioningConfig::allow_override = true`; when `false` all PR comment
+   events are silently acknowledged with no GitHub API calls.
+4. **Restricted to write-or-higher collaborators**: the commenter's GitHub permission
+   level is checked via `GET /repos/{owner}/{repo}/collaborators/{username}/permission`
+   before any action is taken.  Users with `read`, `triage`, or `none` permission
+   receive a rejection comment explaining the access requirement.
+5. **Only processed on open PRs**: comments on closed or merged PRs are silently
+   ignored to prevent stale comments from triggering spurious version changes.
+6. **`!set-version`** validates the pinned version is strictly greater than the current
+   released version (or ≥ `0.0.1` for first releases); validation failures post a
+   rejection comment and acknowledge the event.
+7. **`!release major|minor|patch`** is a recognised but not-yet-implemented stub; it
+   posts an informational "not yet supported" comment and acknowledges the event.
+   Full implementation is deferred pending the bump-override label design (see
+   `CommentCommand::ReleaseBump` in `comment_command_processor.rs`).
+8. **Rejection and informational comment posting is best-effort**: if `create_issue_comment`
+   returns an error it is logged as a warning and the event is still acknowledged
+   (not retried).
+
+## Consequences
+
+- Any GitHub App user with write access or above can influence the release version of
+  any repository the App is installed on, subject to the `allow_override` flag.
+- No persistent state is written for a command: `!set-version` triggers
+  `ReleaseOrchestrator` immediately.  Idempotency is provided by the orchestrator's
+  existing branch-existence check.
+- The `allow_override` flag provides an opt-in safety valve; repositories that do not
+  need manual version overrides can leave it `false` and no comment will ever trigger
+  a release action.
+- Comment posting failures are silent from the user's perspective (event is
+  acknowledged, no retry).  Operators must monitor warning logs to detect persistent
+  GitHub API issues.
+
+## Alternatives considered
+
+- **Allowlist of authorized users in config**: More explicit control, but adds
+  operational burden (keeping the list current) and blocks new maintainers.  The
+  GitHub collaborator permission model is already managed through the repository and
+  reflects the team structure in real time.
+- **Require structured comment syntax (e.g. YAML front matter)**: More extensible for
+  future complex commands but adds unnecessary friction for the common single-line
+  override case.
+- **Store command intent in a PR label**: Labels persist after the PR is merged, which
+  could interfere with other label-based automation.  Labels also lack type-safe
+  arguments.
+
+## Implementation notes
+
+- `CollaboratorPermission::can_issue_commands()` returns `true` for `Admin`,
+  `Maintain`, and `Write`.  `Triage` and `Read` are treated as insufficient.
+- `post_comment` swallows GitHub API errors (with a `warn!` log) so posting failures
+  do not cause retries of the comment event.
+- `parse_comment_command` is a pure free function to keep it independently testable.
+- The changelog field passed to `ReleaseOrchestrator::orchestrate` for `!set-version`
+  is the placeholder string `"Version pinned via PR comment override."`; the
+  orchestrator renders this as the PR body.
+- The `CommentCommandProcessor` is a domain component in the `core` crate; it calls
+  `GitHubOperations` ports and contains no HTTP client code.
+
+## Examples
+
+Pin to a specific version:
+
+```text
+!set-version 2.0.0
+```
+
+Force a minimum bump (stub — not yet active):
+
+```text
+!release major
+```
+
+Both may appear anywhere in the comment body as long as the command starts at the
+beginning of a trimmed line.
+
+## References
+
+- [ADR-001: Hexagonal Architecture](ADR-001-hexagonal-architecture.md)
+- GitHub REST API: `GET /repos/{owner}/{repo}/collaborators/{username}/permission`
+- Conventional Commits specification: <https://www.conventionalcommits.org/>


### PR DESCRIPTION
Implements a new CommentCommandProcessor that handles PullRequestCommentReceived
events, allowing maintainers to pin a release version or request a forced bump
directly from a PR comment.

## What Changed
- New `comment_command_processor` module in `crates/core/src/` containing:
  - `BumpKind` enum (`Major | Minor | Patch`)
  - `CommentCommand` enum (`SetVersion(SemanticVersion) | ReleaseBump(BumpKind) | Unknown`)
  - `CommentCommandConfig` struct with `allow_override` guard
  - `CommentCommandProcessor<G>` struct with a `process()` async entry point
  - `parse_comment_command()` free function — line-scan, case-insensitive
- `create_issue_comment(owner, repo, issue_number, body) -> CoreResult<()>` added to
  the `GitHubOperations` trait, `MockGitHubOperations`, and `GitHubClient`
- `handle_pr_comment()` default method added to `MergedPullRequestHandler` trait;
  `ReleaseRegentProcessor` overrides it to build config and dispatch to the processor
- `PullRequestCommentReceived` event arm in `run_event_loop` now routes to
  `handler.handle_pr_comment()` instead of silently acknowledging

## Why
Teams occasionally need to override the version computed by conventional-commit
analysis — for example, to skip straight to `1.0.0` or to force a major bump for a
breaking change that wasn't flagged in commits. Without this mechanism every such
case required a manual intervention outside the automation pipeline.

## How
`parse_comment_command` scans the comment body line by line for two recognised
prefixes:

- `!set-version X.Y.Z` — pins an explicit semver; validated to be strictly greater
  than the current latest semver tag (or ≥ `0.0.1` when no tags exist). On success,
  delegates to `ReleaseOrchestrator::orchestrate` with the pinned version. On
  rejection, posts a feedback comment via `create_issue_comment` and acknowledges
  the event so it is not retried.
- `!release major|minor|patch` — returns `CoreError::NotSupported` as a stub;
  full implementation is deferred.

Processing is gated by `VersioningConfig::allow_override`; when `false`, all
comment events are silently ignored with no API calls. Comments on closed PRs are
similarly discarded.

## Testing Evidence
- **Test Coverage:** 22 new unit tests in `comment_command_processor_tests.rs`
  covering: command parsing (valid semver, v-prefix, case-insensitivity, multi-line,
  malformed input, all bump kinds), `allow_override: false` guard, unrecognised/empty
  body, closed/merged PR guard, set-version accepted/rejected paths, first-release
  path (no existing tags), 0.0.0 rejection, release-bump stub error, and idempotency
- **Test Results:** 169 core unit tests pass (0 failed); full workspace suite passes
  with 0 failures; zero new Clippy errors under `pedantic + unwrap_used + expect_used`
- **Manual Testing:** Not applicable — behaviour fully covered by unit tests with
  inline test doubles

## Reviewer Guidance
- `parse_comment_command` must appear on its own line in the comment body; commands
  embedded mid-paragraph are intentionally ignored — verify this is the right UX
- `create_issue_comment` result is discarded after a rejection reply; if posting the
  rejection comment fails, the event is still acknowledged (silent failure). Decide
  whether that is acceptable or whether a failed reply should surface as an error
- `!release major/minor/patch` currently returns `CoreError::NotSupported`; callers
  will see this propagated as an unretryable error — confirm the desired user-facing
  behaviour pending the full implementation in the next task
- All existing `MergedPullRequestHandler` implementors (`NoopMergedPRHandler`, etc.)
  are unaffected because `handle_pr_comment` has a default no-op implementation