### PR TITLE
feat(core): implement !release bump-override persistence and set-version improvements

### DIFF
--- a/crates/core/src/comment_command_processor.rs
+++ b/crates/core/src/comment_command_processor.rs
@@ -328,12 +328,23 @@ impl<'a, G: GitHubOperations + Send + Sync> CommentCommandProcessor<'a, G> {
         };
         let body = if let Some(old_label) = replaced_kind {
             let old_kind = old_label.strip_prefix("rr:override-").unwrap_or(old_label);
-            format!(
-                "✅ **Release Regent**: `!release {kind_str}` override recorded \
-                 (replacing previous `!release {old_kind}` override). When this PR \
-                 is merged, the next release version will be bumped by at least one \
-                 {kind_str} increment."
-            )
+            if old_label == new_label {
+                // Same label re-applied: confirm idempotent re-recording.
+                format!(
+                    "✅ **Release Regent**: `!release {kind_str}` override re-recorded \
+                     (the existing `!release {kind_str}` override is unchanged). When this PR \
+                     is merged, the next release version will be bumped by at least one \
+                     {kind_str} increment."
+                )
+            } else {
+                // Different label: replacing a previous override.
+                format!(
+                    "✅ **Release Regent**: `!release {kind_str}` override recorded \
+                     (replacing previous `!release {old_kind}` override). When this PR \
+                     is merged, the next release version will be bumped by at least one \
+                     {kind_str} increment."
+                )
+            }
         } else {
             format!(
                 "✅ **Release Regent**: `!release {kind_str}` override recorded. \
@@ -429,12 +440,17 @@ impl<'a, G: GitHubOperations + Send + Sync> CommentCommandProcessor<'a, G> {
         let base_branch = pr.base.ref_name.clone();
         let base_sha = pr.base.sha.clone();
 
+        // Extract the existing changelog from the PR body that is already in hand.
+        // This avoids a second search_pull_requests call and ensures we read from
+        // exactly the same PR that handle_set_version is operating on, which is
+        // consistent with the orchestrator's PR-selection logic.
+        let existing_changelog = crate::release_orchestrator::extract_changelog_from_pr_body(
+            pr.body.as_deref().unwrap_or(""),
+            &self.config.orchestrator_config.changelog_header,
+        );
+
         let orchestrator =
             ReleaseOrchestrator::new(self.config.orchestrator_config.clone(), self.github);
-
-        let existing_changelog = self
-            .fetch_existing_release_changelog(owner, repo, pr_number, correlation_id)
-            .await;
 
         let orch_result = orchestrator
             .orchestrate(
@@ -448,49 +464,13 @@ impl<'a, G: GitHubOperations + Send + Sync> CommentCommandProcessor<'a, G> {
             )
             .await?;
 
-        let confirmation = Self::format_set_version_confirmation(pinned_version, &orch_result);
+        let confirmation = Self::format_set_version_confirmation(
+            pinned_version,
+            &orch_result,
+            &self.config.orchestrator_config.branch_prefix,
+        );
         self.post_comment(owner, repo, pr_number, &confirmation)
             .await
-    }
-
-    /// Fetch the changelog from the current open release PR, if one exists.
-    ///
-    /// Searches for any open PR whose head branch starts with the release
-    /// branch prefix and extracts the changelog section from its body.
-    /// Returns an empty string when no release PR exists or when the search
-    /// fails (the caller falls back gracefully in both cases).
-    async fn fetch_existing_release_changelog(
-        &self,
-        owner: &str,
-        repo: &str,
-        pr_number: u64,
-        correlation_id: &str,
-    ) -> String {
-        let release_prefix = format!("{}/v", self.config.orchestrator_config.branch_prefix);
-        let query = format!("is:open head:{release_prefix}*");
-        match self.github.search_pull_requests(owner, repo, &query).await {
-            Ok(prs) => prs
-                .iter()
-                .filter(|p| p.head.ref_name.starts_with(&release_prefix))
-                .filter_map(|p| p.body.as_deref())
-                .map(|body| {
-                    crate::release_orchestrator::extract_changelog_from_pr_body(
-                        body,
-                        &self.config.orchestrator_config.changelog_header,
-                    )
-                })
-                .next()
-                .unwrap_or_default(),
-            Err(e) => {
-                warn!(
-                    pr_number,
-                    correlation_id,
-                    error = %e,
-                    "Failed to read existing release PR changelog; proceeding with empty changelog"
-                );
-                String::new()
-            }
-        }
     }
 
     /// Format the confirmation comment posted after a successful `!set-version` run.
@@ -505,6 +485,7 @@ impl<'a, G: GitHubOperations + Send + Sync> CommentCommandProcessor<'a, G> {
     fn format_set_version_confirmation(
         pinned_version: &SemanticVersion,
         result: &crate::release_orchestrator::OrchestratorResult,
+        branch_prefix: &str,
     ) -> String {
         use crate::release_orchestrator::OrchestratorResult;
         match result {
@@ -520,12 +501,22 @@ impl<'a, G: GitHubOperations + Send + Sync> CommentCommandProcessor<'a, G> {
                 "✅ **Release Regent**: Release version `{pinned_version}` is already \
                  the active release PR version. No changes were needed."
             ),
-            OrchestratorResult::NoOp { pr } => format!(
-                "⚠️ **Release Regent**: `!set-version {pinned_version}` was not applied \
-                 — the existing release PR is already at a higher version \
-                 (`{}`). To override, close the existing release PR first.",
-                pr.head.ref_name,
-            ),
+            OrchestratorResult::NoOp { pr } => {
+                // Strip the release branch prefix (e.g. "release/v") to show
+                // a clean version number like "2.0.0" rather than the full
+                // branch name like "release/v2.0.0".
+                let release_v_prefix = format!("{branch_prefix}/v");
+                let version_display = pr
+                    .head
+                    .ref_name
+                    .strip_prefix(&release_v_prefix)
+                    .unwrap_or(&pr.head.ref_name);
+                format!(
+                    "⚠️ **Release Regent**: `!set-version {pinned_version}` was not applied \
+                     — the existing release PR is already at a higher version \
+                     (`{version_display}`). To override, close the existing release PR first."
+                )
+            }
         }
     }
 

--- a/crates/core/src/comment_command_processor.rs
+++ b/crates/core/src/comment_command_processor.rs
@@ -39,13 +39,13 @@ use std::cmp::Ordering;
 
 use tracing::{debug, info, warn, Instrument};
 
+pub use crate::versioning::BumpKind;
 use crate::{
     release_orchestrator::{OrchestratorConfig, ReleaseOrchestrator},
     traits::{event_source::ProcessingEvent, github_operations::GitHubOperations},
     versioning::{resolve_current_version, SemanticVersion, VersionCalculator},
     CoreResult,
 };
-pub use crate::versioning::BumpKind;
 
 // ─────────────────────────────────────────────────────────────────────────────────
 // Label constants
@@ -242,14 +242,8 @@ impl<'a, G: GitHubOperations + Send + Sync> CommentCommandProcessor<'a, G> {
         match command {
             CommentCommand::Unknown => Ok(()),
             CommentCommand::ReleaseBump(kind) => {
-                self.handle_release_bump(
-                    owner,
-                    repo,
-                    issue_number,
-                    &kind,
-                    &event.correlation_id,
-                )
-                .await
+                self.handle_release_bump(owner, repo, issue_number, &kind, &event.correlation_id)
+                    .await
             }
             CommentCommand::SetVersion(pinned_version) => {
                 self.handle_set_version(
@@ -290,14 +284,11 @@ impl<'a, G: GitHubOperations + Send + Sync> CommentCommandProcessor<'a, G> {
 
         // Read current labels to detect a replacement (used in the confirmation
         // message).  Propagate errors so transient API failures cause a retry.
-        let current_labels = self
-            .github
-            .list_pr_labels(owner, repo, pr_number)
-            .await?;
+        let current_labels = self.github.list_pr_labels(owner, repo, pr_number).await?;
 
         let replaced_kind: Option<&str> = ALL_OVERRIDE_LABELS
             .iter()
-            .find(|&&l| l != new_label && current_labels.iter().any(|cl| cl.name == l))
+            .find(|&&l| current_labels.iter().any(|cl| cl.name == l))
             .copied();
 
         // Remove all existing override labels (idempotent; 404 → Ok).
@@ -336,9 +327,7 @@ impl<'a, G: GitHubOperations + Send + Sync> CommentCommandProcessor<'a, G> {
             BumpKind::Patch => "patch",
         };
         let body = if let Some(old_label) = replaced_kind {
-            let old_kind = old_label
-                .strip_prefix("rr:override-")
-                .unwrap_or(old_label);
+            let old_kind = old_label.strip_prefix("rr:override-").unwrap_or(old_label);
             format!(
                 "✅ **Release Regent**: `!release {kind_str}` override recorded \
                  (replacing previous `!release {old_kind}` override). When this PR \
@@ -460,7 +449,8 @@ impl<'a, G: GitHubOperations + Send + Sync> CommentCommandProcessor<'a, G> {
             .await?;
 
         let confirmation = Self::format_set_version_confirmation(pinned_version, &orch_result);
-        self.post_comment(owner, repo, pr_number, &confirmation).await
+        self.post_comment(owner, repo, pr_number, &confirmation)
+            .await
     }
 
     /// Fetch the changelog from the current open release PR, if one exists.

--- a/crates/core/src/comment_command_processor.rs
+++ b/crates/core/src/comment_command_processor.rs
@@ -443,18 +443,100 @@ impl<'a, G: GitHubOperations + Send + Sync> CommentCommandProcessor<'a, G> {
         let orchestrator =
             ReleaseOrchestrator::new(self.config.orchestrator_config.clone(), self.github);
 
-        orchestrator
+        let existing_changelog = self
+            .fetch_existing_release_changelog(owner, repo, pr_number, correlation_id)
+            .await;
+
+        let orch_result = orchestrator
             .orchestrate(
                 owner,
                 repo,
                 pinned_version,
-                "Version pinned via PR comment override.",
+                &existing_changelog,
                 &base_branch,
                 &base_sha,
                 correlation_id,
             )
-            .await
-            .map(|_| ())
+            .await?;
+
+        let confirmation = Self::format_set_version_confirmation(pinned_version, &orch_result);
+        self.post_comment(owner, repo, pr_number, &confirmation).await
+    }
+
+    /// Fetch the changelog from the current open release PR, if one exists.
+    ///
+    /// Searches for any open PR whose head branch starts with the release
+    /// branch prefix and extracts the changelog section from its body.
+    /// Returns an empty string when no release PR exists or when the search
+    /// fails (the caller falls back gracefully in both cases).
+    async fn fetch_existing_release_changelog(
+        &self,
+        owner: &str,
+        repo: &str,
+        pr_number: u64,
+        correlation_id: &str,
+    ) -> String {
+        let release_prefix = format!("{}/v", self.config.orchestrator_config.branch_prefix);
+        let query = format!("is:open head:{release_prefix}*");
+        match self.github.search_pull_requests(owner, repo, &query).await {
+            Ok(prs) => prs
+                .iter()
+                .filter(|p| p.head.ref_name.starts_with(&release_prefix))
+                .filter_map(|p| p.body.as_deref())
+                .map(|body| {
+                    crate::release_orchestrator::extract_changelog_from_pr_body(
+                        body,
+                        &self.config.orchestrator_config.changelog_header,
+                    )
+                })
+                .next()
+                .unwrap_or_default(),
+            Err(e) => {
+                warn!(
+                    pr_number,
+                    correlation_id,
+                    error = %e,
+                    "Failed to read existing release PR changelog; proceeding with empty changelog"
+                );
+                String::new()
+            }
+        }
+    }
+
+    /// Format the confirmation comment posted after a successful `!set-version` run.
+    ///
+    /// The wording varies by orchestration outcome:
+    /// - `Created` / `Renamed` — a new or renamed release PR is now at the
+    ///   pinned version.
+    /// - `Updated` — the existing release PR already had the same version;
+    ///   no version change was needed.
+    /// - `NoOp` — the existing release PR already has a *higher* version;
+    ///   the command was superseded.
+    fn format_set_version_confirmation(
+        pinned_version: &SemanticVersion,
+        result: &crate::release_orchestrator::OrchestratorResult,
+    ) -> String {
+        use crate::release_orchestrator::OrchestratorResult;
+        match result {
+            OrchestratorResult::Created { .. } => format!(
+                "✅ **Release Regent**: Release version pinned to `{pinned_version}`. \
+                 A new release PR has been created."
+            ),
+            OrchestratorResult::Renamed { .. } => format!(
+                "✅ **Release Regent**: Release version pinned to `{pinned_version}`. \
+                 The release PR has been updated to this version."
+            ),
+            OrchestratorResult::Updated { .. } => format!(
+                "✅ **Release Regent**: Release version `{pinned_version}` is already \
+                 the active release PR version. No changes were needed."
+            ),
+            OrchestratorResult::NoOp { pr } => format!(
+                "⚠️ **Release Regent**: `!set-version {pinned_version}` was not applied \
+                 — the existing release PR is already at a higher version \
+                 (`{}`). To override, close the existing release PR first.",
+                pr.head.ref_name,
+            ),
+        }
     }
 
     /// Post a comment on the PR as a best-effort operation.

--- a/crates/core/src/comment_command_processor.rs
+++ b/crates/core/src/comment_command_processor.rs
@@ -45,22 +45,28 @@ use crate::{
     versioning::{resolve_current_version, SemanticVersion, VersionCalculator},
     CoreResult,
 };
+pub use crate::versioning::BumpKind;
+
+// ─────────────────────────────────────────────────────────────────────────────────
+// Label constants
+// ─────────────────────────────────────────────────────────────────────────────────
+
+/// GitHub label applied to a feature PR for a `!release major` override.
+pub const OVERRIDE_LABEL_MAJOR: &str = "rr:override-major";
+/// GitHub label applied to a feature PR for a `!release minor` override.
+pub const OVERRIDE_LABEL_MINOR: &str = "rr:override-minor";
+/// GitHub label applied to a feature PR for a `!release patch` override.
+pub const OVERRIDE_LABEL_PATCH: &str = "rr:override-patch";
+/// All three bump-override label names in one slice, useful for iteration.
+pub const ALL_OVERRIDE_LABELS: &[&str] = &[
+    OVERRIDE_LABEL_MAJOR,
+    OVERRIDE_LABEL_MINOR,
+    OVERRIDE_LABEL_PATCH,
+];
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Public types
 // ─────────────────────────────────────────────────────────────────────────────
-
-/// Which conventional-commit bump dimension the user is requesting via
-/// an `!release` override command.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum BumpKind {
-    /// Force at least a major version bump.
-    Major,
-    /// Force at least a minor version bump.
-    Minor,
-    /// Force at least a patch version bump.
-    Patch,
-}
 
 /// A command parsed from a pull request comment body.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -68,10 +74,6 @@ pub enum CommentCommand {
     /// `!set-version X.Y.Z` — pin the next release to exactly this version.
     SetVersion(SemanticVersion),
     /// `!release major|minor|patch` — override the minimum bump dimension.
-    ///
-    /// **Note**: this variant is recognised by the parser but the processor
-    /// posts an informational comment and acknowledges the event until the
-    /// bump-override design is completed.
     ReleaseBump(BumpKind),
     /// No recognised command was found in the comment body.
     Unknown,
@@ -239,12 +241,15 @@ impl<'a, G: GitHubOperations + Send + Sync> CommentCommandProcessor<'a, G> {
 
         match command {
             CommentCommand::Unknown => Ok(()),
-            CommentCommand::ReleaseBump(_kind) => {
-                // The !release bump design is not yet complete. Post an informational
-                // comment so the user gets feedback and acknowledge the event (Ok).
-                let body = "ℹ️ **Release Regent**: `!release` bump overrides are not yet \
-                             supported. This command will be available in a future release.";
-                self.post_comment(owner, repo, issue_number, body).await
+            CommentCommand::ReleaseBump(kind) => {
+                self.handle_release_bump(
+                    owner,
+                    repo,
+                    issue_number,
+                    &kind,
+                    &event.correlation_id,
+                )
+                .await
             }
             CommentCommand::SetVersion(pinned_version) => {
                 self.handle_set_version(
@@ -261,6 +266,96 @@ impl<'a, G: GitHubOperations + Send + Sync> CommentCommandProcessor<'a, G> {
 
     // ── Private helpers ────────────────────────────────────────────────────
 
+    /// Handle a validated `!release major|minor|patch` command.
+    ///
+    /// Removes any existing `rr:override-*` labels from the commented-upon PR
+    /// (idempotent), applies the new override label, then posts a confirmation
+    /// comment explaining the effect.  All errors from label operations are
+    /// logged as warnings rather than propagated so that a transient GitHub API
+    /// failure does not cause the event to be retried indefinitely.
+    async fn handle_release_bump(
+        &self,
+        owner: &str,
+        repo: &str,
+        pr_number: u64,
+        kind: &BumpKind,
+        correlation_id: &str,
+    ) -> CoreResult<()> {
+        // Determine which label corresponds to this bump kind.
+        let new_label = match kind {
+            BumpKind::Major => OVERRIDE_LABEL_MAJOR,
+            BumpKind::Minor => OVERRIDE_LABEL_MINOR,
+            BumpKind::Patch => OVERRIDE_LABEL_PATCH,
+        };
+
+        // Read current labels to detect a replacement (used in the confirmation
+        // message).  Propagate errors so transient API failures cause a retry.
+        let current_labels = self
+            .github
+            .list_pr_labels(owner, repo, pr_number)
+            .await?;
+
+        let replaced_kind: Option<&str> = ALL_OVERRIDE_LABELS
+            .iter()
+            .find(|&&l| l != new_label && current_labels.iter().any(|cl| cl.name == l))
+            .copied();
+
+        // Remove all existing override labels (idempotent; 404 → Ok).
+        for label in ALL_OVERRIDE_LABELS {
+            if let Err(e) = self
+                .github
+                .remove_label(owner, repo, pr_number, label)
+                .await
+            {
+                warn!(
+                    pr_number,
+                    label,
+                    error = %e,
+                    correlation_id,
+                    "Failed to remove existing override label; continuing"
+                );
+            }
+        }
+
+        // Apply the new override label.
+        self.github
+            .add_labels(owner, repo, pr_number, &[new_label])
+            .await?;
+
+        info!(
+            pr_number,
+            label = new_label,
+            correlation_id,
+            "!release override label applied"
+        );
+
+        // Post a confirmation comment.
+        let kind_str = match kind {
+            BumpKind::Major => "major",
+            BumpKind::Minor => "minor",
+            BumpKind::Patch => "patch",
+        };
+        let body = if let Some(old_label) = replaced_kind {
+            let old_kind = old_label
+                .strip_prefix("rr:override-")
+                .unwrap_or(old_label);
+            format!(
+                "✅ **Release Regent**: `!release {kind_str}` override recorded \
+                 (replacing previous `!release {old_kind}` override). When this PR \
+                 is merged, the next release version will be bumped by at least one \
+                 {kind_str} increment."
+            )
+        } else {
+            format!(
+                "✅ **Release Regent**: `!release {kind_str}` override recorded. \
+                 When this PR is merged, the next release version will be bumped by \
+                 at least one {kind_str} increment."
+            )
+        };
+
+        self.post_comment(owner, repo, pr_number, &body).await
+    }
+
     /// Handle a validated `!set-version X.Y.Z` command.
     ///
     /// Validates the pinned version against the current released version, then
@@ -275,6 +370,25 @@ impl<'a, G: GitHubOperations + Send + Sync> CommentCommandProcessor<'a, G> {
         pinned_version: &SemanticVersion,
         correlation_id: &str,
     ) -> CoreResult<()> {
+        // Guard: only accept !set-version on the release PR (head branch release/v*).
+        let pr = self.github.get_pull_request(owner, repo, pr_number).await?;
+        let branch_prefix = &self.config.orchestrator_config.branch_prefix;
+        let release_head_prefix = format!("{branch_prefix}/v");
+        if !pr.head.ref_name.starts_with(&release_head_prefix) {
+            let rejection = format!(
+                "⚠️ **Release Regent**: `!set-version` must be posted on the active \
+                 release PR (branch `{branch_prefix}/v*`). Please re-post this \
+                 command on the release PR."
+            );
+            warn!(
+                pr_number,
+                head_branch = %pr.head.ref_name,
+                correlation_id,
+                "!set-version rejected: not on release PR"
+            );
+            return self.post_comment(owner, repo, pr_number, &rejection).await;
+        }
+
         // Resolve the currently released version from Git tags.
         let current_version = resolve_current_version(self.github, owner, repo, false).await?;
 
@@ -323,8 +437,6 @@ impl<'a, G: GitHubOperations + Send + Sync> CommentCommandProcessor<'a, G> {
             "!set-version accepted — invoking release orchestrator"
         );
 
-        // Retrieve the PR to extract the base branch name and SHA.
-        let pr = self.github.get_pull_request(owner, repo, pr_number).await?;
         let base_branch = pr.base.ref_name.clone();
         let base_sha = pr.base.sha.clone();
 

--- a/crates/core/src/comment_command_processor_tests.rs
+++ b/crates/core/src/comment_command_processor_tests.rs
@@ -50,6 +50,10 @@ struct TestState {
     commenter_permission: Option<CollaboratorPermission>,
     /// Labels keyed by PR/issue number for `list_pr_labels`.
     pr_labels: HashMap<u64, Vec<Label>>,
+    /// When `true`, the next `add_labels` call returns a `CoreError::GitHub` error.
+    next_add_labels_error: bool,
+    /// When `true`, every `remove_label` call returns a `CoreError::Network` error.
+    all_remove_label_network_error: bool,
 }
 
 #[derive(Clone, Default)]
@@ -107,6 +111,18 @@ impl TestGitHub {
     /// Pre-populate labels for a specific PR/issue number.
     async fn with_pr_labels(self, pr_number: u64, labels: Vec<Label>) -> Self {
         self.state.lock().await.pr_labels.insert(pr_number, labels);
+        self
+    }
+
+    /// Make the next `add_labels` call return a `CoreError::GitHub` error.
+    async fn with_next_add_labels_error(self) -> Self {
+        self.state.lock().await.next_add_labels_error = true;
+        self
+    }
+
+    /// Make all `remove_label` calls return a `CoreError::Network` error.
+    async fn with_all_remove_label_network_error(self) -> Self {
+        self.state.lock().await.all_remove_label_network_error = true;
         self
     }
 
@@ -399,6 +415,13 @@ impl GitHubOperations for TestGitHub {
         labels: &[&str],
     ) -> CoreResult<()> {
         let mut st = self.state.lock().await;
+        if st.next_add_labels_error {
+            st.next_add_labels_error = false;
+            return Err(CoreError::github(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "Simulated add_labels failure",
+            )));
+        }
         let entry = st.pr_labels.entry(pr_number).or_default();
         for &name in labels {
             if !entry.iter().any(|l| l.name == name) {
@@ -421,6 +444,9 @@ impl GitHubOperations for TestGitHub {
         label_name: &str,
     ) -> CoreResult<()> {
         let mut st = self.state.lock().await;
+        if st.all_remove_label_network_error {
+            return Err(CoreError::network("Simulated remove_label network failure"));
+        }
         if let Some(labels) = st.pr_labels.get_mut(&pr_number) {
             labels.retain(|l| l.name != label_name);
         }
@@ -1387,5 +1413,193 @@ async fn test_process_set_version_proceeds_with_empty_changelog_when_search_fail
         comments[0].1.contains('✅'),
         "expected ✅ confirmation even after search failure, got: {}",
         comments[0].1
+    );
+}
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// handle_release_bump error-path tests (spec §9 Minor #4)
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+/// When `add_labels` fails with a GitHub error, the error is propagated so
+/// the event loop can schedule a retry.
+#[tokio::test]
+async fn test_handle_release_bump_add_labels_failure_propagates_error() {
+    let github = TestGitHub::new().with_next_add_labels_error().await;
+    let processor = CommentCommandProcessor::new(default_config(true), &github);
+
+    let event = test_event(77, "!release major", "open");
+    let result = processor.process(&event).await;
+
+    // The error must be propagated (not swallowed as Ok).
+    assert!(
+        result.is_err(),
+        "expected Err when add_labels fails, got: {result:?}"
+    );
+    // No confirmation comment should have been posted.
+    assert!(
+        github.issue_comments().await.is_empty(),
+        "no confirmation comment should be posted when add_labels fails"
+    );
+}
+
+/// When `remove_label` fails with a network error, the failure is logged as a
+/// warning but `add_labels` is still called and a confirmation is still posted.
+#[tokio::test]
+async fn test_handle_release_bump_remove_label_failure_still_adds_new_label() {
+    // Pre-populate an existing override label so the remove path is exercised.
+    let existing_label = Label {
+        id: 1,
+        name: "rr:override-minor".to_string(),
+        color: "ededed".to_string(),
+        description: None,
+    };
+    let github = TestGitHub::new()
+        .with_pr_labels(33, vec![existing_label])
+        .await
+        .with_all_remove_label_network_error()
+        .await;
+    let processor = CommentCommandProcessor::new(default_config(true), &github);
+
+    let event = test_event(33, "!release major", "open");
+    let result = processor.process(&event).await;
+
+    // Despite remove_label failing, the overall operation should succeed.
+    assert!(
+        result.is_ok(),
+        "expected Ok even when remove_label fails, got: {result:?}"
+    );
+    // A confirmation comment must still be posted.
+    let comments = github.issue_comments().await;
+    assert_eq!(
+        comments.len(),
+        1,
+        "expected one confirmation comment despite remove_label failure"
+    );
+    assert!(
+        comments[0].1.contains("override recorded"),
+        "confirmation comment should confirm override, got: {}",
+        comments[0].1
+    );
+}
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// handle_set_version scope guard edge cases (spec §9 Minor #7)
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+/// `!set-version` posted on a PR whose head branch starts with `release/` but
+/// does NOT include a `/v` prefix (e.g. `release/some-branch`) must be rejected
+/// with a scope-guard comment. Only `release/v*` branches are accepted.
+#[tokio::test]
+async fn test_process_set_version_rejected_on_release_branch_without_v_prefix() {
+    // Build a PR whose head branch is "release/some-branch" (no "/v").
+    let now = Utc::now();
+    let r = stub_repo("acme", "app");
+    let non_versioned_release_pr = PullRequest {
+        number: 55,
+        title: "release: some-branch".to_string(),
+        body: None,
+        state: "open".to_string(),
+        draft: false,
+        created_at: now,
+        updated_at: now,
+        merged_at: None,
+        user: stub_user(),
+        head: PullRequestBranch {
+            ref_name: "release/some-branch".to_string(), // starts with "release/" but no "/v"
+            sha: "headsha".to_string(),
+            repo: stub_repo("acme", "app"),
+        },
+        base: PullRequestBranch {
+            ref_name: "main".to_string(),
+            sha: "basesha".to_string(),
+            repo: r,
+        },
+    };
+    let github = TestGitHub::new()
+        .with_tags(vec![make_semver_tag("v1.0.0")])
+        .await
+        .with_pr(non_versioned_release_pr)
+        .await;
+
+    let processor = CommentCommandProcessor::new(default_config(true), &github);
+    let event = test_event(55, "!set-version 2.0.0", "open");
+    let result = processor.process(&event).await;
+
+    assert!(
+        result.is_ok(),
+        "expected Ok (acknowledged), got: {result:?}"
+    );
+    let comments = github.issue_comments().await;
+    assert_eq!(
+        comments.len(),
+        1,
+        "expected one scope-rejection comment, got {comments:?}"
+    );
+    assert_eq!(comments[0].0, 55, "comment should be on PR #55");
+    assert!(
+        comments[0].1.contains("release PR"),
+        "rejection comment should mention release PR, got: {}",
+        comments[0].1
+    );
+    // Orchestrator must not have been called.
+    assert!(
+        github.created_prs().await.is_empty(),
+        "orchestrator must not be called on scope rejection"
+    );
+}
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// handle_release_bump same-override repost test (spec §9 Minor #8)
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+/// When the same `!release patch` override is posted a second time on a PR
+/// that already carries `rr:override-patch`, the confirmation comment must use
+/// "replacing" wording to confirm re-application.
+#[tokio::test]
+async fn test_process_release_bump_same_override_reposted_shows_replacing_confirmation() {
+    let existing_patch_label = Label {
+        id: 1,
+        name: "rr:override-patch".to_string(),
+        color: "ededed".to_string(),
+        description: None,
+    };
+    let github = TestGitHub::new()
+        .with_pr_labels(66, vec![existing_patch_label])
+        .await;
+    let processor = CommentCommandProcessor::new(default_config(true), &github);
+
+    // Post `!release patch` again on a PR that already has rr:override-patch.
+    let event = test_event(66, "!release patch", "open");
+    let result = processor.process(&event).await;
+
+    assert!(result.is_ok(), "expected Ok, got: {result:?}");
+    let comments = github.issue_comments().await;
+    assert_eq!(
+        comments.len(),
+        1,
+        "expected one confirmation comment, got {comments:?}"
+    );
+    assert!(
+        comments[0].1.contains("replacing"),
+        "confirmation should mention 'replacing' when same override is reposted, got: {}",
+        comments[0].1
+    );
+    assert!(
+        comments[0].1.contains("patch"),
+        "confirmation should mention the bump kind, got: {}",
+        comments[0].1
+    );
+    // rr:override-patch must still be present after re-application.
+    let labels = github
+        .state
+        .lock()
+        .await
+        .pr_labels
+        .get(&66)
+        .cloned()
+        .unwrap_or_default();
+    assert!(
+        labels.iter().any(|l| l.name == "rr:override-patch"),
+        "rr:override-patch must be re-applied after repost, got: {labels:?}"
     );
 }

--- a/crates/core/src/comment_command_processor_tests.rs
+++ b/crates/core/src/comment_command_processor_tests.rs
@@ -7,7 +7,7 @@ use crate::{
         },
         github_operations::{
             CollaboratorPermission, CreatePullRequestParams, CreateReleaseParams, GitHubOperations,
-            GitUser as GitHubUser, PullRequest, PullRequestBranch, Release, Repository, Tag,
+            GitUser as GitHubUser, Label, PullRequest, PullRequestBranch, Release, Repository, Tag,
             UpdateReleaseParams,
         },
     },
@@ -46,6 +46,8 @@ struct TestState {
     /// Collaborator permission returned by `get_collaborator_permission`.
     /// `None` defaults to `CollaboratorPermission::Write`.
     commenter_permission: Option<CollaboratorPermission>,
+    /// Labels keyed by PR/issue number for `list_pr_labels`.
+    pr_labels: HashMap<u64, Vec<Label>>,
 }
 
 #[derive(Clone, Default)]
@@ -58,6 +60,7 @@ impl TestGitHub {
         Self {
             state: Arc::new(Mutex::new(TestState {
                 next_pr_number: 200,
+                pr_labels: HashMap::new(),
                 ..Default::default()
             })),
         }
@@ -90,6 +93,12 @@ impl TestGitHub {
     /// Pre-set the collaborator permission returned for any username.
     async fn with_commenter_permission(self, permission: CollaboratorPermission) -> Self {
         self.state.lock().await.commenter_permission = Some(permission);
+        self
+    }
+
+    /// Pre-populate labels for a specific PR/issue number.
+    async fn with_pr_labels(self, pr_number: u64, labels: Vec<Label>) -> Self {
+        self.state.lock().await.pr_labels.insert(pr_number, labels);
         self
     }
 
@@ -366,6 +375,58 @@ impl GitHubOperations for TestGitHub {
             .clone()
             .unwrap_or(CollaboratorPermission::Write))
     }
+
+    async fn add_labels(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        pr_number: u64,
+        labels: &[&str],
+    ) -> CoreResult<()> {
+        let mut st = self.state.lock().await;
+        let entry = st.pr_labels.entry(pr_number).or_default();
+        for &name in labels {
+            if !entry.iter().any(|l| l.name == name) {
+                entry.push(Label {
+                    id: entry.len() as u64 + 1,
+                    name: name.to_string(),
+                    color: "ededed".to_string(),
+                    description: None,
+                });
+            }
+        }
+        Ok(())
+    }
+
+    async fn remove_label(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        pr_number: u64,
+        label_name: &str,
+    ) -> CoreResult<()> {
+        let mut st = self.state.lock().await;
+        if let Some(labels) = st.pr_labels.get_mut(&pr_number) {
+            labels.retain(|l| l.name != label_name);
+        }
+        Ok(())
+    }
+
+    async fn list_pr_labels(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        pr_number: u64,
+    ) -> CoreResult<Vec<Label>> {
+        Ok(self
+            .state
+            .lock()
+            .await
+            .pr_labels
+            .get(&pr_number)
+            .cloned()
+            .unwrap_or_default())
+    }
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -410,6 +471,32 @@ fn make_open_pr(number: u64, base_sha: &str) -> PullRequest {
         user: stub_user(),
         head: PullRequestBranch {
             ref_name: "feat/my-feature".to_string(),
+            sha: "headsha".to_string(),
+            repo: stub_repo("acme", "app"),
+        },
+        base: PullRequestBranch {
+            ref_name: "main".to_string(),
+            sha: base_sha.to_string(),
+            repo: r,
+        },
+    }
+}
+
+fn make_release_pr(number: u64, base_sha: &str) -> PullRequest {
+    let now = Utc::now();
+    let r = stub_repo("acme", "app");
+    PullRequest {
+        number,
+        title: "release: v1.0.0".to_string(),
+        body: None,
+        state: "open".to_string(),
+        draft: false,
+        created_at: now,
+        updated_at: now,
+        merged_at: None,
+        user: stub_user(),
+        head: PullRequestBranch {
+            ref_name: "release/v1.0.0".to_string(),
             sha: "headsha".to_string(),
             repo: stub_repo("acme", "app"),
         },
@@ -673,7 +760,7 @@ async fn test_process_set_version_accepted_when_greater_than_current_released_ta
     let github = TestGitHub::new()
         .with_tags(vec![make_semver_tag("v1.0.0")])
         .await
-        .with_pr(make_open_pr(42, "deadbeef"))
+        .with_pr(make_release_pr(42, "deadbeef"))
         .await;
 
     let processor = CommentCommandProcessor::new(default_config(true), &github);
@@ -695,7 +782,7 @@ async fn test_process_set_version_accepted_when_no_existing_tags_first_release_p
     let github = TestGitHub::new()
         .with_tags(vec![])
         .await
-        .with_pr(make_open_pr(42, "deadbeef"))
+        .with_pr(make_release_pr(42, "deadbeef"))
         .await;
 
     let processor = CommentCommandProcessor::new(default_config(true), &github);
@@ -716,7 +803,7 @@ async fn test_process_set_version_accepted_when_no_tags_and_version_is_zero_zero
     let github = TestGitHub::new()
         .with_tags(vec![])
         .await
-        .with_pr(make_open_pr(42, "deadbeef"))
+        .with_pr(make_release_pr(42, "deadbeef"))
         .await;
 
     let processor = CommentCommandProcessor::new(default_config(true), &github);
@@ -732,6 +819,8 @@ async fn test_process_set_version_rejected_when_equal_to_current_tag_posts_rejec
     // Pinned == current released → rejected.
     let github = TestGitHub::new()
         .with_tags(vec![make_semver_tag("v1.0.0")])
+        .await
+        .with_pr(make_release_pr(42, "deadbeef"))
         .await;
 
     let processor = CommentCommandProcessor::new(default_config(true), &github);
@@ -754,6 +843,8 @@ async fn test_process_set_version_rejected_when_lower_than_current_tag_posts_rej
     // Pinned < current released → rejected.
     let github = TestGitHub::new()
         .with_tags(vec![make_semver_tag("v2.0.0")])
+        .await
+        .with_pr(make_release_pr(42, "deadbeef"))
         .await;
 
     let processor = CommentCommandProcessor::new(default_config(true), &github);
@@ -770,7 +861,11 @@ async fn test_process_set_version_rejected_when_lower_than_current_tag_posts_rej
 #[tokio::test]
 async fn test_process_set_version_zero_zero_zero_rejected_when_no_tags() {
     // 0.0.0 is below the minimum (0.0.1) even with no existing tags.
-    let github = TestGitHub::new().with_tags(vec![]).await;
+    let github = TestGitHub::new()
+        .with_tags(vec![])
+        .await
+        .with_pr(make_release_pr(42, "deadbeef"))
+        .await;
 
     let processor = CommentCommandProcessor::new(default_config(true), &github);
     let event = test_event(42, "!set-version 0.0.0", "open");
@@ -784,9 +879,9 @@ async fn test_process_set_version_zero_zero_zero_rejected_when_no_tags() {
 }
 
 #[tokio::test]
-async fn test_process_release_bump_posts_informational_comment_and_acknowledges() {
-    // !release bump commands are a stub until the design is completed.
-    // The user should receive an informational comment and the event is acknowledged (Ok).
+async fn test_process_release_bump_applies_label_and_posts_confirmation() {
+    // !release major must apply rr:override-major to the feature PR and post
+    // a confirmation comment. No release PR should be created at this point.
     let github = TestGitHub::new();
     let processor = CommentCommandProcessor::new(default_config(true), &github);
 
@@ -794,20 +889,39 @@ async fn test_process_release_bump_posts_informational_comment_and_acknowledges(
     let result = processor.process(&event).await;
 
     assert!(result.is_ok(), "expected Ok, got: {result:?}");
+    // A confirmation comment should be posted on the feature PR.
     let comments = github.issue_comments().await;
-    assert_eq!(comments.len(), 1, "expected one informational comment");
+    assert_eq!(comments.len(), 1, "expected one confirmation comment");
     assert_eq!(comments[0].0, 42);
     assert!(
-        comments[0].1.contains("not yet"),
-        "comment should mention feature is not yet available: {}",
+        comments[0].1.contains("override recorded"),
+        "comment should confirm the override, got: {}",
         comments[0].1
+    );
+    assert!(
+        comments[0].1.contains("major"),
+        "comment should mention the bump kind, got: {}",
+        comments[0].1
+    );
+    // Label must be applied to the feature PR.
+    let labels = github
+        .state
+        .lock()
+        .await
+        .pr_labels
+        .get(&42)
+        .cloned()
+        .unwrap_or_default();
+    assert!(
+        labels.iter().any(|l| l.name == "rr:override-major"),
+        "expected rr:override-major label, got: {labels:?}"
     );
     // No release PR should have been created.
     assert!(github.created_prs().await.is_empty());
 }
 
 #[tokio::test]
-async fn test_process_release_bump_minor_also_posts_informational_comment() {
+async fn test_process_release_bump_minor_applies_label_and_posts_confirmation() {
     let github = TestGitHub::new();
     let processor = CommentCommandProcessor::new(default_config(true), &github);
 
@@ -817,7 +931,17 @@ async fn test_process_release_bump_minor_also_posts_informational_comment() {
     assert!(result.is_ok());
     let comments = github.issue_comments().await;
     assert_eq!(comments.len(), 1);
-    assert!(comments[0].1.contains("not yet"));
+    assert!(comments[0].1.contains("override recorded"));
+    assert!(comments[0].1.contains("minor"));
+    let labels = github
+        .state
+        .lock()
+        .await
+        .pr_labels
+        .get(&42)
+        .cloned()
+        .unwrap_or_default();
+    assert!(labels.iter().any(|l| l.name == "rr:override-minor"));
 }
 
 #[tokio::test]
@@ -829,7 +953,7 @@ async fn test_process_repeated_calls_both_succeed() {
     let github = TestGitHub::new()
         .with_tags(vec![make_semver_tag("v1.0.0")])
         .await
-        .with_pr(make_open_pr(42, "deadbeef"))
+        .with_pr(make_release_pr(42, "deadbeef"))
         .await;
 
     let processor = CommentCommandProcessor::new(default_config(true), &github);
@@ -918,4 +1042,80 @@ async fn test_process_release_bare_no_argument_is_noop() {
     assert!(result.is_ok());
     assert!(github.issue_comments().await.is_empty());
     assert!(github.created_prs().await.is_empty());
+}
+
+#[tokio::test]
+async fn test_process_release_bump_replaces_existing_override_label() {
+    // BA-25: posting !release minor on a PR that already has rr:override-major
+    // should replace the label and mention the replacement in the comment.
+    let existing_label = Label {
+        id: 1,
+        name: "rr:override-major".to_string(),
+        color: "ededed".to_string(),
+        description: None,
+    };
+    let github = TestGitHub::new()
+        .with_pr_labels(55, vec![existing_label])
+        .await;
+    let processor = CommentCommandProcessor::new(default_config(true), &github);
+
+    let event = test_event(55, "!release minor", "open");
+    let result = processor.process(&event).await;
+
+    assert!(result.is_ok(), "expected Ok, got: {result:?}");
+    // rr:override-minor must be present; rr:override-major must be absent.
+    let labels = github
+        .state
+        .lock()
+        .await
+        .pr_labels
+        .get(&55)
+        .cloned()
+        .unwrap_or_default();
+    assert!(
+        labels.iter().any(|l| l.name == "rr:override-minor"),
+        "expected rr:override-minor after replacement, got: {labels:?}"
+    );
+    assert!(
+        !labels.iter().any(|l| l.name == "rr:override-major"),
+        "rr:override-major should have been removed, got: {labels:?}"
+    );
+    let comments = github.issue_comments().await;
+    assert_eq!(comments.len(), 1);
+    assert!(
+        comments[0].1.contains("replacing"),
+        "confirmation comment should mention replacement, got: {}",
+        comments[0].1
+    );
+}
+
+#[tokio::test]
+async fn test_process_set_version_rejected_when_on_non_release_pr_branch() {
+    // BA-26: !set-version on a feature PR (head branch does not start with
+    // "release/v") must post a scope rejection comment and not call the orchestrator.
+    let feature_pr = make_open_pr(90, "abc123"); // head branch: feat/my-feature
+    let github = TestGitHub::new()
+        .with_tags(vec![make_semver_tag("v1.0.0")])
+        .await
+        .with_pr(feature_pr)
+        .await;
+
+    let processor = CommentCommandProcessor::new(default_config(true), &github);
+    let event = test_event(90, "!set-version 2.0.0", "open");
+    let result = processor.process(&event).await;
+
+    assert!(result.is_ok(), "expected Ok, got: {result:?}");
+    let comments = github.issue_comments().await;
+    assert_eq!(comments.len(), 1, "expected one scope rejection comment");
+    assert_eq!(comments[0].0, 90);
+    assert!(
+        comments[0].1.contains("release PR"),
+        "rejection comment should mention release PR, got: {}",
+        comments[0].1
+    );
+    // Orchestrator must not have been called.
+    assert!(
+        github.created_prs().await.is_empty(),
+        "orchestrator must not be called on scope rejection"
+    );
 }

--- a/crates/core/src/comment_command_processor_tests.rs
+++ b/crates/core/src/comment_command_processor_tests.rs
@@ -1385,33 +1385,33 @@ async fn test_process_set_version_posts_noop_warning_when_existing_pr_has_higher
     assert!(github.created_prs().await.is_empty());
 }
 
-/// When `search_pull_requests` fails during changelog lookup, the fallback is
-/// an empty changelog; orchestration still proceeds and a ✅ comment is posted.
+/// When the PR body is `None` (no pre-existing changelog content), the
+/// changelog defaults to empty; orchestration still proceeds and a ✅ comment
+/// is posted.  This exercises the `pr.body.as_deref().unwrap_or("")` fallback
+/// that replaced the former `fetch_existing_release_changelog` helper.
 #[tokio::test]
-async fn test_process_set_version_proceeds_with_empty_changelog_when_search_fails() {
+async fn test_process_set_version_proceeds_with_empty_changelog_when_pr_body_is_none() {
     let github = TestGitHub::new()
         .with_tags(vec![])
         .await
-        .with_pr(make_release_pr(42, "abc123"))
-        .await
-        .with_search_error()
+        .with_pr(make_release_pr(42, "abc123")) // body: None
         .await;
 
     let processor = CommentCommandProcessor::new(default_config(true), &github);
     let event = test_event(42, "!set-version 1.0.0", "open");
     let result = processor.process(&event).await;
 
-    // Must succeed despite search failure.
+    // Must succeed even though there is no existing changelog body.
     assert!(
         result.is_ok(),
-        "expected Ok even when search fails, got: {result:?}"
+        "expected Ok when pr.body is None, got: {result:?}"
     );
     // Must still post a confirmation comment.
     let comments = github.issue_comments().await;
     assert_eq!(comments.len(), 1, "expected one confirmation comment");
     assert!(
         comments[0].1.contains('✅'),
-        "expected ✅ confirmation even after search failure, got: {}",
+        "expected ✅ confirmation, got: {}",
         comments[0].1
     );
 }
@@ -1554,9 +1554,9 @@ async fn test_process_set_version_rejected_on_release_branch_without_v_prefix() 
 
 /// When the same `!release patch` override is posted a second time on a PR
 /// that already carries `rr:override-patch`, the confirmation comment must use
-/// "replacing" wording to confirm re-application.
+/// "re-recorded" wording (not "replacing") to confirm idempotent re-application.
 #[tokio::test]
-async fn test_process_release_bump_same_override_reposted_shows_replacing_confirmation() {
+async fn test_process_release_bump_same_override_reposted_shows_rererecorded_confirmation() {
     let existing_patch_label = Label {
         id: 1,
         name: "rr:override-patch".to_string(),
@@ -1580,8 +1580,8 @@ async fn test_process_release_bump_same_override_reposted_shows_replacing_confir
         "expected one confirmation comment, got {comments:?}"
     );
     assert!(
-        comments[0].1.contains("replacing"),
-        "confirmation should mention 'replacing' when same override is reposted, got: {}",
+        comments[0].1.contains("re-recorded"),
+        "confirmation should mention 're-recorded' when same override is reposted, got: {}",
         comments[0].1
     );
     assert!(

--- a/crates/core/src/comment_command_processor_tests.rs
+++ b/crates/core/src/comment_command_processor_tests.rs
@@ -33,6 +33,8 @@ struct TestState {
     prs_by_number: HashMap<u64, PullRequest>,
     /// PRs returned by `search_pull_requests` (drives `ReleaseOrchestrator`).
     search_results: Vec<PullRequest>,
+    /// When `true`, `search_pull_requests` returns a `CoreError::Network` error.
+    search_returns_error: bool,
     /// Whether the next `create_branch` call should return `CoreError::Conflict`.
     next_create_branch_conflict: bool,
     /// Recorded `create_issue_comment` calls: `(issue_number, body)`.
@@ -81,6 +83,12 @@ impl TestGitHub {
     /// Pre-load search results for `ReleaseOrchestrator::search_for_existing_release_pr`.
     async fn with_search_results(self, prs: Vec<PullRequest>) -> Self {
         self.state.lock().await.search_results = prs;
+        self
+    }
+
+    /// Make all `search_pull_requests` calls return a network error.
+    async fn with_search_error(self) -> Self {
+        self.state.lock().await.search_returns_error = true;
         self
     }
 
@@ -276,7 +284,14 @@ impl GitHubOperations for TestGitHub {
         _repo: &str,
         _query: &str,
     ) -> CoreResult<Vec<PullRequest>> {
-        Ok(self.state.lock().await.search_results.clone())
+        let mut st = self.state.lock().await;
+        if st.search_returns_error {
+            // One-shot: fail once, then succeed on subsequent calls so the
+            // orchestrator's internal search can still work.
+            st.search_returns_error = false;
+            return Err(CoreError::network("Simulated search_pull_requests failure"));
+        }
+        Ok(st.search_results.clone())
     }
 
     async fn update_pull_request(
@@ -503,6 +518,40 @@ fn make_release_pr(number: u64, base_sha: &str) -> PullRequest {
         base: PullRequestBranch {
             ref_name: "main".to_string(),
             sha: base_sha.to_string(),
+            repo: r,
+        },
+    }
+}
+
+/// Build a release PR whose head branch is `release/v{version}` and whose body
+/// contains a `## Changelog` section with `changelog_content`.
+fn make_release_pr_with_changelog(
+    number: u64,
+    version: &str,
+    changelog_content: &str,
+) -> PullRequest {
+    let now = Utc::now();
+    let r = stub_repo("acme", "app");
+    PullRequest {
+        number,
+        title: format!("release: v{version}"),
+        body: Some(format!(
+            "## Changelog\n\n{changelog_content}\n\n## Notes\n\nAutomated."
+        )),
+        state: "open".to_string(),
+        draft: false,
+        created_at: now,
+        updated_at: now,
+        merged_at: None,
+        user: stub_user(),
+        head: PullRequestBranch {
+            ref_name: format!("release/v{version}"),
+            sha: "headsha".to_string(),
+            repo: stub_repo("acme", "app"),
+        },
+        base: PullRequestBranch {
+            ref_name: "main".to_string(),
+            sha: "basesha".to_string(),
             repo: r,
         },
     }
@@ -768,8 +817,19 @@ async fn test_process_set_version_accepted_when_greater_than_current_released_ta
     let result = processor.process(&event).await;
 
     assert!(result.is_ok());
-    // No rejection comment should have been posted.
-    assert!(github.issue_comments().await.is_empty());
+    // A ✅ confirmation comment must be posted after successful orchestration.
+    let comments = github.issue_comments().await;
+    assert_eq!(
+        comments.len(),
+        1,
+        "expected one confirmation comment, got {comments:?}"
+    );
+    assert_eq!(comments[0].0, 42);
+    assert!(
+        comments[0].1.contains('✅'),
+        "expected confirmation (✅), got: {}",
+        comments[0].1
+    );
     // The orchestrator should have created a new release PR.
     let prs = github.created_prs().await;
     assert_eq!(prs.len(), 1);
@@ -791,7 +851,14 @@ async fn test_process_set_version_accepted_when_no_existing_tags_first_release_p
     let result = processor.process(&event).await;
 
     assert!(result.is_ok());
-    assert!(github.issue_comments().await.is_empty());
+    // A ✅ confirmation comment must be posted after successful orchestration.
+    let comments = github.issue_comments().await;
+    assert_eq!(
+        comments.len(),
+        1,
+        "expected one confirmation comment, got {comments:?}"
+    );
+    assert!(comments[0].1.contains('✅'));
     let prs = github.created_prs().await;
     assert_eq!(prs.len(), 1);
     assert!(prs[0].head.starts_with("release/v1.0.0"));
@@ -811,7 +878,14 @@ async fn test_process_set_version_accepted_when_no_tags_and_version_is_zero_zero
     let result = processor.process(&event).await;
 
     assert!(result.is_ok());
-    assert!(github.issue_comments().await.is_empty());
+    // A ✅ confirmation comment must be posted after successful orchestration.
+    let comments = github.issue_comments().await;
+    assert_eq!(
+        comments.len(),
+        1,
+        "expected one confirmation comment, got {comments:?}"
+    );
+    assert!(comments[0].1.contains('✅'));
 }
 
 #[tokio::test]
@@ -1117,5 +1191,201 @@ async fn test_process_set_version_rejected_when_on_non_release_pr_branch() {
     assert!(
         github.created_prs().await.is_empty(),
         "orchestrator must not be called on scope rejection"
+    );
+}
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// !set-version changelog preservation & confirmation tests (task 9.30)
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+/// BA-28a: !set-version when no existing release PR exists → orchestrator is
+/// called with an empty changelog and a ✅ Created confirmation comment is posted.
+#[tokio::test]
+async fn test_process_set_version_posts_created_confirmation_when_no_existing_release_pr() {
+    // No tags, no existing release PRs → first-release path.
+    // search_results is empty → no existing changelog → orchestrator receives "".
+    let github = TestGitHub::new()
+        .with_tags(vec![])
+        .await
+        .with_pr(make_release_pr(42, "deadbeef"))
+        .await;
+
+    let processor = CommentCommandProcessor::new(default_config(true), &github);
+    let event = test_event(42, "!set-version 1.0.0", "open");
+    let result = processor.process(&event).await;
+
+    assert!(result.is_ok(), "expected Ok, got: {result:?}");
+    let comments = github.issue_comments().await;
+    assert_eq!(
+        comments.len(),
+        1,
+        "expected exactly one confirmation comment"
+    );
+    assert_eq!(comments[0].0, 42, "comment should be on PR 42");
+    assert!(
+        comments[0].1.contains('✅'),
+        "comment should contain ✅, got: {}",
+        comments[0].1
+    );
+    assert!(
+        comments[0].1.contains("1.0.0"),
+        "comment should mention the pinned version, got: {}",
+        comments[0].1
+    );
+    // Release PR must have been created.
+    let prs = github.created_prs().await;
+    assert_eq!(prs.len(), 1, "expected one release PR to be created");
+}
+
+/// BA-28b: !set-version when an existing release PR has the same version →
+/// real changelog is extracted and passed to the orchestrator, ✅ Updated comment.
+#[tokio::test]
+async fn test_process_set_version_preserves_existing_changelog_on_update_path() {
+    // The existing release PR already targets 2.0.0 (same as pinned version).
+    // The orchestrator will update its body and return OrchestratorResult::Updated.
+    let existing_changelog = "- feat: add widget [aabbccdd]";
+    let existing_release_pr = make_release_pr_with_changelog(100, "2.0.0", existing_changelog);
+
+    let github = TestGitHub::new()
+        .with_tags(vec![make_semver_tag("v1.0.0")])
+        .await
+        .with_pr(existing_release_pr.clone())
+        .await
+        .with_search_results(vec![existing_release_pr])
+        .await;
+
+    let processor = CommentCommandProcessor::new(default_config(true), &github);
+    // Set the pinned version to 2.0.0 — same as the existing release PR.
+    let event = test_event(100, "!set-version 2.0.0", "open");
+    let result = processor.process(&event).await;
+
+    assert!(result.is_ok(), "expected Ok, got: {result:?}");
+    let comments = github.issue_comments().await;
+    assert_eq!(comments.len(), 1, "expected one confirmation comment");
+    assert!(
+        comments[0].1.contains('✅'),
+        "expected ✅ confirmation, got: {}",
+        comments[0].1
+    );
+    assert!(
+        comments[0].1.contains("2.0.0"),
+        "comment should mention the version, got: {}",
+        comments[0].1
+    );
+    // Because an existing PR at the same version was found, orchestrate()
+    // updates it rather than creating.  Verify no new PR was created.
+    assert!(
+        github.created_prs().await.is_empty(),
+        "no new PR should be created when updating existing version"
+    );
+}
+
+/// !set-version raises the version on an existing release PR →
+/// real changelog preserved, ✅ Renamed confirmation comment posted.
+#[tokio::test]
+async fn test_process_set_version_posts_renamed_confirmation_when_version_raised() {
+    // Existing release PR is at 1.5.0; pinning to 2.0.0 will trigger a rename.
+    let existing_changelog = "- feat: feature A [11223344]";
+    let existing_release_pr = make_release_pr_with_changelog(101, "1.5.0", existing_changelog);
+
+    let github = TestGitHub::new()
+        .with_tags(vec![make_semver_tag("v1.0.0")])
+        .await
+        .with_pr(existing_release_pr.clone())
+        .await
+        .with_search_results(vec![existing_release_pr])
+        .await;
+
+    let processor = CommentCommandProcessor::new(default_config(true), &github);
+    let event = test_event(101, "!set-version 2.0.0", "open");
+    let result = processor.process(&event).await;
+
+    assert!(result.is_ok(), "expected Ok, got: {result:?}");
+    let comments = github.issue_comments().await;
+    assert_eq!(comments.len(), 1, "expected one confirmation comment");
+    assert!(
+        comments[0].1.contains('✅'),
+        "expected ✅ confirmation, got: {}",
+        comments[0].1
+    );
+    // The rename path closes the old PR and creates a new one at the higher version.
+    let prs = github.created_prs().await;
+    assert_eq!(
+        prs.len(),
+        1,
+        "expected one new release PR created for the renamed version"
+    );
+    assert!(
+        prs[0].head.starts_with("release/v2.0.0"),
+        "new PR should be at v2.0.0, got: {}",
+        prs[0].head
+    );
+}
+
+/// BA-29: !set-version below existing release PR version → orchestrator returns
+/// NoOp, a ⚠️ warning comment is posted, no PR modification occurs.
+#[tokio::test]
+async fn test_process_set_version_posts_noop_warning_when_existing_pr_has_higher_version() {
+    // Existing release PR is at 3.0.0; pinned to 2.0.0 → orchestrator NoOp.
+    let existing_release_pr =
+        make_release_pr_with_changelog(102, "3.0.0", "- feat: big thing [deadbeef]");
+
+    let github = TestGitHub::new()
+        .with_tags(vec![make_semver_tag("v1.0.0")])
+        .await
+        .with_pr(existing_release_pr.clone())
+        .await
+        .with_search_results(vec![existing_release_pr])
+        .await;
+
+    let processor = CommentCommandProcessor::new(default_config(true), &github);
+    let event = test_event(102, "!set-version 2.0.0", "open");
+    let result = processor.process(&event).await;
+
+    assert!(result.is_ok(), "expected Ok, got: {result:?}");
+    let comments = github.issue_comments().await;
+    assert_eq!(comments.len(), 1, "expected one ⚠️ comment");
+    assert!(
+        comments[0].1.contains('⚠'),
+        "expected ⚠️ warning, got: {}",
+        comments[0].1
+    );
+    assert!(
+        comments[0].1.contains("2.0.0"),
+        "comment should mention the attempted version, got: {}",
+        comments[0].1
+    );
+    // No new PR should have been created.
+    assert!(github.created_prs().await.is_empty());
+}
+
+/// When `search_pull_requests` fails during changelog lookup, the fallback is
+/// an empty changelog; orchestration still proceeds and a ✅ comment is posted.
+#[tokio::test]
+async fn test_process_set_version_proceeds_with_empty_changelog_when_search_fails() {
+    let github = TestGitHub::new()
+        .with_tags(vec![])
+        .await
+        .with_pr(make_release_pr(42, "abc123"))
+        .await
+        .with_search_error()
+        .await;
+
+    let processor = CommentCommandProcessor::new(default_config(true), &github);
+    let event = test_event(42, "!set-version 1.0.0", "open");
+    let result = processor.process(&event).await;
+
+    // Must succeed despite search failure.
+    assert!(
+        result.is_ok(),
+        "expected Ok even when search fails, got: {result:?}"
+    );
+    // Must still post a confirmation comment.
+    let comments = github.issue_comments().await;
+    assert_eq!(comments.len(), 1, "expected one confirmation comment");
+    assert!(
+        comments[0].1.contains('✅'),
+        "expected ✅ confirmation even after search failure, got: {}",
+        comments[0].1
     );
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -815,16 +815,7 @@ where
             let labels = if merged_pr_number > 0 {
                 self.github_operations
                     .list_pr_labels(owner, repo, merged_pr_number)
-                    .await
-                    .unwrap_or_else(|e| {
-                        tracing::warn!(
-                            error = %e,
-                            merged_pr = merged_pr_number,
-                            correlation_id = %correlation_id,
-                            "Failed to read override labels from merged PR; proceeding without floor"
-                        );
-                        vec![]
-                    })
+                    .await?
             } else {
                 vec![]
             };

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -817,6 +817,11 @@ where
                     .list_pr_labels(owner, repo, merged_pr_number)
                     .await?
             } else {
+                tracing::warn!(
+                    correlation_id = %correlation_id,
+                    "Merged PR payload is missing pull_request.number; \
+                     bump-override floor will not be applied for this release"
+                );
                 vec![]
             };
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -919,6 +919,31 @@ where
                 }
             }
 
+            // ── Consume override label: remove from the now-merged feature PR ──
+            //
+            // Remove all rr:override-* labels from the feature PR that was just
+            // merged. This is idempotent (remove_label treats 404 as Ok) and
+            // runs unconditionally to clean up any label that may have been
+            // applied by a previous `!release` command on this PR.
+            if floor_kind.is_some() {
+                use comment_command_processor::ALL_OVERRIDE_LABELS;
+                for &label in ALL_OVERRIDE_LABELS {
+                    if let Err(e) = self
+                        .github_operations
+                        .remove_label(owner, repo, merged_pr_number, label)
+                        .await
+                    {
+                        tracing::warn!(
+                            error = %e,
+                            merged_pr = merged_pr_number,
+                            label,
+                            correlation_id = %correlation_id,
+                            "Failed to remove consumed override label; continuing"
+                        );
+                    }
+                }
+            }
+
             Ok(orch_result)
         }
     }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -290,7 +290,7 @@ where
 
         let config = CommentCommandConfig {
             orchestrator_config: release_orchestrator::OrchestratorConfig {
-                branch_prefix: "release".to_string(),
+                branch_prefix: release_orchestrator::OrchestratorConfig::default().branch_prefix,
                 title_template: repo_config.release_pr.title_template.clone(),
                 changelog_header: "## Changelog".to_string(),
             },
@@ -693,34 +693,234 @@ where
 
         // Build orchestrator config honouring the repository PR title template.
         let orch_config = release_orchestrator::OrchestratorConfig {
-            branch_prefix: "release".to_string(),
+            branch_prefix: release_orchestrator::OrchestratorConfig::default().branch_prefix,
             title_template: repo_config.release_pr.title_template.clone(),
             changelog_header: "## Changelog".to_string(),
         };
 
+        // Determine whether the merged PR is itself a release PR by checking
+        // whether its head branch starts with the configured release prefix + "/v".
+        let merged_pr_head_ref = event
+            .payload
+            .get("pull_request")
+            .and_then(|pr| pr.get("head"))
+            .and_then(|h| h.get("ref"))
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .to_string();
+        let release_head_prefix = format!("{}/v", orch_config.branch_prefix);
+        let is_release_pr = merged_pr_head_ref.starts_with(&release_head_prefix);
+
+        // Resolve the merged PR number (needed to read override labels on the
+        // feature-PR path, and logged for diagnostics on the release-PR path).
+        let merged_pr_number: u64 = event
+            .payload
+            .get("pull_request")
+            .and_then(|pr| pr.get("number"))
+            .and_then(serde_json::Value::as_u64)
+            .unwrap_or(0);
+
         let orchestrator =
             release_orchestrator::ReleaseOrchestrator::new(orch_config, &self.github_operations);
 
-        tracing::info!(
-            owner = %owner,
-            repo = %repo,
-            version = %calc_result.next_version,
-            base_branch = %base_branch,
-            correlation_id = %correlation_id,
-            "Orchestrating release PR for merged pull request"
-        );
+        if is_release_pr {
+            // ── Release PR path ─────────────────────────────────────────────
+            tracing::info!(
+                owner = %owner,
+                repo = %repo,
+                version = %calc_result.next_version,
+                base_branch = %base_branch,
+                correlation_id = %correlation_id,
+                "Orchestrating for merged release PR"
+            );
 
-        orchestrator
-            .orchestrate(
-                owner,
-                repo,
-                &calc_result.next_version,
-                &changelog,
-                &base_branch,
-                &base_sha,
-                correlation_id,
-            )
-            .await
+            let orch_result = orchestrator
+                .orchestrate(
+                    owner,
+                    repo,
+                    &calc_result.next_version,
+                    &changelog,
+                    &base_branch,
+                    &base_sha,
+                    correlation_id,
+                )
+                .await?;
+
+            // After a release is published, clear stale rr:override-* labels
+            // from any open feature PRs. These overrides were scoped to this
+            // release cycle; contributors must re-post !release if still needed.
+            use comment_command_processor::ALL_OVERRIDE_LABELS;
+            for &label_name in ALL_OVERRIDE_LABELS {
+                let query = format!("is:open label:{label_name}");
+                match self
+                    .github_operations
+                    .search_pull_requests(owner, repo, &query)
+                    .await
+                {
+                    Ok(stale_prs) => {
+                        for stale_pr in stale_prs {
+                            if let Err(e) = self
+                                .github_operations
+                                .remove_label(owner, repo, stale_pr.number, label_name)
+                                .await
+                            {
+                                tracing::warn!(
+                                    error = %e,
+                                    pr = stale_pr.number,
+                                    label = label_name,
+                                    correlation_id = %correlation_id,
+                                    "Failed to remove stale override label; continuing"
+                                );
+                            }
+                            let kind_str = label_name
+                                .strip_prefix("rr:override-")
+                                .unwrap_or(label_name);
+                            let cleanup_body = format!(
+                                "ℹ️ **Release Regent**: The `!release {kind_str}` override on \
+                                 this PR has been cleared because a new release was published \
+                                 before this PR merged. If the work in this PR still warrants \
+                                 a minimum bump for the next release, please re-post your \
+                                 `!release` command."
+                            );
+                            if let Err(e) = self
+                                .github_operations
+                                .create_issue_comment(owner, repo, stale_pr.number, &cleanup_body)
+                                .await
+                            {
+                                tracing::warn!(
+                                    error = %e,
+                                    pr = stale_pr.number,
+                                    correlation_id = %correlation_id,
+                                    "Failed to post stale-override cleanup comment; continuing"
+                                );
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            error = %e,
+                            label = label_name,
+                            correlation_id = %correlation_id,
+                            "Failed to search for PRs with stale override label; continuing"
+                        );
+                    }
+                }
+            }
+
+            Ok(orch_result)
+        } else {
+            // ── Feature PR path ─────────────────────────────────────────────
+            // Read any rr:override-* label from the merged PR and apply it as
+            // a minimum-bump floor before calling the orchestrator.
+            let labels = if merged_pr_number > 0 {
+                self.github_operations
+                    .list_pr_labels(owner, repo, merged_pr_number)
+                    .await
+                    .unwrap_or_else(|e| {
+                        tracing::warn!(
+                            error = %e,
+                            merged_pr = merged_pr_number,
+                            correlation_id = %correlation_id,
+                            "Failed to read override labels from merged PR; proceeding without floor"
+                        );
+                        vec![]
+                    })
+            } else {
+                vec![]
+            };
+
+            use comment_command_processor::{
+                OVERRIDE_LABEL_MAJOR, OVERRIDE_LABEL_MINOR, OVERRIDE_LABEL_PATCH,
+            };
+            use versioning::BumpKind;
+            let floor_kind: Option<BumpKind> = labels.iter().find_map(|l| match l.name.as_str() {
+                OVERRIDE_LABEL_MAJOR => Some(BumpKind::Major),
+                OVERRIDE_LABEL_MINOR => Some(BumpKind::Minor),
+                OVERRIDE_LABEL_PATCH => Some(BumpKind::Patch),
+                _ => None,
+            });
+
+            let effective_version =
+                if let (Some(ref floor), Some(ref current)) = (&floor_kind, &current_version) {
+                    versioning::apply_bump_floor(current, &calc_result.next_version, floor.clone())
+                } else {
+                    calc_result.next_version.clone()
+                };
+
+            tracing::debug!(
+                owner = %owner,
+                repo = %repo,
+                calculated = %calc_result.next_version,
+                effective = %effective_version,
+                floor = ?floor_kind,
+                correlation_id = %correlation_id,
+                "Resolved effective release version after bump-floor check"
+            );
+
+            tracing::info!(
+                owner = %owner,
+                repo = %repo,
+                version = %effective_version,
+                base_branch = %base_branch,
+                correlation_id = %correlation_id,
+                "Orchestrating release PR for merged pull request"
+            );
+
+            let orch_result = orchestrator
+                .orchestrate(
+                    owner,
+                    repo,
+                    &effective_version,
+                    &changelog,
+                    &base_branch,
+                    &base_sha,
+                    correlation_id,
+                )
+                .await?;
+
+            // Post an audit comment on the release PR when the floor was applied.
+            if effective_version != calc_result.next_version {
+                let kind_str = match floor_kind
+                    .as_ref()
+                    .expect("floor_kind is Some when versions differ")
+                {
+                    BumpKind::Major => "major",
+                    BumpKind::Minor => "minor",
+                    BumpKind::Patch => "patch",
+                };
+                let release_pr_number = match &orch_result {
+                    release_orchestrator::OrchestratorResult::Created { pr, .. } => Some(pr.number),
+                    release_orchestrator::OrchestratorResult::Updated { pr } => Some(pr.number),
+                    release_orchestrator::OrchestratorResult::Renamed { pr } => Some(pr.number),
+                    release_orchestrator::OrchestratorResult::NoOp { pr } => Some(pr.number),
+                };
+                if let Some(release_pr) = release_pr_number {
+                    let audit_body = format!(
+                        "🔼 **Release Regent**: Version floor applied from `!release {kind_str}` \
+                         override on PR #{merged_pr_number}. The calculated version was \
+                         `{calc}` but was raised to `{eff}` to satisfy the requested \
+                         minimum {kind_str} bump.",
+                        calc = calc_result.next_version,
+                        eff = effective_version,
+                    );
+                    if let Err(e) = self
+                        .github_operations
+                        .create_issue_comment(owner, repo, release_pr, &audit_body)
+                        .await
+                    {
+                        tracing::warn!(
+                            error = %e,
+                            release_pr,
+                            merged_pr = merged_pr_number,
+                            correlation_id = %correlation_id,
+                            "Failed to post bump-floor audit comment; continuing"
+                        );
+                    }
+                }
+            }
+
+            Ok(orch_result)
+        }
     }
 }
 

--- a/crates/core/src/lib_tests.rs
+++ b/crates/core/src/lib_tests.rs
@@ -1358,6 +1358,15 @@ async fn test_handle_merged_feature_pr_with_override_major_label_applies_floor()
         "audit comment should mention effective version 2.0.0, got: {}",
         audit.1
     );
+
+    // The consumed override label must be removed from the merged feature PR.
+    let removed = github.removed_labels.lock().await;
+    assert!(
+        removed
+            .iter()
+            .any(|(pr, label)| *pr == 7 && label == "rr:override-major"),
+        "expected rr:override-major to be removed from merged feature PR #7, got: {removed:?}"
+    );
 }
 
 /// When the merged feature PR has no override labels, the calculated version
@@ -1505,5 +1514,164 @@ async fn test_handle_merged_release_pr_clears_stale_override_labels_from_open_pr
             .iter()
             .any(|(_, body)| body.contains("cleared because a new release was published")),
         "cleanup comment should explain why the label was cleared"
+    );
+}
+
+/// When the merged feature PR carries an `rr:override-minor` label, the
+/// calculated patch version is raised to the next minor version.
+#[tokio::test]
+async fn test_handle_merged_feature_pr_with_override_minor_label_applies_floor() {
+    // Current released tag: v1.2.3  →  current_version = Some(1.2.3)
+    // Version calculator produces 1.2.4 (patch bump).
+    // Floor = Minor  →  apply_bump_floor(1.2.3, 1.2.4, Minor) = 1.3.0
+    let tag = GitTag {
+        name: "v1.2.3".to_string(),
+        target_sha: "a".repeat(40),
+        tag_type: GitTagType::Lightweight,
+        message: None,
+        tagger: None,
+        created_at: None,
+    };
+    let override_label = Label {
+        id: 2,
+        name: "rr:override-minor".to_string(),
+        color: "0075ca".to_string(),
+        description: None,
+    };
+    let github = TestGitHubForLib::new_empty()
+        .with_tags(vec![tag])
+        .with_pr_labels(10, vec![override_label]);
+
+    let config = TestConfigForLib;
+    let version_calc = TestVersionCalcForLib::returning("1.2.4");
+
+    let processor = ReleaseRegentProcessor::new(github.clone(), config, version_calc);
+
+    let event = ProcessingEvent {
+        event_id: "evt-minor-floor".into(),
+        correlation_id: "corr-minor-floor".into(),
+        event_type: EventType::PullRequestMerged,
+        repository: RepositoryInfo {
+            owner: "acme".into(),
+            name: "app".into(),
+            default_branch: "main".into(),
+        },
+        payload: serde_json::json!({
+            "pull_request": {
+                "head": { "ref": "feat/minor-feature" },
+                "base": { "ref": "main" },
+                "number": 10,
+                "merge_commit_sha": "e".repeat(40)
+            }
+        }),
+        received_at: Utc::now(),
+        source: EventSourceKind::Webhook,
+    };
+
+    let result = processor.handle_merged_pull_request(&event).await.unwrap();
+
+    // Release PR must be at 1.3.0 (minor floor applied), not 1.2.4.
+    match &result {
+        release_orchestrator::OrchestratorResult::Created { branch_name, .. } => {
+            assert!(
+                branch_name.contains("1.3.0"),
+                "branch should reference 1.3.0 (minor floor applied), got: {branch_name}"
+            );
+        }
+        other => panic!("expected Created, got {other:?}"),
+    }
+
+    // The consumed rr:override-minor label must be removed from PR #10 (task 9.20.5).
+    let removed = github.removed_labels.lock().await;
+    assert!(
+        removed
+            .iter()
+            .any(|(pr, label)| *pr == 10 && label == "rr:override-minor"),
+        "expected rr:override-minor to be removed from merged PR #10, got: {removed:?}"
+    );
+}
+
+/// When the merged feature PR has `rr:override-patch` and the calculated version
+/// is already a minor bump (which exceeds the patch floor), the calculated version
+/// is used unchanged and the label is still removed.
+#[tokio::test]
+async fn test_handle_merged_feature_pr_with_patch_floor_no_effect_when_calculated_exceeds() {
+    // Current released tag: v1.2.3  →  current_version = Some(1.2.3)
+    // Version calculator produces 1.3.0 (minor bump).
+    // Floor = Patch  →  floor_version = 1.2.4, which is LESS than 1.3.0.
+    // Effective = max(1.3.0, 1.2.4) = 1.3.0 (unchanged).
+    let tag = GitTag {
+        name: "v1.2.3".to_string(),
+        target_sha: "a".repeat(40),
+        tag_type: GitTagType::Lightweight,
+        message: None,
+        tagger: None,
+        created_at: None,
+    };
+    let override_label = Label {
+        id: 3,
+        name: "rr:override-patch".to_string(),
+        color: "e4e669".to_string(),
+        description: None,
+    };
+    let github = TestGitHubForLib::new_empty()
+        .with_tags(vec![tag])
+        .with_pr_labels(11, vec![override_label]);
+
+    let config = TestConfigForLib;
+    let version_calc = TestVersionCalcForLib::returning("1.3.0");
+
+    let processor = ReleaseRegentProcessor::new(github.clone(), config, version_calc);
+
+    let event = ProcessingEvent {
+        event_id: "evt-patch-floor".into(),
+        correlation_id: "corr-patch-floor".into(),
+        event_type: EventType::PullRequestMerged,
+        repository: RepositoryInfo {
+            owner: "acme".into(),
+            name: "app".into(),
+            default_branch: "main".into(),
+        },
+        payload: serde_json::json!({
+            "pull_request": {
+                "head": { "ref": "feat/patch-feature" },
+                "base": { "ref": "main" },
+                "number": 11,
+                "merge_commit_sha": "f".repeat(40)
+            }
+        }),
+        received_at: Utc::now(),
+        source: EventSourceKind::Webhook,
+    };
+
+    let result = processor.handle_merged_pull_request(&event).await.unwrap();
+
+    // Release PR must be at 1.3.0 (patch floor has no effect on a minor bump).
+    match &result {
+        release_orchestrator::OrchestratorResult::Created { branch_name, .. } => {
+            assert!(
+                branch_name.contains("1.3.0"),
+                "branch should remain 1.3.0 (patch floor has no effect), got: {branch_name}"
+            );
+        }
+        other => panic!("expected Created, got {other:?}"),
+    }
+
+    // No audit comment should be posted because the floor had no effect.
+    let comments = github.issue_comments.lock().await;
+    assert!(
+        comments
+            .iter()
+            .all(|(_, body)| !body.contains("Version floor applied")),
+        "no audit comment should be posted when floor has no effect"
+    );
+
+    // Even though the floor had no effect, the label must still be removed (task 9.20.5).
+    let removed = github.removed_labels.lock().await;
+    assert!(
+        removed
+            .iter()
+            .any(|(pr, label)| *pr == 11 && label == "rr:override-patch"),
+        "expected rr:override-patch to be removed from merged PR #11, got: {removed:?}"
     );
 }

--- a/crates/core/src/lib_tests.rs
+++ b/crates/core/src/lib_tests.rs
@@ -559,6 +559,17 @@ struct TestGitHubForLib {
     removed_labels: Arc<Mutex<Vec<(u64, String)>>>,
     /// Records every `(issue_number, body)` passed to `create_issue_comment`.
     issue_comments: Arc<Mutex<Vec<(u64, String)>>>,
+    /// When set, `search_pull_requests` returns an error if the query
+    /// contains this label name.  Other searches succeed normally.
+    fail_search_for_label: Option<String>,
+    /// When set, `remove_label` returns a network error for the specified PR number.
+    fail_remove_label_for_pr: Option<u64>,
+    /// When set, `create_issue_comment` returns a network error for the specified
+    /// PR / issue number.
+    fail_comment_for_pr: Option<u64>,
+    /// When set, `list_pr_labels` returns a `CoreError::GitHub` for the
+    /// specified PR / issue number.
+    fail_list_labels_for_pr: Option<u64>,
 }
 
 impl TestGitHubForLib {
@@ -572,6 +583,10 @@ impl TestGitHubForLib {
             create_branch_calls: Arc::new(Mutex::new(vec![])),
             removed_labels: Arc::new(Mutex::new(vec![])),
             issue_comments: Arc::new(Mutex::new(vec![])),
+            fail_search_for_label: None,
+            fail_remove_label_for_pr: None,
+            fail_comment_for_pr: None,
+            fail_list_labels_for_pr: None,
         }
     }
 
@@ -587,6 +602,33 @@ impl TestGitHubForLib {
 
     fn with_search_results(mut self, prs: Vec<PullRequest>) -> Self {
         self.search_results = prs;
+        self
+    }
+
+    /// Make `search_pull_requests` return an error when the query contains
+    /// the specified label name.  Other searches succeed normally.
+    fn with_fail_search_for_label(mut self, label: impl Into<String>) -> Self {
+        self.fail_search_for_label = Some(label.into());
+        self
+    }
+
+    /// Make `remove_label` return a network error for the specified PR number.
+    fn with_fail_remove_label_for_pr(mut self, pr_number: u64) -> Self {
+        self.fail_remove_label_for_pr = Some(pr_number);
+        self
+    }
+
+    /// Make `create_issue_comment` return a network error for the specified PR
+    /// / issue number.
+    fn with_fail_comment_for_pr(mut self, pr_number: u64) -> Self {
+        self.fail_comment_for_pr = Some(pr_number);
+        self
+    }
+
+    /// Make `list_pr_labels` return a `CoreError::GitHub` for the specified PR
+    /// / issue number.
+    fn with_fail_list_labels_for_pr(mut self, pr_number: u64) -> Self {
+        self.fail_list_labels_for_pr = Some(pr_number);
         self
     }
 }
@@ -745,8 +787,15 @@ impl GitHubOperations for TestGitHubForLib {
         &self,
         _owner: &str,
         _repo: &str,
-        _query: &str,
+        query: &str,
     ) -> CoreResult<Vec<PullRequest>> {
+        if let Some(ref failing_label) = self.fail_search_for_label {
+            if query.contains(failing_label.as_str()) {
+                return Err(CoreError::network(format!(
+                    "Simulated search_pull_requests failure for label {failing_label}"
+                )));
+            }
+        }
         Ok(self.search_results.clone())
     }
 
@@ -801,6 +850,11 @@ impl GitHubOperations for TestGitHubForLib {
         issue_number: u64,
         body: &str,
     ) -> CoreResult<()> {
+        if self.fail_comment_for_pr == Some(issue_number) {
+            return Err(CoreError::network(format!(
+                "Simulated create_issue_comment failure for PR #{issue_number}"
+            )));
+        }
         self.issue_comments
             .lock()
             .await
@@ -834,6 +888,11 @@ impl GitHubOperations for TestGitHubForLib {
         issue_number: u64,
         label_name: &str,
     ) -> CoreResult<()> {
+        if self.fail_remove_label_for_pr == Some(issue_number) {
+            return Err(CoreError::network(format!(
+                "Simulated remove_label failure for PR #{issue_number}"
+            )));
+        }
         self.removed_labels
             .lock()
             .await
@@ -847,6 +906,12 @@ impl GitHubOperations for TestGitHubForLib {
         _repo: &str,
         issue_number: u64,
     ) -> CoreResult<Vec<crate::traits::github_operations::Label>> {
+        if self.fail_list_labels_for_pr == Some(issue_number) {
+            return Err(CoreError::github(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                format!("Simulated list_pr_labels failure for PR #{issue_number}"),
+            )));
+        }
         Ok(self
             .pr_labels
             .get(&issue_number)
@@ -1673,5 +1738,251 @@ async fn test_handle_merged_feature_pr_with_patch_floor_no_effect_when_calculate
             .iter()
             .any(|(pr, label)| *pr == 11 && label == "rr:override-patch"),
         "expected rr:override-patch to be removed from merged PR #11, got: {removed:?}"
+    );
+}
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// handle_merged_pull_request — release-PR path error tests (spec §9 Minor #5)
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+/// When `search_pull_requests` fails for one override label (e.g., `rr:override-major`),
+/// a warning is logged and the cleanup for the remaining labels still proceeds.
+/// The overall event must succeed.
+#[tokio::test]
+async fn test_handle_merged_release_pr_search_failure_for_one_label_continues() {
+    // search_results contains PR #99 which will be found for override-minor and
+    // override-patch, but the search for override-major will fail.
+    let stale_pr = make_pr(99, "feat/stale-feature", "feat: stale work");
+    let github = TestGitHubForLib::new_empty()
+        .with_search_results(vec![stale_pr])
+        .with_fail_search_for_label("rr:override-major");
+
+    let config = TestConfigForLib;
+    let version_calc = TestVersionCalcForLib::returning("1.1.0");
+    let processor = ReleaseRegentProcessor::new(github.clone(), config, version_calc);
+
+    let event = ProcessingEvent {
+        event_id: "evt-search-fail".into(),
+        correlation_id: "corr-search-fail".into(),
+        event_type: EventType::PullRequestMerged,
+        repository: RepositoryInfo {
+            owner: "acme".into(),
+            name: "app".into(),
+            default_branch: "main".into(),
+        },
+        payload: serde_json::json!({
+            "pull_request": {
+                "head": { "ref": "release/v1.1.0" },
+                "base": { "ref": "main" },
+                "number": 100,
+                "merge_commit_sha": "d".repeat(40)
+            }
+        }),
+        received_at: Utc::now(),
+        source: EventSourceKind::Webhook,
+    };
+
+    // Event must succeed despite the partial search failure.
+    let result = processor.handle_merged_pull_request(&event).await;
+    assert!(
+        result.is_ok(),
+        "expected Ok when one search fails, got: {result:?}"
+    );
+
+    // override-minor and override-patch searches succeeded → PR #99 was processed
+    // for at least 2 labels.  override-major search failed → no remove for that label.
+    let removed = github.removed_labels.lock().await;
+    assert!(
+        removed.len() >= 2,
+        "expected at least 2 label removals (minor + patch), got: {removed:?}"
+    );
+    let has_major_removal = removed
+        .iter()
+        .any(|(_, label)| label == "rr:override-major");
+    assert!(
+        !has_major_removal,
+        "should NOT have removed override-major (search failed), got: {removed:?}"
+    );
+}
+
+/// When `remove_label` fails for one PR, a warning is logged and the cleanup
+/// comment for that PR is still attempted.  The overall event must succeed.
+#[tokio::test]
+async fn test_handle_merged_release_pr_remove_label_failure_still_posts_cleanup_comment() {
+    let stale_pr = make_pr(99, "feat/stale-feature", "feat: stale work");
+    let github = TestGitHubForLib::new_empty()
+        .with_search_results(vec![stale_pr])
+        .with_fail_remove_label_for_pr(99); // remove_label on PR #99 will fail
+
+    let config = TestConfigForLib;
+    let version_calc = TestVersionCalcForLib::returning("1.1.0");
+    let processor = ReleaseRegentProcessor::new(github.clone(), config, version_calc);
+
+    let event = ProcessingEvent {
+        event_id: "evt-remove-fail".into(),
+        correlation_id: "corr-remove-fail".into(),
+        event_type: EventType::PullRequestMerged,
+        repository: RepositoryInfo {
+            owner: "acme".into(),
+            name: "app".into(),
+            default_branch: "main".into(),
+        },
+        payload: serde_json::json!({
+            "pull_request": {
+                "head": { "ref": "release/v1.1.0" },
+                "base": { "ref": "main" },
+                "number": 100,
+                "merge_commit_sha": "e".repeat(40)
+            }
+        }),
+        received_at: Utc::now(),
+        source: EventSourceKind::Webhook,
+    };
+
+    // Event must succeed despite remove_label failures.
+    let result = processor.handle_merged_pull_request(&event).await;
+    assert!(
+        result.is_ok(),
+        "expected Ok when remove_label fails, got: {result:?}"
+    );
+
+    // Cleanup comments must still be posted on PR #99 even though remove_label failed.
+    let comments = github.issue_comments.lock().await;
+    let cleanup_comments: Vec<_> = comments.iter().filter(|(pr, _)| *pr == 99).collect();
+    assert!(
+        !cleanup_comments.is_empty(),
+        "cleanup comments should still be posted even when remove_label fails, got: {comments:?}"
+    );
+}
+
+/// When posting the cleanup comment fails for a PR, a warning is logged but
+/// the cleanup loop continues and the overall event still succeeds.
+#[tokio::test]
+async fn test_handle_merged_release_pr_cleanup_comment_failure_event_still_succeeds() {
+    let stale_pr = make_pr(99, "feat/stale-feature", "feat: stale work");
+    let github = TestGitHubForLib::new_empty()
+        .with_search_results(vec![stale_pr])
+        .with_fail_comment_for_pr(99); // comment on PR #99 will fail
+
+    let config = TestConfigForLib;
+    let version_calc = TestVersionCalcForLib::returning("1.1.0");
+    let processor = ReleaseRegentProcessor::new(github.clone(), config, version_calc);
+
+    let event = ProcessingEvent {
+        event_id: "evt-comment-fail".into(),
+        correlation_id: "corr-comment-fail".into(),
+        event_type: EventType::PullRequestMerged,
+        repository: RepositoryInfo {
+            owner: "acme".into(),
+            name: "app".into(),
+            default_branch: "main".into(),
+        },
+        payload: serde_json::json!({
+            "pull_request": {
+                "head": { "ref": "release/v1.1.0" },
+                "base": { "ref": "main" },
+                "number": 100,
+                "merge_commit_sha": "g".repeat(40)
+            }
+        }),
+        received_at: Utc::now(),
+        source: EventSourceKind::Webhook,
+    };
+
+    // Event must succeed despite comment posting failure.
+    let result = processor.handle_merged_pull_request(&event).await;
+    assert!(
+        result.is_ok(),
+        "expected Ok when cleanup comment fails, got: {result:?}"
+    );
+
+    // Labels should have been removed even though the comment failed.
+    let removed = github.removed_labels.lock().await;
+    assert!(
+        !removed.is_empty(),
+        "labels should still be removed even when comment posting fails, got {removed:?}"
+    );
+}
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// handle_merged_pull_request — feature-PR path audit-comment failure (Minor #6)
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+/// When the floor IS applied but posting the audit comment to the release PR
+/// fails, a warning is logged and `Ok(orch_result)` is returned.
+#[tokio::test]
+async fn test_handle_merged_feature_pr_audit_comment_failure_returns_ok() {
+    // Current released tag: v1.0.0  →  current_version = Some(1.0.0)
+    // Version calculator produces 1.1.0 (minor bump).
+    // Floor = Major  →  effective = 2.0.0, so the floor IS applied.
+    // The release PR created by the orchestrator gets number 42 (from TestGitHubForLib).
+    let tag = GitTag {
+        name: "v1.0.0".to_string(),
+        target_sha: "a".repeat(40),
+        tag_type: GitTagType::Lightweight,
+        message: None,
+        tagger: None,
+        created_at: None,
+    };
+    let override_label = Label {
+        id: 1,
+        name: "rr:override-major".to_string(),
+        color: "ff0000".to_string(),
+        description: None,
+    };
+    // Fail create_issue_comment on the release PR (number 42
+    // as returned by create_pull_request in the double).
+    let github = TestGitHubForLib::new_empty()
+        .with_tags(vec![tag])
+        .with_pr_labels(7, vec![override_label])
+        .with_fail_comment_for_pr(42); // audit comment on release PR #42 will fail
+
+    let config = TestConfigForLib;
+    let version_calc = TestVersionCalcForLib::returning("1.1.0");
+    let processor = ReleaseRegentProcessor::new(github.clone(), config, version_calc);
+
+    let event = ProcessingEvent {
+        event_id: "evt-audit-fail".into(),
+        correlation_id: "corr-audit-fail".into(),
+        event_type: EventType::PullRequestMerged,
+        repository: RepositoryInfo {
+            owner: "acme".into(),
+            name: "app".into(),
+            default_branch: "main".into(),
+        },
+        payload: serde_json::json!({
+            "pull_request": {
+                "head": { "ref": "feat/cool-feature" },
+                "base": { "ref": "main" },
+                "number": 7,
+                "merge_commit_sha": "b".repeat(40)
+            }
+        }),
+        received_at: Utc::now(),
+        source: EventSourceKind::Webhook,
+    };
+
+    // The overall result must be Ok even though the audit comment failed.
+    let result = processor.handle_merged_pull_request(&event).await;
+    assert!(
+        result.is_ok(),
+        "expected Ok when audit comment posting fails, got: {result:?}"
+    );
+
+    // The release PR must have been created at 2.0.0 (floor applied).
+    let created = github.created_prs.lock().await;
+    assert_eq!(created.len(), 1, "expected one release PR");
+    assert!(
+        created[0].0.contains("2.0.0"),
+        "release PR branch should reference 2.0.0, got: {}",
+        created[0].0
+    );
+
+    // No audit comment should be present (it failed).
+    let comments = github.issue_comments.lock().await;
+    assert!(
+        comments
+            .iter()
+            .all(|(_, b)| !b.contains("Version floor applied")),
+        "no floor audit comment should be posted when it fails, got: {comments:?}"
     );
 }

--- a/crates/core/src/lib_tests.rs
+++ b/crates/core/src/lib_tests.rs
@@ -461,8 +461,8 @@ use traits::{
         GitUser as GitOpsUser, ListTagsOptions,
     },
     github_operations::{
-        CreatePullRequestParams, CreateReleaseParams, GitHubOperations, GitUser, PullRequest,
-        PullRequestBranch, Release, Repository, Tag, UpdateReleaseParams,
+        CreatePullRequestParams, CreateReleaseParams, GitHubOperations, GitUser, Label,
+        PullRequest, PullRequestBranch, Release, Repository, Tag, UpdateReleaseParams,
     },
     version_calculator::{
         CalculationOptions, ChangelogEntry, CommitAnalysis, ValidationRules, VersionBump,
@@ -548,8 +548,17 @@ fn make_git_commit(sha: &str) -> GitCommit {
 struct TestGitHubForLib {
     tags: Vec<GitTag>,
     existing_prs: Vec<PullRequest>,
+    /// Returned by `search_pull_requests` (independently configurable from
+    /// `existing_prs` which drives `list_pull_requests`).
+    search_results: Vec<PullRequest>,
+    /// Labels keyed by PR / issue number (drives `list_pr_labels`).
+    pr_labels: HashMap<u64, Vec<Label>>,
     created_prs: Arc<Mutex<Vec<(String, String, String)>>>, // (branch, title, body)
     create_branch_calls: Arc<Mutex<Vec<String>>>,
+    /// Records every `(issue_number, label_name)` passed to `remove_label`.
+    removed_labels: Arc<Mutex<Vec<(u64, String)>>>,
+    /// Records every `(issue_number, body)` passed to `create_issue_comment`.
+    issue_comments: Arc<Mutex<Vec<(u64, String)>>>,
 }
 
 impl TestGitHubForLib {
@@ -557,9 +566,28 @@ impl TestGitHubForLib {
         Self {
             tags: vec![],
             existing_prs: vec![],
+            search_results: vec![],
+            pr_labels: HashMap::new(),
             created_prs: Arc::new(Mutex::new(vec![])),
             create_branch_calls: Arc::new(Mutex::new(vec![])),
+            removed_labels: Arc::new(Mutex::new(vec![])),
+            issue_comments: Arc::new(Mutex::new(vec![])),
         }
+    }
+
+    fn with_tags(mut self, tags: Vec<GitTag>) -> Self {
+        self.tags = tags;
+        self
+    }
+
+    fn with_pr_labels(mut self, pr_number: u64, labels: Vec<Label>) -> Self {
+        self.pr_labels.insert(pr_number, labels);
+        self
+    }
+
+    fn with_search_results(mut self, prs: Vec<PullRequest>) -> Self {
+        self.search_results = prs;
+        self
     }
 }
 
@@ -719,7 +747,7 @@ impl GitHubOperations for TestGitHubForLib {
         _repo: &str,
         _query: &str,
     ) -> CoreResult<Vec<PullRequest>> {
-        Ok(self.existing_prs.clone())
+        Ok(self.search_results.clone())
     }
 
     async fn update_pull_request(
@@ -770,9 +798,13 @@ impl GitHubOperations for TestGitHubForLib {
         &self,
         _owner: &str,
         _repo: &str,
-        _issue_number: u64,
-        _body: &str,
+        issue_number: u64,
+        body: &str,
     ) -> CoreResult<()> {
+        self.issue_comments
+            .lock()
+            .await
+            .push((issue_number, body.to_string()));
         Ok(())
     }
 
@@ -783,6 +815,43 @@ impl GitHubOperations for TestGitHubForLib {
         _username: &str,
     ) -> CoreResult<crate::traits::github_operations::CollaboratorPermission> {
         Ok(crate::traits::github_operations::CollaboratorPermission::Write)
+    }
+
+    async fn add_labels(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _issue_number: u64,
+        _labels: &[&str],
+    ) -> CoreResult<()> {
+        Ok(())
+    }
+
+    async fn remove_label(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        issue_number: u64,
+        label_name: &str,
+    ) -> CoreResult<()> {
+        self.removed_labels
+            .lock()
+            .await
+            .push((issue_number, label_name.to_string()));
+        Ok(())
+    }
+
+    async fn list_pr_labels(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        issue_number: u64,
+    ) -> CoreResult<Vec<crate::traits::github_operations::Label>> {
+        Ok(self
+            .pr_labels
+            .get(&issue_number)
+            .cloned()
+            .unwrap_or_default())
     }
 }
 
@@ -1189,5 +1258,252 @@ async fn test_handle_merged_pr_includes_changelog_entries_in_pr_body() {
     assert!(
         body.contains(&"b".repeat(40)),
         "body missing commit sha B: {body}"
+    );
+}
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// Bump-override floor tests (task 9.20)
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+/// When the merged feature PR carries an `rr:override-major` label, the
+/// calculated version (a minor bump) is raised to a major bump and an audit
+/// comment is posted on the resulting release PR.
+#[tokio::test]
+async fn test_handle_merged_feature_pr_with_override_major_label_applies_floor() {
+    // Current released tag: v1.0.0  →  current_version = Some(1.0.0)
+    // Version calculator produces 1.1.0 (minor bump).
+    // Floor = Major  →  apply_bump_floor(1.0.0, 1.1.0, Major) = 2.0.0
+    let tag = GitTag {
+        name: "v1.0.0".to_string(),
+        target_sha: "a".repeat(40),
+        tag_type: GitTagType::Lightweight,
+        message: None,
+        tagger: None,
+        created_at: None,
+    };
+    let override_label = Label {
+        id: 1,
+        name: "rr:override-major".to_string(),
+        color: "ff0000".to_string(),
+        description: None,
+    };
+    // PR #7 is the feature PR being merged; its labels are read at orchestration time.
+    let github = TestGitHubForLib::new_empty()
+        .with_tags(vec![tag])
+        .with_pr_labels(7, vec![override_label]);
+
+    let config = TestConfigForLib;
+    let version_calc = TestVersionCalcForLib::returning("1.1.0");
+
+    let processor = ReleaseRegentProcessor::new(github.clone(), config, version_calc);
+
+    let event = ProcessingEvent {
+        event_id: "evt-floor-1".into(),
+        correlation_id: "corr-floor-1".into(),
+        event_type: EventType::PullRequestMerged,
+        repository: RepositoryInfo {
+            owner: "acme".into(),
+            name: "app".into(),
+            default_branch: "main".into(),
+        },
+        payload: serde_json::json!({
+            "pull_request": {
+                // Head branch is NOT a release branch → feature PR path.
+                "head": { "ref": "feat/cool-feature" },
+                "base": { "ref": "main" },
+                "number": 7,
+                "merge_commit_sha": "b".repeat(40)
+            }
+        }),
+        received_at: Utc::now(),
+        source: EventSourceKind::Webhook,
+    };
+
+    let result = processor.handle_merged_pull_request(&event).await.unwrap();
+
+    // Release PR must be created at 2.0.0, not 1.1.0.
+    match &result {
+        release_orchestrator::OrchestratorResult::Created { pr, branch_name } => {
+            assert!(
+                branch_name.contains("2.0.0"),
+                "branch should reference 2.0.0 (floor applied), got: {branch_name}"
+            );
+            assert!(
+                pr.head.ref_name.contains("2.0.0"),
+                "PR head branch should reference 2.0.0, got: {}",
+                pr.head.ref_name
+            );
+        }
+        other => panic!("expected Created, got {other:?}"),
+    }
+
+    // An audit comment should have been posted on the release PR explaining
+    // the floor application.
+    let comments = github.issue_comments.lock().await;
+    assert!(
+        !comments.is_empty(),
+        "expected at least one audit comment, got none"
+    );
+    let audit = comments
+        .iter()
+        .find(|(_, body)| body.contains("Version floor applied"))
+        .expect("audit comment about version floor was not posted");
+    assert!(
+        audit.1.contains("major"),
+        "audit comment should mention 'major', got: {}",
+        audit.1
+    );
+    assert!(
+        audit.1.contains("2.0.0"),
+        "audit comment should mention effective version 2.0.0, got: {}",
+        audit.1
+    );
+}
+
+/// When the merged feature PR has no override labels, the calculated version
+/// is used unchanged and no audit comment is posted.
+#[tokio::test]
+async fn test_handle_merged_feature_pr_without_override_label_uses_calculated_version() {
+    let tag = GitTag {
+        name: "v1.0.0".to_string(),
+        target_sha: "a".repeat(40),
+        tag_type: GitTagType::Lightweight,
+        message: None,
+        tagger: None,
+        created_at: None,
+    };
+    // No pr_labels configured → list_pr_labels returns [].
+    let github = TestGitHubForLib::new_empty().with_tags(vec![tag]);
+    let config = TestConfigForLib;
+    let version_calc = TestVersionCalcForLib::returning("1.1.0");
+
+    let processor = ReleaseRegentProcessor::new(github.clone(), config, version_calc);
+
+    let event = ProcessingEvent {
+        event_id: "evt-floor-2".into(),
+        correlation_id: "corr-floor-2".into(),
+        event_type: EventType::PullRequestMerged,
+        repository: RepositoryInfo {
+            owner: "acme".into(),
+            name: "app".into(),
+            default_branch: "main".into(),
+        },
+        payload: serde_json::json!({
+            "pull_request": {
+                "head": { "ref": "feat/other-feature" },
+                "base": { "ref": "main" },
+                "number": 8,
+                "merge_commit_sha": "c".repeat(40)
+            }
+        }),
+        received_at: Utc::now(),
+        source: EventSourceKind::Webhook,
+    };
+
+    let result = processor.handle_merged_pull_request(&event).await.unwrap();
+
+    // Release PR should be at 1.1.0 (the calculated version, no floor change).
+    match &result {
+        release_orchestrator::OrchestratorResult::Created { branch_name, .. } => {
+            assert!(
+                branch_name.contains("1.1.0"),
+                "branch should reference 1.1.0 (no floor), got: {branch_name}"
+            );
+        }
+        other => panic!("expected Created, got {other:?}"),
+    }
+
+    // No audit comment should have been posted (no floor was applied).
+    let comments = github.issue_comments.lock().await;
+    assert!(
+        comments
+            .iter()
+            .all(|(_, body)| !body.contains("Version floor applied")),
+        "unexpected audit comment when no floor was applied"
+    );
+}
+
+/// When a release PR is merged, stale `rr:override-*` labels on open feature
+/// PRs are removed and a cleanup comment is posted on each affected PR.
+#[tokio::test]
+async fn test_handle_merged_release_pr_clears_stale_override_labels_from_open_prs() {
+    // Feature PR #99 has a stale rr:override-major label from a previous
+    // !release command.  It will appear in search results for all three label
+    // queries (the stub returns `search_results` regardless of the query, which
+    // exercises the cleanup loop for all three label names).
+    let stale_pr = make_pr(99, "feat/stale-feature", "feat: stale work");
+
+    let github = TestGitHubForLib::new_empty().with_search_results(vec![stale_pr]);
+    let config = TestConfigForLib;
+    let version_calc = TestVersionCalcForLib::returning("1.1.0");
+
+    let processor = ReleaseRegentProcessor::new(github.clone(), config, version_calc);
+
+    let event = ProcessingEvent {
+        event_id: "evt-floor-3".into(),
+        correlation_id: "corr-floor-3".into(),
+        event_type: EventType::PullRequestMerged,
+        repository: RepositoryInfo {
+            owner: "acme".into(),
+            name: "app".into(),
+            default_branch: "main".into(),
+        },
+        payload: serde_json::json!({
+            "pull_request": {
+                // Head branch starts with "release/v" → release PR path.
+                "head": { "ref": "release/v1.0.0" },
+                "base": { "ref": "main" },
+                "number": 100,
+                "merge_commit_sha": "d".repeat(40)
+            }
+        }),
+        received_at: Utc::now(),
+        source: EventSourceKind::Webhook,
+    };
+
+    processor.handle_merged_pull_request(&event).await.unwrap();
+
+    // remove_label should have been called once per override label constant
+    // (major, minor, patch), each time on PR #99.
+    let removed = github.removed_labels.lock().await;
+    assert_eq!(
+        removed.len(),
+        3,
+        "expected 3 remove_label calls (one per override label), got: {removed:?}"
+    );
+    let removed_names: Vec<&str> = removed.iter().map(|(_, n)| n.as_str()).collect();
+    assert!(
+        removed_names.contains(&"rr:override-major"),
+        "expected rr:override-major to be removed"
+    );
+    assert!(
+        removed_names.contains(&"rr:override-minor"),
+        "expected rr:override-minor to be removed"
+    );
+    assert!(
+        removed_names.contains(&"rr:override-patch"),
+        "expected rr:override-patch to be removed"
+    );
+    assert!(
+        removed.iter().all(|(pr, _)| *pr == 99),
+        "all removals should target PR #99"
+    );
+
+    // A cleanup comment should have been posted for each removal.
+    let comments = github.issue_comments.lock().await;
+    assert_eq!(
+        comments.len(),
+        3,
+        "expected 3 cleanup comments (one per override label), got: {comments:?}"
+    );
+    assert!(
+        comments.iter().all(|(pr, _)| *pr == 99),
+        "all cleanup comments should target PR #99"
+    );
+    assert!(
+        comments
+            .iter()
+            .any(|(_, body)| body.contains("cleared because a new release was published")),
+        "cleanup comment should explain why the label was cleared"
     );
 }

--- a/crates/core/src/release_orchestrator.rs
+++ b/crates/core/src/release_orchestrator.rs
@@ -510,9 +510,12 @@ impl<'a, G: GitHubOperations> ReleaseOrchestrator<'a, G> {
 
     /// Extract the changelog section from a PR body.
     ///
-    /// Returns everything between `## Changelog` (or the configured header) and
-    /// the next `##` heading (or end of string), trimmed.
+    /// Returns everything between the configured changelog header and the next
+    /// `##` heading (or end of string), trimmed.  Delegates to the public free
+    /// function [`extract_changelog_from_pr_body`].
     fn extract_changelog_from_body<'b>(&self, body: &'b str) -> &'b str {
+        // The free function returns an owned String; we extract a static slice
+        // from `body` directly to preserve the borrow lifetime.
         let header = &self.config.changelog_header;
         let Some(after_header) = body
             .find(header.as_str())
@@ -551,6 +554,51 @@ impl<'a, G: GitHubOperations> ReleaseOrchestrator<'a, G> {
         let version_str = branch.strip_prefix(&prefix)?;
         crate::versioning::VersionCalculator::parse_version(version_str).ok()
     }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Public free function: changelog extraction
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Extract the changelog section from a PR body string.
+///
+/// Scans `body` for the first occurrence of `changelog_header` (e.g.
+/// `"## Changelog"`) and returns the text between that header and the next
+/// `##` heading — or the end of the string if no further heading exists — with
+/// surrounding whitespace trimmed.
+///
+/// Returns an empty string when `changelog_header` is not found in `body`.
+///
+/// # Parameters
+///
+/// - `body`: The full PR body (markdown string) to scan.
+/// - `changelog_header`: The exact header string used to delimit the changelog
+///   section.  Must match the value used when creating release PRs (default:
+///   `"## Changelog"`).
+///
+/// # Examples
+///
+/// ```rust
+/// use release_regent_core::release_orchestrator::extract_changelog_from_pr_body;
+///
+/// let body = "## Changelog\n\n- feat: add widget [abc123]\n\n## Notes\n\nSee wiki.";
+/// let changelog = extract_changelog_from_pr_body(body, "## Changelog");
+/// assert_eq!(changelog, "- feat: add widget [abc123]");
+///
+/// let missing = extract_changelog_from_pr_body("No header here.", "## Changelog");
+/// assert_eq!(missing, "");
+/// ```
+#[must_use]
+pub fn extract_changelog_from_pr_body(body: &str, changelog_header: &str) -> String {
+    let Some(after_header) = body
+        .find(changelog_header)
+        .map(|i| &body[i + changelog_header.len()..])
+    else {
+        return String::new();
+    };
+
+    let end = after_header.find("\n##").unwrap_or(after_header.len());
+    after_header[..end].trim().to_string()
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/crates/core/src/release_orchestrator_tests.rs
+++ b/crates/core/src/release_orchestrator_tests.rs
@@ -976,3 +976,58 @@ async fn test_update_release_pr_does_not_patch_title_when_unchanged() {
         updates[0].1
     );
 }
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// extract_changelog_from_pr_body — free-function unit tests (task 9.30.1)
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+#[test]
+fn test_extract_changelog_from_pr_body_returns_section_content() {
+    let body = "## Changelog\n\n- feat: add widget [abc123]\n\n## Notes\n\nSee wiki.";
+    let result = extract_changelog_from_pr_body(body, "## Changelog");
+    assert_eq!(result, "- feat: add widget [abc123]");
+}
+
+#[test]
+fn test_extract_changelog_from_pr_body_returns_empty_when_header_not_found() {
+    let body = "# Release v1.0.0\n\nSome description without a changelog header.";
+    let result = extract_changelog_from_pr_body(body, "## Changelog");
+    assert_eq!(result, "");
+}
+
+#[test]
+fn test_extract_changelog_from_pr_body_returns_remainder_when_no_next_heading() {
+    let body = "## Changelog\n\n- fix: patch issue [def456]\n- feat: new thing [ghi789]";
+    let result = extract_changelog_from_pr_body(body, "## Changelog");
+    assert_eq!(
+        result,
+        "- fix: patch issue [def456]\n- feat: new thing [ghi789]"
+    );
+}
+
+#[test]
+fn test_extract_changelog_from_pr_body_trims_surrounding_whitespace() {
+    let body = "## Changelog\n\n\n  - feat: widget [abc]\n\n\n";
+    let result = extract_changelog_from_pr_body(body, "## Changelog");
+    assert_eq!(result, "- feat: widget [abc]");
+}
+
+#[test]
+fn test_extract_changelog_from_pr_body_handles_custom_header() {
+    let body = "## Release Notes\n\n- feat: something\n\n## Changelog\n\n- other";
+    let result = extract_changelog_from_pr_body(body, "## Release Notes");
+    assert_eq!(result, "- feat: something");
+}
+
+#[test]
+fn test_extract_changelog_from_pr_body_empty_section_returns_empty() {
+    let body = "## Changelog\n\n## Notes\n\nSome notes.";
+    let result = extract_changelog_from_pr_body(body, "## Changelog");
+    assert_eq!(result, "");
+}
+
+#[test]
+fn test_extract_changelog_from_pr_body_empty_body_returns_empty() {
+    let result = extract_changelog_from_pr_body("", "## Changelog");
+    assert_eq!(result, "");
+}

--- a/crates/core/src/release_orchestrator_tests.rs
+++ b/crates/core/src/release_orchestrator_tests.rs
@@ -370,10 +370,36 @@ impl GitHubOperations for TestGitHub {
     ) -> CoreResult<crate::traits::github_operations::CollaboratorPermission> {
         Ok(crate::traits::github_operations::CollaboratorPermission::Write)
     }
-}
 
-// ─────────────────────────────────────────────────────────────────────────────
-// Test helpers
+    async fn add_labels(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _issue_number: u64,
+        _labels: &[&str],
+    ) -> CoreResult<()> {
+        Ok(())
+    }
+
+    async fn remove_label(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _issue_number: u64,
+        _label_name: &str,
+    ) -> CoreResult<()> {
+        Ok(())
+    }
+
+    async fn list_pr_labels(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _issue_number: u64,
+    ) -> CoreResult<Vec<crate::traits::github_operations::Label>> {
+        Ok(vec![])
+    }
+}
 // ─────────────────────────────────────────────────────────────────────────────
 
 fn stub_repo(owner: &str, repo: &str) -> Repository {

--- a/crates/core/src/traits/github_operations.rs
+++ b/crates/core/src/traits/github_operations.rs
@@ -49,6 +49,84 @@ use serde::{Deserialize, Serialize};
 /// The authentication mechanism is implementation-specific.
 #[async_trait]
 pub trait GitHubOperations: GitOperations + Send + Sync {
+    /// Add one or more labels to an issue or pull request.
+    ///
+    /// The operation is idempotent: if a label is already present on the
+    /// issue/PR it is **not** added a second time and no error is returned.
+    ///
+    /// # Parameters
+    /// - `owner`: Repository owner name
+    /// - `repo`: Repository name
+    /// - `issue_number`: Issue or pull request number
+    /// - `labels`: Slice of label name strings to add
+    ///
+    /// # Returns
+    /// `Ok(())` on success (whether or not labels were already present).
+    ///
+    /// # Errors
+    /// - `CoreError::NotFound` — the issue/PR does not exist
+    /// - `CoreError::GitHub` — the API call failed for any other reason
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// github.add_labels("owner", "repo", 42, &["rr:override-major"]).await?;
+    /// ```
+    async fn add_labels(
+        &self,
+        owner: &str,
+        repo: &str,
+        issue_number: u64,
+        labels: &[&str],
+    ) -> CoreResult<()>;
+
+    /// Create a new branch pointing to the given commit SHA
+    ///
+    /// Creates a new Git branch (ref) in the repository at the specified commit.
+    ///
+    /// # Parameters
+    /// - `owner`: Repository owner name
+    /// - `repo`: Repository name
+    /// - `branch_name`: Name of the new branch (without `refs/heads/` prefix)
+    /// - `sha`: Commit SHA the branch should initially point to
+    ///
+    /// # Returns
+    /// `Ok(())` on success
+    ///
+    /// # Errors
+    /// - `CoreError::Conflict` - A branch with this name already exists (HTTP 422)
+    /// - `CoreError::GitHub` - API communication failed
+    /// - `CoreError::InvalidInput` - Invalid branch name or SHA
+    async fn create_branch(
+        &self,
+        owner: &str,
+        repo: &str,
+        branch_name: &str,
+        sha: &str,
+    ) -> CoreResult<()>;
+
+    /// Post a comment on an issue or pull request
+    ///
+    /// # Parameters
+    /// - `owner`: Repository owner name
+    /// - `repo`: Repository name
+    /// - `issue_number`: Issue or pull request number to comment on
+    /// - `body`: Comment body (Markdown supported)
+    ///
+    /// # Returns
+    /// `Ok(())` on success
+    ///
+    /// # Errors
+    /// - `CoreError::NotFound` - Issue or PR does not exist
+    /// - `CoreError::GitHub` - API communication failed
+    async fn create_issue_comment(
+        &self,
+        owner: &str,
+        repo: &str,
+        issue_number: u64,
+        body: &str,
+    ) -> CoreResult<()>;
+
     /// Create a new pull request
     ///
     /// # Parameters
@@ -118,6 +196,47 @@ pub trait GitHubOperations: GitOperations + Send + Sync {
         tagger: Option<GitUser>,
     ) -> CoreResult<Tag>;
 
+    /// Delete a branch
+    ///
+    /// Removes the named branch (ref) from the repository. This is a destructive
+    /// operation; the commits remain accessible through other refs or by SHA.
+    ///
+    /// # Parameters
+    /// - `owner`: Repository owner name
+    /// - `repo`: Repository name
+    /// - `branch_name`: Name of the branch to delete (without `refs/heads/` prefix)
+    ///
+    /// # Returns
+    /// `Ok(())` on success
+    ///
+    /// # Errors
+    /// - `CoreError::NotFound` - Branch does not exist
+    /// - `CoreError::GitHub` - API communication failed
+    async fn delete_branch(&self, owner: &str, repo: &str, branch_name: &str) -> CoreResult<()>;
+
+    /// Get the permission level a specific user has on a repository
+    ///
+    /// Used to authorise PR comment commands: only collaborators with `Write`,
+    /// `Maintain`, or `Admin` access may issue commands.
+    ///
+    /// # Parameters
+    /// - `owner`: Repository owner name
+    /// - `repo`: Repository name
+    /// - `username`: GitHub login of the user to check
+    ///
+    /// # Returns
+    /// The user's [`CollaboratorPermission`] level
+    ///
+    /// # Errors
+    /// - `CoreError::GitHub` - API communication failed
+    /// - `CoreError::NotFound` - User is not a collaborator on the repository
+    async fn get_collaborator_permission(
+        &self,
+        owner: &str,
+        repo: &str,
+        username: &str,
+    ) -> CoreResult<CollaboratorPermission>;
+
     /// Get the latest release (non-draft, non-prerelease)
     ///
     /// # Parameters
@@ -169,27 +288,34 @@ pub trait GitHubOperations: GitOperations + Send + Sync {
     /// - `CoreError::NotSupported` - Release not found
     async fn get_release_by_tag(&self, owner: &str, repo: &str, tag: &str) -> CoreResult<Release>;
 
-    /// List releases in a repository
+    /// List all labels currently applied to an issue or pull request.
+    ///
+    /// Returns an empty vector when no labels are present.
     ///
     /// # Parameters
     /// - `owner`: Repository owner name
     /// - `repo`: Repository name
-    /// - `per_page`: Number of releases per page (max 100)
-    /// - `page`: Page number to retrieve (1-based)
+    /// - `issue_number`: Issue or pull request number
     ///
     /// # Returns
-    /// List of releases ordered by creation date (newest first)
+    /// All labels currently applied to the issue/PR.
     ///
     /// # Errors
-    /// - `CoreError::GitHub` - API communication failed
-    /// - `CoreError::InvalidInput` - Invalid pagination parameters
-    async fn list_releases(
+    /// - `CoreError::NotFound` — the issue/PR does not exist
+    /// - `CoreError::GitHub` — the API call failed for any other reason
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// let labels = github.list_pr_labels("owner", "repo", 42).await?;
+    /// let has_override = labels.iter().any(|l| l.name == "rr:override-major");
+    /// ```
+    async fn list_pr_labels(
         &self,
         owner: &str,
         repo: &str,
-        per_page: Option<u8>,
-        page: Option<u32>,
-    ) -> CoreResult<Vec<Release>>;
+        issue_number: u64,
+    ) -> CoreResult<Vec<Label>>;
 
     /// List pull requests in a repository
     ///
@@ -221,12 +347,68 @@ pub trait GitHubOperations: GitOperations + Send + Sync {
         page: Option<u32>,
     ) -> CoreResult<Vec<PullRequest>>;
 
+    /// List releases in a repository
+    ///
+    /// # Parameters
+    /// - `owner`: Repository owner name
+    /// - `repo`: Repository name
+    /// - `per_page`: Number of releases per page (max 100)
+    /// - `page`: Page number to retrieve (1-based)
+    ///
+    /// # Returns
+    /// List of releases ordered by creation date (newest first)
+    ///
+    /// # Errors
+    /// - `CoreError::GitHub` - API communication failed
+    /// - `CoreError::InvalidInput` - Invalid pagination parameters
+    async fn list_releases(
+        &self,
+        owner: &str,
+        repo: &str,
+        per_page: Option<u8>,
+        page: Option<u32>,
+    ) -> CoreResult<Vec<Release>>;
+
+    /// Remove a single label from an issue or pull request.
+    ///
+    /// The operation is idempotent: if the label is not currently applied to
+    /// the issue/PR, `Ok(())` is returned (GitHub 404 on the label is treated
+    /// as success). A 404 on the *issue/PR itself* is still an error.
+    ///
+    /// # Parameters
+    /// - `owner`: Repository owner name
+    /// - `repo`: Repository name
+    /// - `issue_number`: Issue or pull request number
+    /// - `label_name`: Name of the label to remove
+    ///
+    /// # Returns
+    /// `Ok(())` on success or when the label was not present.
+    ///
+    /// # Errors
+    /// - `CoreError::NotFound` — the issue/PR does not exist
+    /// - `CoreError::GitHub` — the API call failed for any other reason
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// // Idempotent: succeeds even if the label is absent.
+    /// github.remove_label("owner", "repo", 42, "rr:override-major").await?;
+    /// ```
+    async fn remove_label(
+        &self,
+        owner: &str,
+        repo: &str,
+        issue_number: u64,
+        label_name: &str,
+    ) -> CoreResult<()>;
+
     /// Search pull requests using GitHub search query syntax
     ///
     /// Supports a subset of GitHub search qualifiers:
     /// - `is:open` / `is:closed` / `is:merged` — filter by state
     /// - `head:BRANCH` or `head:PREFIX*` — filter by head branch (glob prefix with `*`)
     /// - `base:BRANCH` — filter by exact base branch name
+    /// - `label:NAME` — filter by label name (exact match)
     ///
     /// # Parameters
     /// - `owner`: Repository owner name
@@ -294,94 +476,6 @@ pub trait GitHubOperations: GitOperations + Send + Sync {
         release_id: u64,
         params: UpdateReleaseParams,
     ) -> CoreResult<Release>;
-
-    /// Create a new branch pointing to the given commit SHA
-    ///
-    /// Creates a new Git branch (ref) in the repository at the specified commit.
-    ///
-    /// # Parameters
-    /// - `owner`: Repository owner name
-    /// - `repo`: Repository name
-    /// - `branch_name`: Name of the new branch (without `refs/heads/` prefix)
-    /// - `sha`: Commit SHA the branch should initially point to
-    ///
-    /// # Returns
-    /// `Ok(())` on success
-    ///
-    /// # Errors
-    /// - `CoreError::Conflict` - A branch with this name already exists (HTTP 422)
-    /// - `CoreError::GitHub` - API communication failed
-    /// - `CoreError::InvalidInput` - Invalid branch name or SHA
-    async fn create_branch(
-        &self,
-        owner: &str,
-        repo: &str,
-        branch_name: &str,
-        sha: &str,
-    ) -> CoreResult<()>;
-
-    /// Delete a branch
-    ///
-    /// Removes the named branch (ref) from the repository. This is a destructive
-    /// operation; the commits remain accessible through other refs or by SHA.
-    ///
-    /// # Parameters
-    /// - `owner`: Repository owner name
-    /// - `repo`: Repository name
-    /// - `branch_name`: Name of the branch to delete (without `refs/heads/` prefix)
-    ///
-    /// # Returns
-    /// `Ok(())` on success
-    ///
-    /// # Errors
-    /// - `CoreError::NotFound` - Branch does not exist
-    /// - `CoreError::GitHub` - API communication failed
-    async fn delete_branch(&self, owner: &str, repo: &str, branch_name: &str) -> CoreResult<()>;
-
-    /// Get the permission level a specific user has on a repository
-    ///
-    /// Used to authorise PR comment commands: only collaborators with `Write`,
-    /// `Maintain`, or `Admin` access may issue commands.
-    ///
-    /// # Parameters
-    /// - `owner`: Repository owner name
-    /// - `repo`: Repository name
-    /// - `username`: GitHub login of the user to check
-    ///
-    /// # Returns
-    /// The user's [`CollaboratorPermission`] level
-    ///
-    /// # Errors
-    /// - `CoreError::GitHub` - API communication failed
-    /// - `CoreError::NotFound` - User is not a collaborator on the repository
-    async fn get_collaborator_permission(
-        &self,
-        owner: &str,
-        repo: &str,
-        username: &str,
-    ) -> CoreResult<CollaboratorPermission>;
-
-    /// Post a comment on an issue or pull request
-    ///
-    /// # Parameters
-    /// - `owner`: Repository owner name
-    /// - `repo`: Repository name
-    /// - `issue_number`: Issue or pull request number to comment on
-    /// - `body`: Comment body (Markdown supported)
-    ///
-    /// # Returns
-    /// `Ok(())` on success
-    ///
-    /// # Errors
-    /// - `CoreError::NotFound` - Issue or PR does not exist
-    /// - `CoreError::GitHub` - API communication failed
-    async fn create_issue_comment(
-        &self,
-        owner: &str,
-        repo: &str,
-        issue_number: u64,
-        body: &str,
-    ) -> CoreResult<()>;
 }
 
 // Note: Git commit information is now provided by GitOperations trait
@@ -432,6 +526,19 @@ pub struct GitUser {
     pub login: Option<String>,
     /// User name
     pub name: String,
+}
+
+/// A GitHub label applied to an issue or pull request.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Label {
+    /// Label ID
+    pub id: u64,
+    /// Label name (e.g. `rr:override-major`)
+    pub name: String,
+    /// Label colour as a 6-character hex string without the leading `#`
+    pub color: String,
+    /// Optional human-readable description
+    pub description: Option<String>,
 }
 
 /// Pull request information

--- a/crates/core/src/versioning.rs
+++ b/crates/core/src/versioning.rs
@@ -127,11 +127,39 @@
 //! assert!(VersionCalculator::parse_version("1.2.3-").is_err()); // Empty prerelease
 //! ```
 
+use std::cmp::Ordering;
+use std::fmt;
+
 use crate::traits::git_operations::{GitTag, ListTagsOptions};
 use crate::{CoreError, CoreResult};
 use serde::{Deserialize, Serialize};
-use std::fmt;
 use tracing::{debug, info};
+
+/// Which conventional-commit bump dimension the user requests via an `!release`
+/// override command.
+///
+/// This is a versioning concept shared between
+/// [`crate::comment_command_processor`] (command dispatch) and
+/// [`apply_bump_floor`] (floor computation). Keeping it here avoids any
+/// cyclic module dependency.
+///
+/// # Examples
+///
+/// ```
+/// use release_regent_core::versioning::BumpKind;
+///
+/// let floor = BumpKind::Major;
+/// assert_eq!(floor, BumpKind::Major);
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BumpKind {
+    /// Force at least a major version bump.
+    Major,
+    /// Force at least a minor version bump.
+    Minor,
+    /// Force at least a patch version bump.
+    Patch,
+}
 
 /// Conventional commit information
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -197,15 +225,87 @@ impl SemanticVersion {
         self.prerelease.is_some()
     }
 
+    /// Compute the next major version (`x+1.0.0`), discarding pre-release and
+    /// build metadata from the current version.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use release_regent_core::versioning::SemanticVersion;
+    ///
+    /// let v = SemanticVersion { major: 1, minor: 2, patch: 3,
+    ///                            prerelease: None, build: None };
+    /// assert_eq!(v.next_major().to_string(), "2.0.0");
+    ///
+    /// // Pre-release is discarded.
+    /// let pre = SemanticVersion { major: 1, minor: 0, patch: 0,
+    ///                              prerelease: Some("rc.1".to_string()), build: None };
+    /// assert_eq!(pre.next_major().to_string(), "2.0.0");
+    /// ```
+    #[must_use]
+    pub fn next_major(&self) -> SemanticVersion {
+        SemanticVersion {
+            major: self.major + 1,
+            minor: 0,
+            patch: 0,
+            prerelease: None,
+            build: None,
+        }
+    }
+
+    /// Compute the next minor version (`x.y+1.0`), discarding pre-release and
+    /// build metadata from the current version.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use release_regent_core::versioning::SemanticVersion;
+    ///
+    /// let v = SemanticVersion { major: 1, minor: 2, patch: 3,
+    ///                            prerelease: None, build: None };
+    /// assert_eq!(v.next_minor().to_string(), "1.3.0");
+    /// ```
+    #[must_use]
+    pub fn next_minor(&self) -> SemanticVersion {
+        SemanticVersion {
+            major: self.major,
+            minor: self.minor + 1,
+            patch: 0,
+            prerelease: None,
+            build: None,
+        }
+    }
+
+    /// Compute the next patch version (`x.y.z+1`), discarding pre-release and
+    /// build metadata from the current version.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use release_regent_core::versioning::SemanticVersion;
+    ///
+    /// let v = SemanticVersion { major: 1, minor: 2, patch: 3,
+    ///                            prerelease: None, build: None };
+    /// assert_eq!(v.next_patch().to_string(), "1.2.4");
+    /// ```
+    #[must_use]
+    pub fn next_patch(&self) -> SemanticVersion {
+        SemanticVersion {
+            major: self.major,
+            minor: self.minor,
+            patch: self.patch + 1,
+            prerelease: None,
+            build: None,
+        }
+    }
+
     /// Check if this version has build metadata
     pub fn has_build_metadata(&self) -> bool {
         self.build.is_some()
     }
 
     /// Compare versions ignoring build metadata (as per semver spec)
-    pub fn compare_precedence(&self, other: &Self) -> std::cmp::Ordering {
-        use std::cmp::Ordering;
-
+    pub fn compare_precedence(&self, other: &Self) -> Ordering {
         // Compare major.minor.patch first
         match (self.major, self.minor, self.patch).cmp(&(other.major, other.minor, other.patch)) {
             Ordering::Equal => {
@@ -544,6 +644,70 @@ impl VersionCalculator {
     }
 }
 
+/// Apply a minimum-bump floor to a calculated semantic version.
+///
+/// Computes the version that `floor` would produce from `current`
+/// (`current.next_major()`, `current.next_minor()`, or `current.next_patch()`),
+/// then returns whichever of `calculated` and `floor_version` is the greater
+/// according to semver precedence.
+///
+/// This is a pure function with no I/O and no side effects.
+///
+/// # Arguments
+///
+/// * `current` — the highest released version tag at the time the feature PR
+///   was merged (the baseline from which the floor is computed).
+/// * `calculated` — the version that conventional-commit analysis produced
+///   before any floor is applied.
+/// * `floor` — the minimum bump dimension requested via `!release`.
+///
+/// # Returns
+///
+/// `max(calculated, floor_version)` by semver precedence.
+///
+/// # Examples
+///
+/// ```
+/// use release_regent_core::versioning::{apply_bump_floor, BumpKind, SemanticVersion};
+///
+/// let current    = SemanticVersion { major: 1, minor: 2, patch: 3,
+///                                    prerelease: None, build: None };
+/// let calculated = SemanticVersion { major: 1, minor: 2, patch: 4,
+///                                    prerelease: None, build: None };
+///
+/// // !release major → floor = 2.0.0, which is greater than 1.2.4.
+/// let effective = apply_bump_floor(&current, &calculated, BumpKind::Major);
+/// assert_eq!(effective.to_string(), "2.0.0");
+///
+/// // !release patch → floor = 1.2.4, which equals the calculated version.
+/// let effective = apply_bump_floor(&current, &calculated, BumpKind::Patch);
+/// assert_eq!(effective.to_string(), "1.2.4");
+///
+/// // If conventional commits already force a higher version, the floor
+/// // has no effect.
+/// let major_calc = SemanticVersion { major: 2, minor: 0, patch: 0,
+///                                    prerelease: None, build: None };
+/// let effective  = apply_bump_floor(&current, &major_calc, BumpKind::Minor);
+/// assert_eq!(effective.to_string(), "2.0.0");
+/// ```
+#[must_use]
+pub fn apply_bump_floor(
+    current: &SemanticVersion,
+    calculated: &SemanticVersion,
+    floor: BumpKind,
+) -> SemanticVersion {
+    let floor_version = match floor {
+        BumpKind::Major => current.next_major(),
+        BumpKind::Minor => current.next_minor(),
+        BumpKind::Patch => current.next_patch(),
+    };
+
+    match calculated.compare_precedence(&floor_version) {
+        Ordering::Less => floor_version,
+        _ => calculated.clone(),
+    }
+}
+
 /// Compare two semver pre-release strings following the semver 2.0 specification (§11.4).
 ///
 /// Each dot-separated identifier is compared pairwise from left to right:
@@ -554,9 +718,7 @@ impl VersionCalculator {
 ///
 /// When all compared pairs are equal, the version with more identifiers is `Greater`
 /// (e.g. `alpha.1 > alpha` per §11.4.4).
-fn compare_prerelease(a: &str, b: &str) -> std::cmp::Ordering {
-    use std::cmp::Ordering;
-
+fn compare_prerelease(a: &str, b: &str) -> Ordering {
     let mut a_ids = a.split('.');
     let mut b_ids = b.split('.');
 

--- a/crates/core/src/versioning_tests.rs
+++ b/crates/core/src/versioning_tests.rs
@@ -900,3 +900,62 @@ async fn test_resolve_current_version_propagates_api_errors() {
 
     assert!(result.is_err());
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// apply_bump_floor — additional unit tests (spec §9)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Spec §9 row: "Floor with pre-release current version"
+/// current=2.0.0-rc.1, calculated=2.0.0, floor=Major → 3.0.0
+///
+/// `next_major()` on a pre-release version strips the pre-release tag and
+/// bumps the major component, so 2.0.0-rc.1 → 3.0.0.  The calculated version
+/// (2.0.0) is less than the floor (3.0.0), so the floor wins.
+#[test]
+fn test_apply_bump_floor_with_prerelease_current_version() {
+    let current = SemanticVersion {
+        major: 2,
+        minor: 0,
+        patch: 0,
+        prerelease: Some("rc.1".to_string()),
+        build: None,
+    };
+    let calculated = SemanticVersion {
+        major: 2,
+        minor: 0,
+        patch: 0,
+        prerelease: None,
+        build: None,
+    };
+
+    let result = apply_bump_floor(&current, &calculated, BumpKind::Major);
+
+    assert_eq!(result.to_string(), "3.0.0");
+}
+
+/// Spec §9 row: "Floor raises patch → minor"
+/// current=1.2.3, calculated=1.2.4 (patch bump), floor=Minor → 1.3.0
+///
+/// The floor version from `next_minor()` is 1.3.0, which exceeds the
+/// calculated patch bump 1.2.4, so the floor is applied.
+#[test]
+fn test_apply_bump_floor_raises_patch_to_minor() {
+    let current = SemanticVersion {
+        major: 1,
+        minor: 2,
+        patch: 3,
+        prerelease: None,
+        build: None,
+    };
+    let calculated = SemanticVersion {
+        major: 1,
+        minor: 2,
+        patch: 4,
+        prerelease: None,
+        build: None,
+    };
+
+    let result = apply_bump_floor(&current, &calculated, BumpKind::Minor);
+
+    assert_eq!(result.to_string(), "1.3.0");
+}

--- a/crates/github_client/src/lib.rs
+++ b/crates/github_client/src/lib.rs
@@ -748,6 +748,10 @@ impl GitHubOperations for GitHubClient {
 
         let installation = self.installation().await?;
         // GitHub returns 404 when the label is not on the issue; treat that as Ok.
+        // ASSUMPTION: label names in this codebase match [a-zA-Z0-9 _.-]+ optionally
+        // prefixed by a namespace with colons (e.g. "rr:override-minor").  Only colons
+        // are percent-encoded here; spaces and other characters are intentionally not
+        // handled because Release Regent's own labels never contain them.
         let encoded = label_name.replace(':', "%3A");
         let path = format!("/repos/{owner}/{repo}/issues/{issue_number}/labels/{encoded}");
         match installation.delete(&path).await {

--- a/crates/github_client/src/lib.rs
+++ b/crates/github_client/src/lib.rs
@@ -16,7 +16,7 @@ use release_regent_core::{
         },
         github_operations::{
             CollaboratorPermission, CreatePullRequestParams, CreateReleaseParams, GitHubOperations,
-            GitUser as GitHubUser, PullRequest, PullRequestBranch, Release, Repository, Tag,
+            GitUser as GitHubUser, Label, PullRequest, PullRequestBranch, Release, Repository, Tag,
             UpdateReleaseParams,
         },
     },
@@ -710,6 +710,78 @@ impl GitHubOperations for GitHubClient {
                 CollaboratorPermission::None
             }
         })
+    }
+
+    async fn add_labels(
+        &self,
+        owner: &str,
+        repo: &str,
+        issue_number: u64,
+        labels: &[&str],
+    ) -> CoreResult<()> {
+        info!(owner, repo, issue_number, "Adding labels");
+
+        let installation = self.installation().await?;
+        let path = format!("/repos/{owner}/{repo}/issues/{issue_number}/labels");
+        let body = serde_json::json!({ "labels": labels });
+        installation
+            .post(&path, &body)
+            .await
+            .map_err(map_sdk_error)?;
+        Ok(())
+    }
+
+    async fn remove_label(
+        &self,
+        owner: &str,
+        repo: &str,
+        issue_number: u64,
+        label_name: &str,
+    ) -> CoreResult<()> {
+        info!(
+            owner,
+            repo,
+            issue_number,
+            label = label_name,
+            "Removing label"
+        );
+
+        let installation = self.installation().await?;
+        // GitHub returns 404 when the label is not on the issue; treat that as Ok.
+        let encoded = label_name.replace(':', "%3A");
+        let path = format!("/repos/{owner}/{repo}/issues/{issue_number}/labels/{encoded}");
+        match installation.delete(&path).await {
+            Ok(_) => Ok(()),
+            Err(github_bot_sdk::error::ApiError::HttpError { status: 404, .. }) => Ok(()),
+            Err(e) => Err(map_sdk_error(e)),
+        }
+    }
+
+    async fn list_pr_labels(
+        &self,
+        owner: &str,
+        repo: &str,
+        issue_number: u64,
+    ) -> CoreResult<Vec<Label>> {
+        info!(owner, repo, issue_number, "Listing PR labels");
+
+        let installation = self.installation().await?;
+        let path = format!("/repos/{owner}/{repo}/issues/{issue_number}/labels");
+        let response = installation.get(&path).await.map_err(map_sdk_error)?;
+        let raw: Vec<serde_json::Value> =
+            response.json().await.map_err(|e| CoreError::github(e))?;
+
+        let labels = raw
+            .into_iter()
+            .map(|v| Label {
+                id: v["id"].as_u64().unwrap_or(0),
+                name: v["name"].as_str().unwrap_or("").to_string(),
+                color: v["color"].as_str().unwrap_or("").to_string(),
+                description: v["description"].as_str().map(str::to_string),
+            })
+            .collect();
+
+        Ok(labels)
     }
 }
 

--- a/crates/github_client/src/lib.rs
+++ b/crates/github_client/src/lib.rs
@@ -748,10 +748,10 @@ impl GitHubOperations for GitHubClient {
 
         let installation = self.installation().await?;
         // GitHub returns 404 when the label is not on the issue; treat that as Ok.
-        // ASSUMPTION: label names in this codebase match [a-zA-Z0-9 _.-]+ optionally
-        // prefixed by a namespace with colons (e.g. "rr:override-minor").  Only colons
-        // are percent-encoded here; spaces and other characters are intentionally not
-        // handled because Release Regent's own labels never contain them.
+        // ASSUMPTION: label names in this codebase match [a-zA-Z0-9:_.-]+ (e.g.
+        // "rr:override-minor").  Only colons are percent-encoded here; spaces and
+        // other characters are intentionally not handled because Release Regent's
+        // own labels never contain them.
         let encoded = label_name.replace(':', "%3A");
         let path = format!("/repos/{owner}/{repo}/issues/{issue_number}/labels/{encoded}");
         match installation.delete(&path).await {

--- a/crates/testing/src/mocks/github_operations.rs
+++ b/crates/testing/src/mocks/github_operations.rs
@@ -854,6 +854,13 @@ impl GitHubOperations for MockGitHubOperations {
             return Err(error);
         }
 
+        if let Some(msg) = self.method_errors.get(method) {
+            let error = CoreError::network(msg.clone());
+            self.record_call(method, &params_str, CallResult::Error(error.to_string()))
+                .await;
+            return Err(error);
+        }
+
         let mut state_filter: Option<String> = None;
         let mut head_filter: Option<String> = None;
         let mut base_filter: Option<String> = None;
@@ -901,11 +908,12 @@ impl GitHubOperations for MockGitHubOperations {
             .filter(|pr| {
                 label_filter.as_ref().map_or(true, |l| {
                     let key = format!("{owner}/{repo}/{}", pr.number);
-                    let pr_labels = self.pr_labels.try_read();
-                    pr_labels.as_deref().map_or(false, |map| {
-                        map.get(&key)
-                            .map_or(false, |labels| labels.iter().any(|lbl| lbl.name == *l))
-                    })
+                    // blocking_read() is safe here: this mock is test-only and
+                    // no concurrent writer can be active inside a synchronous
+                    // iterator closure.
+                    let map = self.pr_labels.blocking_read();
+                    map.get(&key)
+                        .map_or(false, |labels| labels.iter().any(|lbl| lbl.name == *l))
                 })
             })
             .collect();
@@ -1046,9 +1054,8 @@ impl GitHubOperations for MockGitHubOperations {
         labels: &[&str],
     ) -> CoreResult<()> {
         let method = "add_labels";
-        let params_str = format!(
-            "owner={owner}, repo={repo}, issue={issue_number}, labels={labels:?}"
-        );
+        let params_str =
+            format!("owner={owner}, repo={repo}, issue={issue_number}, labels={labels:?}");
 
         self.check_quota().await?;
         self.simulate_latency().await;
@@ -1097,9 +1104,8 @@ impl GitHubOperations for MockGitHubOperations {
         label_name: &str,
     ) -> CoreResult<()> {
         let method = "remove_label";
-        let params_str = format!(
-            "owner={owner}, repo={repo}, issue={issue_number}, label={label_name}"
-        );
+        let params_str =
+            format!("owner={owner}, repo={repo}, issue={issue_number}, label={label_name}");
 
         self.check_quota().await?;
         self.simulate_latency().await;
@@ -1138,8 +1144,7 @@ impl GitHubOperations for MockGitHubOperations {
         issue_number: u64,
     ) -> CoreResult<Vec<Label>> {
         let method = "list_pr_labels";
-        let params_str =
-            format!("owner={owner}, repo={repo}, issue={issue_number}");
+        let params_str = format!("owner={owner}, repo={repo}, issue={issue_number}");
 
         self.check_quota().await?;
         self.simulate_latency().await;
@@ -1159,7 +1164,13 @@ impl GitHubOperations for MockGitHubOperations {
         }
 
         let key = format!("{owner}/{repo}/{issue_number}");
-        let labels = self.pr_labels.read().await.get(&key).cloned().unwrap_or_default();
+        let labels = self
+            .pr_labels
+            .read()
+            .await
+            .get(&key)
+            .cloned()
+            .unwrap_or_default();
 
         self.record_call(method, &params_str, CallResult::Success)
             .await;

--- a/crates/testing/src/mocks/github_operations.rs
+++ b/crates/testing/src/mocks/github_operations.rs
@@ -56,6 +56,17 @@ pub struct MockGitHubOperations {
     /// A name already present causes `create_branch` to return
     /// `CoreError::Conflict`, matching real GitHub 422 behaviour.
     branches: HashMap<String, Vec<String>>,
+    /// Labels keyed `"owner/repo/issue_number"`.  Used by `list_pr_labels`,
+    /// `add_labels` (appends), and `remove_label` (removes by name).
+    /// The `search_pull_requests` label-filter also reads from this map.
+    pr_labels: HashMap<String, Vec<Label>>,
+    /// Configurable collaborator permission returned by
+    /// `get_collaborator_permission` for any username.
+    /// `None` defaults to `CollaboratorPermission::Write`.
+    collaborator_permission: Option<CollaboratorPermission>,
+    /// Per-method error overrides.  Key is the method name string; value is the
+    /// error message to return.  Takes precedence over global failure simulation.
+    method_errors: HashMap<String, String>,
 }
 
 impl MockGitHubOperations {
@@ -101,6 +112,9 @@ impl MockGitHubOperations {
             tags: HashMap::new(),
             releases: HashMap::new(),
             branches: HashMap::new(),
+            pr_labels: HashMap::new(),
+            collaborator_permission: None,
+            method_errors: HashMap::new(),
         }
     }
 
@@ -155,6 +169,9 @@ impl MockGitHubOperations {
             tags: HashMap::new(),
             releases: HashMap::new(),
             branches: HashMap::new(),
+            pr_labels: HashMap::new(),
+            collaborator_permission: None,
+            method_errors: HashMap::new(),
         }
     }
 
@@ -279,6 +296,48 @@ impl MockGitHubOperations {
     pub fn with_branches(mut self, owner: &str, name: &str, branches: Vec<String>) -> Self {
         let key = format!("{}/{}", owner, name);
         self.branches.insert(key, branches);
+        self
+    }
+
+    /// Pre-populate the mock with labels for a specific PR/issue number.
+    ///
+    /// These labels are returned by `list_pr_labels` and are also used by
+    /// `search_pull_requests` to support `label:NAME` queries.
+    ///
+    /// The key is formatted as `"{owner}/{repo}/{issue_number}"` so that
+    /// labels can be scoped to a specific repository.
+    pub fn with_pr_labels(
+        mut self,
+        owner: &str,
+        repo: &str,
+        issue_number: u64,
+        labels: Vec<Label>,
+    ) -> Self {
+        let key = format!("{owner}/{repo}/{issue_number}");
+        self.pr_labels.insert(key, labels);
+        self
+    }
+
+    /// Configure the collaborator permission returned by
+    /// `get_collaborator_permission` for any username.
+    ///
+    /// Defaults to `CollaboratorPermission::Write` when not set.
+    pub fn with_collaborator_permission(mut self, permission: CollaboratorPermission) -> Self {
+        self.collaborator_permission = Some(permission);
+        self
+    }
+
+    /// Configure a named method to return an error.
+    ///
+    /// This takes precedence over global failure simulation and lets tests
+    /// simulate partial failures (e.g. only `remove_label` fails while other
+    /// calls succeed).
+    ///
+    /// `method_name` must match the method name string used internally, e.g.
+    /// `"add_labels"`, `"remove_label"`, `"list_pr_labels"`.
+    pub fn with_method_error(mut self, method_name: &str, error_message: &str) -> Self {
+        self.method_errors
+            .insert(method_name.to_string(), error_message.to_string());
         self
     }
 }
@@ -795,6 +854,7 @@ impl GitHubOperations for MockGitHubOperations {
         let mut state_filter: Option<String> = None;
         let mut head_filter: Option<String> = None;
         let mut base_filter: Option<String> = None;
+        let mut label_filter: Option<String> = None;
 
         for token in query.split_whitespace() {
             if let Some(s) = token.strip_prefix("is:") {
@@ -803,6 +863,8 @@ impl GitHubOperations for MockGitHubOperations {
                 head_filter = Some(h.to_string());
             } else if let Some(b) = token.strip_prefix("base:") {
                 base_filter = Some(b.to_string());
+            } else if let Some(l) = token.strip_prefix("label:") {
+                label_filter = Some(l.to_string());
             }
         }
 
@@ -832,6 +894,14 @@ impl GitHubOperations for MockGitHubOperations {
                 base_filter
                     .as_ref()
                     .map_or(true, |b| pr.base.ref_name == *b)
+            })
+            .filter(|pr| {
+                label_filter.as_ref().map_or(true, |l| {
+                    let key = format!("{owner}/{repo}/{}", pr.number);
+                    self.pr_labels
+                        .get(&key)
+                        .map_or(false, |labels| labels.iter().any(|lbl| lbl.name == *l))
+                })
             })
             .collect();
 
@@ -948,9 +1018,122 @@ impl GitHubOperations for MockGitHubOperations {
             return Err(error);
         }
 
+        if let Some(msg) = self.method_errors.get(method) {
+            let error = CoreError::network(msg.clone());
+            self.record_call(method, &params_str, CallResult::Error(error.to_string()))
+                .await;
+            return Err(error);
+        }
+
         self.record_call(method, &params_str, CallResult::Success)
             .await;
-        Ok(CollaboratorPermission::Write)
+        Ok(self
+            .collaborator_permission
+            .clone()
+            .unwrap_or(CollaboratorPermission::Write))
+    }
+
+    async fn add_labels(
+        &self,
+        owner: &str,
+        repo: &str,
+        issue_number: u64,
+        labels: &[&str],
+    ) -> CoreResult<()> {
+        let method = "add_labels";
+        let params_str = format!(
+            "owner={owner}, repo={repo}, issue={issue_number}, labels={labels:?}"
+        );
+
+        self.check_quota().await?;
+        self.simulate_latency().await;
+
+        if self.should_simulate_failure().await {
+            let error = CoreError::network("Simulated GitHub API error");
+            self.record_call(method, &params_str, CallResult::Error(error.to_string()))
+                .await;
+            return Err(error);
+        }
+
+        if let Some(msg) = self.method_errors.get(method) {
+            let error = CoreError::network(msg.clone());
+            self.record_call(method, &params_str, CallResult::Error(error.to_string()))
+                .await;
+            return Err(error);
+        }
+
+        self.record_call(method, &params_str, CallResult::Success)
+            .await;
+        Ok(())
+    }
+
+    async fn remove_label(
+        &self,
+        owner: &str,
+        repo: &str,
+        issue_number: u64,
+        label_name: &str,
+    ) -> CoreResult<()> {
+        let method = "remove_label";
+        let params_str = format!(
+            "owner={owner}, repo={repo}, issue={issue_number}, label={label_name}"
+        );
+
+        self.check_quota().await?;
+        self.simulate_latency().await;
+
+        if self.should_simulate_failure().await {
+            let error = CoreError::network("Simulated GitHub API error");
+            self.record_call(method, &params_str, CallResult::Error(error.to_string()))
+                .await;
+            return Err(error);
+        }
+
+        if let Some(msg) = self.method_errors.get(method) {
+            let error = CoreError::network(msg.clone());
+            self.record_call(method, &params_str, CallResult::Error(error.to_string()))
+                .await;
+            return Err(error);
+        }
+
+        self.record_call(method, &params_str, CallResult::Success)
+            .await;
+        Ok(())
+    }
+
+    async fn list_pr_labels(
+        &self,
+        owner: &str,
+        repo: &str,
+        issue_number: u64,
+    ) -> CoreResult<Vec<Label>> {
+        let method = "list_pr_labels";
+        let params_str =
+            format!("owner={owner}, repo={repo}, issue={issue_number}");
+
+        self.check_quota().await?;
+        self.simulate_latency().await;
+
+        if self.should_simulate_failure().await {
+            let error = CoreError::network("Simulated GitHub API error");
+            self.record_call(method, &params_str, CallResult::Error(error.to_string()))
+                .await;
+            return Err(error);
+        }
+
+        if let Some(msg) = self.method_errors.get(method) {
+            let error = CoreError::network(msg.clone());
+            self.record_call(method, &params_str, CallResult::Error(error.to_string()))
+                .await;
+            return Err(error);
+        }
+
+        let key = format!("{owner}/{repo}/{issue_number}");
+        let labels = self.pr_labels.get(&key).cloned().unwrap_or_default();
+
+        self.record_call(method, &params_str, CallResult::Success)
+            .await;
+        Ok(labels)
     }
 }
 

--- a/crates/testing/src/mocks/github_operations.rs
+++ b/crates/testing/src/mocks/github_operations.rs
@@ -59,7 +59,10 @@ pub struct MockGitHubOperations {
     /// Labels keyed `"owner/repo/issue_number"`.  Used by `list_pr_labels`,
     /// `add_labels` (appends), and `remove_label` (removes by name).
     /// The `search_pull_requests` label-filter also reads from this map.
-    pr_labels: HashMap<String, Vec<Label>>,
+    ///
+    /// Wrapped in `Arc<RwLock<...>>` so that the `&self` async-trait methods
+    /// can mutate the map without requiring `&mut self`.
+    pr_labels: Arc<RwLock<HashMap<String, Vec<Label>>>>,
     /// Configurable collaborator permission returned by
     /// `get_collaborator_permission` for any username.
     /// `None` defaults to `CollaboratorPermission::Write`.
@@ -112,7 +115,7 @@ impl MockGitHubOperations {
             tags: HashMap::new(),
             releases: HashMap::new(),
             branches: HashMap::new(),
-            pr_labels: HashMap::new(),
+            pr_labels: Arc::new(RwLock::new(HashMap::new())),
             collaborator_permission: None,
             method_errors: HashMap::new(),
         }
@@ -169,7 +172,7 @@ impl MockGitHubOperations {
             tags: HashMap::new(),
             releases: HashMap::new(),
             branches: HashMap::new(),
-            pr_labels: HashMap::new(),
+            pr_labels: Arc::new(RwLock::new(HashMap::new())),
             collaborator_permission: None,
             method_errors: HashMap::new(),
         }
@@ -307,14 +310,14 @@ impl MockGitHubOperations {
     /// The key is formatted as `"{owner}/{repo}/{issue_number}"` so that
     /// labels can be scoped to a specific repository.
     pub fn with_pr_labels(
-        mut self,
+        self,
         owner: &str,
         repo: &str,
         issue_number: u64,
         labels: Vec<Label>,
     ) -> Self {
         let key = format!("{owner}/{repo}/{issue_number}");
-        self.pr_labels.insert(key, labels);
+        self.pr_labels.blocking_write().insert(key, labels);
         self
     }
 
@@ -898,9 +901,11 @@ impl GitHubOperations for MockGitHubOperations {
             .filter(|pr| {
                 label_filter.as_ref().map_or(true, |l| {
                     let key = format!("{owner}/{repo}/{}", pr.number);
-                    self.pr_labels
-                        .get(&key)
-                        .map_or(false, |labels| labels.iter().any(|lbl| lbl.name == *l))
+                    let pr_labels = self.pr_labels.try_read();
+                    pr_labels.as_deref().map_or(false, |map| {
+                        map.get(&key)
+                            .map_or(false, |labels| labels.iter().any(|lbl| lbl.name == *l))
+                    })
                 })
             })
             .collect();
@@ -1062,6 +1067,23 @@ impl GitHubOperations for MockGitHubOperations {
             return Err(error);
         }
 
+        let key = format!("{owner}/{repo}/{issue_number}");
+        {
+            let mut map = self.pr_labels.write().await;
+            let entry = map.entry(key).or_default();
+            for label_name in labels {
+                // Avoid duplicates — match GitHub's idempotent behaviour.
+                if !entry.iter().any(|l| l.name == *label_name) {
+                    entry.push(Label {
+                        id: 0,
+                        name: label_name.to_string(),
+                        color: String::new(),
+                        description: None,
+                    });
+                }
+            }
+        }
+
         self.record_call(method, &params_str, CallResult::Success)
             .await;
         Ok(())
@@ -1094,6 +1116,14 @@ impl GitHubOperations for MockGitHubOperations {
             self.record_call(method, &params_str, CallResult::Error(error.to_string()))
                 .await;
             return Err(error);
+        }
+
+        let key = format!("{owner}/{repo}/{issue_number}");
+        {
+            let mut map = self.pr_labels.write().await;
+            if let Some(entry) = map.get_mut(&key) {
+                entry.retain(|l| l.name != label_name);
+            }
         }
 
         self.record_call(method, &params_str, CallResult::Success)
@@ -1129,7 +1159,7 @@ impl GitHubOperations for MockGitHubOperations {
         }
 
         let key = format!("{owner}/{repo}/{issue_number}");
-        let labels = self.pr_labels.get(&key).cloned().unwrap_or_default();
+        let labels = self.pr_labels.read().await.get(&key).cloned().unwrap_or_default();
 
         self.record_call(method, &params_str, CallResult::Success)
             .await;

--- a/docs/adr/ADR-004-bump-override-persistence.md
+++ b/docs/adr/ADR-004-bump-override-persistence.md
@@ -1,0 +1,609 @@
+# ADR-004: Bump Override Persistence Strategy for `!release` Commands
+
+Status: Accepted
+Date: 2026-04-01
+Owners: @pvandervelde
+
+## Context
+
+[ADR-003](ADR-003-pr-comment-commands.md) introduced PR comment commands, implementing
+`!set-version X.Y.Z` fully and registering `!release major|minor|patch` as a recognised
+but unimplemented stub. The stub posts an informational "not yet supported" comment and
+acknowledges the event.
+
+Implementing `!release major|minor|patch` raises a fundamental persistence problem:
+`!release major` specifies only a *minimum bump direction* — the concrete target version
+cannot be determined until the next `PullRequestMerged` event carries the commit history
+needed for version calculation.
+
+`!set-version X.Y.Z` specifies a complete, concrete target version and can invoke the
+`ReleaseOrchestrator` immediately. However, it shares a different scope problem: if the
+command is accepted on any open PR, then posted on a feature PR that is later abandoned,
+the release PR has already been changed based on work that was never merged. This is a
+stale-override risk identical in effect to the original (rejected) option of storing
+`!release` overrides on the release PR — version decisions would be driven by
+unmerged work.
+
+Five design questions must be answered before implementation can begin.
+
+### Design Question 1 — Storage medium
+
+Where is the forced-minimum-bump stored between the comment event and the next
+`PullRequestMerged` event?
+
+**Options evaluated:**
+
+| Option | Description | Assessment |
+|--------|-------------|------------|
+| (a) GitHub label on the release PR | `rr:override-major` on the release PR | ❌ Stale if the commented-upon feature PR is abandoned — an override from a PR that was never merged would affect the next arbitrary merge |
+| (b) Hidden HTML comment in PR body | Embed structured data in the PR body | ❌ Fragile: manual edits corrupt state; parsing is error-prone; not human-friendly |
+| (c) In-process memory | Store in a `HashMap` or similar | ❌ Not viable: lost on any restart or pod rescheduling |
+| (d) External state store (DB, Redis) | Persist to a dedicated store | ❌ Adds infrastructure dependency and operational burden; contradicts the GitHub-native design |
+| (e) GitHub label on the commented-upon (feature) PR | `rr:override-major` on the PR the comment was posted on | ✅ Override is scoped to that specific PR; if the PR is abandoned, no `PullRequestMerged` fires and the label is never consumed; restart-safe; visible in GitHub UI |
+
+**Decision** (Q1): GitHub label on the **commented-upon PR** (the feature PR, option e).
+
+Label set: `rr:override-major`, `rr:override-minor`, `rr:override-patch`.
+At most one override label is active per PR at a time.
+
+**Rationale for rejecting option (a)**: Storing the label on the release PR creates a
+coupling between two unrelated concerns. A `!release major` comment on feature PR #55
+should only affect orchestration if PR #55 *actually merges*. If PR #55 is closed
+without merging, the override intent should be silently discarded. Option (a) cannot
+distinguish between "PR #55 merged" and "some other PR merged after #55 was abandoned"
+— the release PR label would be consumed by the first subsequent merge regardless.
+
+### Design Question 2 — Scope / lifetime of the override
+
+Does the override apply to any future `PullRequestMerged` event, or only to the specific
+PR that the `!release` comment was posted on?
+
+The override is an expression of intent about a specific piece of work: **"when this
+PR is merged, ensure the release version is at least a major bump"**. That intent is
+inseparably tied to the PR being merged. A PR that is abandoned without merging carries
+no relevant intent for future repository activity.
+
+**Decision** (Q2): The override label is consumed when the **specific PR it was posted
+on** is merged via `PullRequestMerged`. If that PR is closed without merging, the label
+remains on the closed PR but is never read by the orchestration path and has no effect.
+No explicit cleanup is required.
+
+### Design Question 3 — Conflict resolution with breaking-change commits
+
+When `BREAKING CHANGE:` commits are present (which implies a required major bump),
+does `!release minor` still apply?
+
+`BREAKING CHANGE:` commits establish an *inherent* requirement for a major bump
+according to the Conventional Commits specification. The override floor is a *minimum*
+constraint — the final effective version is `max(calculated_version, floor_version)`.
+
+| Calculated bump | Override floor | Result |
+|----------------|----------------|--------|
+| `patch` (1.2.4) | `major` floor → 2.0.0 | 2.0.0 (floor raised it) |
+| `minor` (1.3.0) | `patch` floor → 1.2.4 | 1.3.0 (calculated already exceeds floor) |
+| `major` (2.0.0) | `minor` floor → 1.3.0 | 2.0.0 (calculated already exceeds floor) |
+| `major` (2.0.0) from BREAKING CHANGE | `minor` floor | 2.0.0 (BREAKING CHANGE wins) |
+
+**Decision** (Q3): The override floor is a **minimum floor, not a ceiling**. The
+effective version is `max(calculated_version, apply_floor(current_version, floor_kind))`.
+`BREAKING CHANGE:` commits always produce a major-version increment regardless of any
+floor. A `!release minor` label cannot reduce or override a major bump required by the
+commit history.
+
+### Design Question 4 — Precedence when `!set-version` and `!release` coexist
+
+A `!set-version X.Y.Z` command is posted on some PR; a different feature PR has an
+`rr:override-*` bump floor label. Which takes precedence?
+
+Because override labels are scoped to individual PRs (Q1, Q2), `!set-version` and
+`!release` are evaluated at different times and on potentially different PRs. They do
+not directly conflict:
+
+- `!set-version` invokes the orchestrator immediately with the pinned version.
+- A subsequent merge of a PR carrying an `rr:override-*` label will apply the floor
+  at that merge event, which may update the release PR version further.
+
+This is consistent with normal release flow: any merged PR may change the release
+version. An explicit `!set-version 1.5.0` sets the release PR to `1.5.0`; if a feature
+PR with `rr:override-major` later merges, the floor may raise the release PR to `2.0.0`.
+This is expected and correct — the `!set-version` represented the state of intent at
+the time it was posted, not a permanent cap on future versions.
+
+**Decision** (Q4): When both are in play, there is no precedence relationship to enforce
+at runtime:
+
+- `!set-version` (now restricted to the release PR, see Q5) invokes the orchestrator
+  immediately with the pinned version.
+- A subsequent merge of a feature PR carrying an `rr:override-*` label applies the
+  floor at that merge event, which may update the release PR version above the pinned
+  value. This is expected and correct.
+
+Operators who wish to cancel a pending `rr:override-*` label must remove it manually
+from the feature PR in the GitHub UI.
+
+### Design Question 5 — Scope of `!set-version` commands
+
+When a `!set-version X.Y.Z` command is received, the processor must call the
+`ReleaseOrchestrator` immediately with the pinned version. But on which PR should
+the command be accepted?
+
+If `!set-version` is accepted on any open PR (the original design), and the commented-upon
+PR is later abandoned, the release PR has already been changed to a version driven by
+unmerged work. This is conceptually the same stale-override risk that motivated the
+rejection of option (a) in Q1.
+
+**Options evaluated:**
+
+| Option | Description | Assessment |
+|--------|-------------|------------|
+| (a) Accept on any open PR | Current design; apply immediately | ❌ Stale-override risk: release PR version can reflect a PR that was never merged |
+| (b) Defer to PR merge, store version in label | `rr:set-version:1.5.0` label on feature PR; apply when merged | ❌ Non-standard label naming; encoding semver in a label is fragile and limits label query capabilities; complicates parsing |
+| (c) Restrict to the release PR only | Only accept when commented on a PR whose head branch matches `release/v*` | ✅ No stale risk; no deferred state; semantically natural — the release PR is the right place to manage release version |
+
+**Decision** (Q5): `!set-version` is only accepted when posted on the **active release PR**,
+identified by head branch matching the `release/v` prefix (i.e. `head.ref_name.starts_with(branch_prefix + "v")`
+where `branch_prefix` comes from `OrchestratorConfig`). If the command is posted on any
+other open PR, a **scope rejection comment** is posted and the event is acknowledged
+without modifying any PR:
+
+> ⚠️ **Release Regent**: `!set-version` must be posted on the active release PR
+> (branch `release/v*`). Please re-post this command on the release PR.
+
+**Rationale**: The release PR is the natural place to express "set this release to
+exactly version X.Y.Z" — it is the artefact that represents the pending release.
+Accepting the command on feature PRs would allow a never-merged PR to permanently
+change the release version, which contradicts the principle that version decisions
+are only based on merged work.
+
+Note: `get_pull_request` already exists on `GitHubOperations` and `PullRequest.head.ref_name`
+is already available, so no new trait methods are required to implement this check.
+
+### Design Question 6 — Stale override labels when a release completes before the feature PR merges
+
+A feature PR may sit open with an `rr:override-*` label for an extended period. During
+that time, the active release PR may be merged (publishing a release) before the feature
+PR merges. When the feature PR eventually merges, should its override label still be applied?
+
+**The problem**: The override expressed intent for *that release cycle* — the commenter
+intended the work in that feature PR to warrant a particular minimum bump. If the release
+already happened without including the feature PR, applying the override to the *next*
+release cycle is wrong: it would impose a version floor decision made in a prior context
+onto a new release that the commenter never evaluated.
+
+**Options evaluated:**
+
+| Option | Description | Assessment |
+|--------|-------------|------------|
+| (a) Check label timestamp vs release timestamp | Fetch label application time via `GET /issues/{n}/events`; discard if before latest release | ✅ Accurate but requires an extra API call on every merge event that carries an override label |
+| (b) Accept the edge case | Let stale overrides apply; document that operators must manually remove labels | ❌ Produces incorrect version bumps based on stale intent; poor UX |
+| (c) Clear override labels when the release PR merges | When a release PR (`head: release/v*`) merges, find all open PRs with override labels and remove them | ✅ Proactive; enforces a clean one-cycle scope; each affected PR receives an explanatory comment |
+
+**Decision** (Q6): Clear all outstanding `rr:override-*` labels from open PRs when a
+**release PR** is merged (option c).
+
+**Rationale**: Option (c) cleanly enforces the intended scope: overrides are valid for
+one release cycle only. Once a release lands, version decisions for that cycle are final.
+Feature PRs that were not part of that release must re-evaluate their version intent when
+they eventually merge — contributors should re-post `!release` if the work still warrants
+a minimum bump. The cleanup is proactive and observable (comment posted), so contributors
+understand why their label was removed rather than wondering why the floor was silently
+not applied.
+
+**Detection**: Head branch of the merged PR at `payload["pull_request"]["head"]["ref"]`
+starts with the configured `branch_prefix + "/v"` (e.g. `release/v*`).
+
+**Cleanup comment posted on each affected open PR:**
+
+> ℹ️ **Release Regent**: The `!release {kind}` override on this PR has been cleared
+> because a new release was published before this PR merged. If the work in this PR still
+> warrants a minimum bump for the next release, please re-post your `!release` command.
+
+**New `GitHubOperations` capability required**: Finding open PRs that carry a specific
+label. Options:
+
+- Extend `search_pull_requests` to support `label:NAME` qualifiers (cleanest — no new
+  method, just extend the query parsing).
+- Add a dedicated `list_open_prs_with_label(owner, repo, label) -> CoreResult<Vec<PullRequest>>`.
+
+The preferred approach is extending `search_pull_requests` with `label:` support, keeping
+the API surface small. This is left to task 9.20.2.
+
+## Decision
+
+Use GitHub labels (`rr:override-major`, `rr:override-minor`, `rr:override-patch`) on
+the **commented-upon (feature) PR** as the persistence mechanism for `!release` bump
+overrides. The label is applied immediately when the command is received and is consumed
+when that specific PR is merged.
+
+`!set-version` is only accepted when posted on the release PR (head branch `release/v*`);
+posted elsewhere, a scope rejection comment is returned.
+
+When a **release PR merges**, all outstanding `rr:override-*` labels on open PRs are
+cleared with an explanatory comment; those overrides were scoped to the completed release
+cycle and must not carry forward.
+
+Processing model:
+
+1. **When `!release major|minor|patch` is received** (`CommentCommandProcessor`):
+   - Validate: `allow_override = true`, PR is open, commenter has Write access or above.
+   - Remove any existing `rr:override-*` labels from the **feature PR** (the PR the
+     comment was posted on).
+   - Apply the new label (e.g. `rr:override-major`) to the feature PR.
+   - Post a **confirmation comment** on the feature PR:
+     > ✅ **Release Regent**: `!release major` override recorded. When this PR is merged,
+     > the next release version will be bumped by at least one major increment.
+   - Acknowledge the event.
+
+2. **When a PR is merged** (`ReleaseRegentProcessor::handle_merged_pull_request`):
+
+   **Case A — Feature PR** (head branch does NOT start with `release/v`):
+   - Read labels from the **merged PR** (`list_pr_labels(merged_pr_number)`).
+   - If an `rr:override-*` label is present, compute the floor version:
+     - `rr:override-major` → `current_version.next_major()` (e.g. 1.2.3 → 2.0.0)
+     - `rr:override-minor` → `current_version.next_minor()` (e.g. 1.2.3 → 1.3.0)
+     - `rr:override-patch` → `current_version.next_patch()` (e.g. 1.2.3 → 1.2.4)
+   - Compute `effective_version = max(next_version, floor_version)` using
+     `SemanticVersion::compare_precedence`.
+   - Call `orchestrator.orchestrate(…, &effective_version, …)`.
+   - If the floor was applied (i.e. `effective_version != next_version`), post an
+     **audit comment** on the resulting release PR:
+     > 🔼 **Release Regent**: Version floor applied from `!release {kind}` on PR #{n}
+     > by @{login}. Effective version raised from `{next_version}` to `{effective_version}`.
+   - No cleanup of the merged PR's label is needed; the PR is now closed.
+
+   **Case B — Release PR** (head branch starts with `release/v`):
+   - Perform normal orchestration (version calculation and `orchestrate` call).
+   - After orchestration, search for all open PRs bearing any `rr:override-*` label
+     (`search_pull_requests` with `is:open label:rr:override-major`, repeated for minor
+     and patch, deduplicating results).
+   - For each found PR: remove all `rr:override-*` labels; post the cleanup comment:
+     > ℹ️ **Release Regent**: The `!release {kind}` override on this PR has been cleared
+     > because a new release was published before this PR merged. If the work in this PR
+     > still warrants a minimum bump for the next release, please re-post your `!release`
+     > command.
+   - Log cleanup at `info!` level per affected PR. Treat removal errors as `warn!` and
+     continue — the cleanup is best-effort and must not fail the event processing.
+
+3. **When `!set-version X.Y.Z` is received** (`CommentCommandProcessor`):
+   - Validate: `allow_override = true`, PR is open, commenter has Write access or above.
+   - Call `get_pull_request(owner, repo, issue_number)` to retrieve the PR.
+   - If `head.ref_name` does **not** start with `release/v` (the configured branch prefix),
+     post a scope rejection comment and acknowledge the event without calling the
+     orchestrator:
+     > ⚠️ **Release Regent**: `!set-version` must be posted on the active release PR
+     > (branch `release/v*`). Please re-post this command on the release PR.
+   - If on the release PR: validate `pinned > current_version` → call
+     `ReleaseOrchestrator::orchestrate(…, &pinned_version, …)`.
+   - No interaction with override labels on other PRs. Any open feature PRs that carry
+     `rr:override-*` labels will still apply their floors when those PRs eventually merge.
+     This is consistent with normal release flow.
+
+## Consequences
+
+- Override state is visible in the GitHub UI on the **feature PR** that bears the label,
+  providing immediate context: any contributor can see that this PR carries a bump intent.
+- Override labels on abandoned (closed without merging) PRs are harmless; they are never
+  read by the orchestration path.
+- Override labels on open PRs are **cleared automatically** when a release is published
+  (release PR merged). Contributors receive an explanatory comment; re-posting `!release`
+  is required if the intent still applies to the next release.
+- State survives pod restarts, deployments, and scheduler preemptions with no additional
+  infrastructure.
+- GitHub label operations are idempotent: adding an already-present label is a no-op;
+  removing an absent label returns 404, which the implementation must treat as `Ok(())`.
+- Multiple feature PRs may each carry `rr:override-*` labels simultaneously. Each floor
+  is applied independently at the time its PR merges. The orchestrator's natural version
+  comparison logic ensures the highest version wins over time.
+- Three audit trail mechanisms: confirmation comment on the feature PR when the override is
+  recorded; audit comment on the release PR when the floor is actually applied; cleanup
+  comment on each open feature PR when a release is published.
+- API call budget for `handle_merged_pull_request` increases by **one** call per feature
+  PR merge event that carries an override label (`list_pr_labels(merged_pr_number)`); and
+  by up to three search calls + N remove/comment calls per release PR merge event (where
+  N is the number of open PRs with stale override labels).
+- Four new `GitHubOperations` trait capabilities are required: `add_labels`, `remove_label`,
+  `list_pr_labels`, and `label:` filter support in `search_pull_requests`.
+- Commands from users with insufficient permission produce a `❌` rejection comment
+  identifying the commenter and explaining the permission requirement. This ensures
+  contributors understand why their command was not processed rather than seeing silence.
+
+## Alternatives considered
+
+- **Label on the release PR**: Rejected — creates stale override risk: a `!release major`
+  comment on an abandoned PR would apply its floor to the next arbitrary merge, regardless
+  of which PR actually delivered the work that warranted the override. Version decisions
+  should only be based on merged work.
+- **Embed override in PR body (hidden HTML comment)**: Rejected — fragile to manual
+  edits, requires custom parsing, and is not machine-idempotent.
+- **Eagerly create a release PR when `!release` is received**: Rejected — requires calling
+  the version calculator from the comment processor, which lacks the commit history
+  needed to generate a useful changelog.
+- **Persist to external store**: Rejected — introduces external dependencies and
+  operational burden; contradicts the GitHub-native design philosophy.
+- **Check label timestamp for staleness (Q6, option a)**: Rejected in favour of proactive
+  cleanup on release PR merge — the timestamp approach requires an extra API call on every
+  feature PR merge that carries an override label, and the intent is already served by
+  cleaning up at the point of release.
+
+## Implementation notes
+
+### New `GitHubOperations` methods
+
+```rust
+/// Add one or more labels to an issue or pull request.
+///
+/// If a label is already present the operation is a no-op (idempotent).
+async fn add_labels(
+    &self,
+    owner: &str,
+    repo: &str,
+    issue_number: u64,
+    labels: &[String],
+) -> CoreResult<()>;
+
+/// Remove a single label from an issue or pull request.
+///
+/// If the label is not present, returns `Ok(())` (idempotent).
+async fn remove_label(
+    &self,
+    owner: &str,
+    repo: &str,
+    issue_number: u64,
+    label_name: &str,
+) -> CoreResult<()>;
+
+/// List all labels currently applied to an issue or pull request.
+async fn list_pr_labels(
+    &self,
+    owner: &str,
+    repo: &str,
+    issue_number: u64,
+) -> CoreResult<Vec<Label>>;
+```
+
+`search_pull_requests` must additionally support a `label:NAME` qualifier so open PRs
+with override labels can be found when a release PR merges:
+
+```
+// Example query used during release PR merge cleanup:
+"is:open label:rr:override-major"
+```
+
+### Label type
+
+Add `Label` to the `github_operations` module:
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Label {
+    pub id: u64,
+    pub name: String,
+    pub color: String,
+    pub description: Option<String>,
+}
+```
+
+### Override floor computation helper
+
+Add a free function in `crates/core/src/versioning.rs`:
+
+```rust
+/// Apply a minimum bump-kind floor to a calculated next version.
+///
+/// Returns `max(calculated, floor_version)` using semver precedence ordering.
+/// `current` is the latest released version; it is used to derive the floor
+/// target (e.g. next major of `1.2.3` is `2.0.0`).
+pub fn apply_bump_floor(
+    current: &SemanticVersion,
+    calculated: &SemanticVersion,
+    floor: BumpKind,
+) -> SemanticVersion {
+    let floor_version = match floor {
+        BumpKind::Major => current.next_major(),
+        BumpKind::Minor => current.next_minor(),
+        BumpKind::Patch => current.next_patch(),
+    };
+    match calculated.compare_precedence(&floor_version) {
+        Ordering::Less => floor_version,
+        _ => calculated.clone(),
+    }
+}
+```
+
+### Label constants
+
+Define in `crates/core/src/comment_command_processor.rs`:
+
+```rust
+pub const OVERRIDE_LABEL_MAJOR: &str = "rr:override-major";
+pub const OVERRIDE_LABEL_MINOR: &str = "rr:override-minor";
+pub const OVERRIDE_LABEL_PATCH: &str = "rr:override-patch";
+
+pub const ALL_OVERRIDE_LABELS: &[&str] = &[
+    OVERRIDE_LABEL_MAJOR,
+    OVERRIDE_LABEL_MINOR,
+    OVERRIDE_LABEL_PATCH,
+];
+```
+
+### GitHub label creation
+
+Override labels (`rr:override-major` etc.) must be created in the target repository
+before they can be applied. The implementation should call `add_labels` with the label
+name; if GitHub responds with 422 (label does not exist), it must first create the label
+via a `create_label` API call. Add `create_label` to `GitHubOperations` or handle this
+transparently inside `add_labels` in the concrete `GitHubClient` implementation. This
+detail is left to task 9.20.2.
+
+### `remove_label` 404 handling
+
+GitHub returns HTTP 404 when attempting to remove a label that is not present.
+Concrete implementations of `remove_label` must map this to `Ok(())` (idempotent).
+
+### Extracting the PR number for a `PullRequestMerged` event
+
+`handle_merged_pull_request` reads the merged PR number from the webhook payload:
+
+```rust
+let merged_pr_number: u64 = event
+    .payload
+    .get("pull_request")
+    .and_then(|pr| pr.get("number"))
+    .and_then(serde_json::Value::as_u64)
+    .ok_or_else(|| CoreError::invalid_input("payload", "missing pull_request.number"))?;
+```
+
+This number is passed to `list_pr_labels` to read override labels from the merged PR.
+
+### Confirmation comment body (feature PR)
+
+When a `!release` command is accepted:
+
+> ✅ **Release Regent**: `!release {kind}` override recorded. When this PR is merged,
+> the next release version will be bumped by at least one {kind} increment.
+
+If the commenter replaces a previous `!release` label on the same PR:
+
+> ✅ **Release Regent**: `!release {kind}` override recorded (replacing previous
+> `!release {old_kind}` override). When this PR is merged, the next release version
+> will be bumped by at least one {kind} increment.
+
+### Audit comment body (release PR)
+
+When the floor is applied during `handle_merged_pull_request`:
+
+> 🔼 **Release Regent**: Version floor applied from `!release {kind}` override on PR #{n}.
+> The calculated version was `{next_version}` but was raised to `{effective_version}` to
+> satisfy the requested minimum {kind} bump.
+
+### Cleanup comment body (open feature PR after release PR merges)
+
+When override labels are cleared because a release was published:
+
+> ℹ️ **Release Regent**: The `!release {kind}` override on this PR has been cleared
+> because a new release was published before this PR merged. If the work in this PR still
+> warrants a minimum bump for the next release, please re-post your `!release` command.
+
+## Examples
+
+### Scenario: release PR merges before feature PR with override (stale label cleared)
+
+```
+1. Current released version: v1.2.3
+2. Contributor posts `!release major` on feature PR #55 (open)
+   → rr:override-major applied to PR #55; confirmation comment posted
+3. PR #56 merges (unrelated, minor feature; no override label)
+   → handle_merged_pull_request for PR #56 (head: feat/ui-update)
+   → Reads labels from PR #56 → none
+   → next_version = 1.3.0 (minor from commits)
+   → orchestrate → release PR created at release/v1.3.0
+4. Release PR (head: release/v1.3.0) is merged into main
+   → handle_merged_pull_request for the release PR
+   → Normal orchestration runs
+   → Post-orchestration: search for open PRs with rr:override-* labels → finds PR #55
+   → Removes rr:override-major from PR #55
+   → Posts cleanup comment on PR #55
+5. PR #55 later merges (fix commit)
+   → handle_merged_pull_request reads labels from #55 → none (label was cleared)
+   → next_version = 1.3.1 (patch)
+   → orchestrate with 1.3.1 → no floor applied (correct)
+   (Contributor must re-post !release major if the work still warrants a major bump)
+```
+
+### Scenario: override lifts patch bump to major
+
+```
+1. Current released version: v1.2.3 (from latest semver tag)
+2. Contributor posts `!release major` on feature PR #55 (open, not yet merged)
+   → CommentCommandProcessor removes any existing rr:override-* labels from PR #55
+   → Applies `rr:override-major` label to PR #55
+   → Posts confirmation comment on PR #55
+3. PR #55 is merged (contains only a fix commit)
+   → handle_merged_pull_request reads labels from merged PR #55
+   → Finds rr:override-major
+   → Calculates next_version = 1.2.4 (patch from commits)
+   → Computes floor: next_major(1.2.3) = 2.0.0
+   → effective_version = max(1.2.4, 2.0.0) = 2.0.0
+   → Calls orchestrate(..., &2.0.0, ...)
+   → Orchestrator creates/renames release PR to release/v2.0.0
+   → Posts audit comment on the release PR
+   (PR #55 label needs no cleanup; it is now merged and closed)
+```
+
+### Scenario: PR with override is abandoned (no effect)
+
+```
+1. Current released version: v1.2.3
+2. Contributor posts `!release major` on PR #55
+   → rr:override-major applied to PR #55
+   → Confirmation comment posted on PR #55
+3. PR #55 is closed without merging
+   → No PullRequestMerged event fires
+   → rr:override-major on PR #55 is never read by orchestration
+   → PR #56 merges (unrelated, patch only)
+   → handle_merged_pull_request reads labels from PR #56 → none
+   → next_version = 1.2.4 (patch)
+   → orchestrate with 1.2.4 → no floor applied (correct)
+```
+
+### Scenario: existing release PR already at higher version
+
+```
+1. Current released version: v1.2.3
+2. A previous PR already raised the release PR to v2.0.0
+3. Contributor posts `!release major` on PR #66
+   → rr:override-major applied to PR #66
+4. PR #66 merges (fix commit)
+   → handle_merged_pull_request reads labels from #66 → rr:override-major
+   → next_version = 1.2.4 (patch from commits)
+   → floor = next_major(1.2.3) = 2.0.0
+   → effective_version = max(1.2.4, 2.0.0) = 2.0.0
+   → orchestrate: existing PR is already 2.0.0 → NoOp
+   → No audit comment needed (floor did not change effective_version vs existing PR)
+```
+
+### Scenario: `!set-version` on a feature PR is rejected
+
+```
+1. Contributor opens feature PR #70 (not a release PR; head branch = `feat/my-feature`)
+2. Contributor posts `!set-version 2.0.0` on PR #70
+   → CommentCommandProcessor checks: allow_override ✓, PR open ✓, Write access ✓
+   → Calls get_pull_request(owner, repo, 70) → head.ref_name = "feat/my-feature"
+   → "feat/my-feature" does not start with "release/v"
+   → Posts scope rejection comment on PR #70:
+     "⚠️ Release Regent: `!set-version` must be posted on the active release PR..."
+   → Event acknowledged; no orchestrator call; no PR modified
+```
+
+### Scenario: `!set-version` followed by a PR with an override label
+
+```
+1. Current released version: v1.2.3
+2. Contributor posts `!release major` on feature PR #55 → rr:override-major on #55
+3. Contributor posts `!set-version 1.5.0` on the release PR (head branch: release/v1.3.0)
+   → CommentCommandProcessor checks: allow_override ✓, PR open ✓, Write access ✓
+   → Calls get_pull_request(owner, repo, release_pr_number) → head.ref_name = "release/v1.3.0"
+   → "release/v1.3.0" starts with "release/v" ✓
+   → Validates: 1.5.0 > 1.2.3 ✓
+   → orchestrate(..., &1.5.0, ...) → release PR renamed to 1.5.0
+   (PR #55 still has rr:override-major; !set-version does not touch it)
+4. PR #55 is later merged (fix commit)
+   → handle_merged_pull_request reads labels from #55 → rr:override-major
+   → next_version = 1.5.1 (patch from #55 commits)
+   → floor = next_major(1.2.3) = 2.0.0
+   → effective_version = max(1.5.1, 2.0.0) = 2.0.0
+   → orchestrate: existing PR (1.5.0) < effective (2.0.0) → Renamed
+   → Audit comment posted on release PR
+```
+
+This is expected and consistent: each merge event re-evaluates the release version.
+
+## References
+
+- [ADR-003: PR Comment Commands](ADR-003-pr-comment-commands.md)
+- `docs/specs/requirements/functional-requirements.md` — DR-3, DR-4, DR-5
+- `docs/specs/requirements/user-stories.md` — US-4
+- `docs/specs/testing/behavioral-assertions.md` — BA-19 through BA-29
+- GitHub REST API: Labels on Issues/PRs — `POST /repos/{owner}/{repo}/issues/{issue_number}/labels`
+- GitHub REST API: Remove label — `DELETE /repos/{owner}/{repo}/issues/{issue_number}/labels/{name}`
+- Conventional Commits specification: <https://www.conventionalcommits.org/>

--- a/docs/specs/interfaces/bump_override_implementation.md
+++ b/docs/specs/interfaces/bump_override_implementation.md
@@ -1,0 +1,863 @@
+# Interface Specification: Bump-Override Implementation (ADR-004)
+
+**Status**: Ready for implementation
+**ADR**: [ADR-004](../../adr/ADR-004-bump-override-persistence.md)
+**Tasks**: 9.20.3, 9.20.4
+**Affected files**:
+
+- `crates/core/src/versioning.rs` — new `apply_bump_floor` function, new `SemanticVersion`
+  bump helpers
+- `crates/core/src/comment_command_processor.rs` — label constants, `!release` handler,
+  `!set-version` scope guard
+- `crates/core/src/lib.rs` — `handle_merged_pull_request` changes (feature PR path and
+  release PR path)
+
+---
+
+## 1. Constants — `comment_command_processor.rs`
+
+Define as `pub const` at module scope (after the public-type section, before the
+`CommentCommandProcessor` struct). Alphabetical ordering within the constants block.
+
+```rust
+/// Label applied to a feature PR when `!release major` is posted.
+///
+/// Consumed when the PR is merged to apply a major-version floor.
+pub const OVERRIDE_LABEL_MAJOR: &str = "rr:override-major";
+
+/// Label applied to a feature PR when `!release minor` is posted.
+///
+/// Consumed when the PR is merged to apply a minor-version floor.
+pub const OVERRIDE_LABEL_MINOR: &str = "rr:override-minor";
+
+/// Label applied to a feature PR when `!release patch` is posted.
+///
+/// Consumed when the PR is merged to apply a patch-version floor.
+pub const OVERRIDE_LABEL_PATCH: &str = "rr:override-patch";
+
+/// All three override label names, ordered major → minor → patch.
+///
+/// Used by cleanup logic in `handle_merged_pull_request` when a release PR
+/// merges: every open PR carrying any of these labels receives a cleanup
+/// comment and has the label removed.
+pub const ALL_OVERRIDE_LABELS: &[&str] = &[
+    OVERRIDE_LABEL_MAJOR,
+    OVERRIDE_LABEL_MINOR,
+    OVERRIDE_LABEL_PATCH,
+];
+```
+
+---
+
+## 2. `SemanticVersion` bump helpers — `versioning.rs`
+
+These are new methods on `SemanticVersion`. They must be inserted into the
+`impl SemanticVersion` block, sorted alphabetically with existing methods.
+
+```rust
+/// Compute the next major version (x+1.0.0), discarding pre-release and
+/// build metadata from the current version.
+///
+/// # Examples
+///
+/// ```
+/// use release_regent_core::versioning::SemanticVersion;
+///
+/// let v = SemanticVersion { major: 1, minor: 2, patch: 3,
+///                            prerelease: None, build: None };
+/// assert_eq!(v.next_major().to_string(), "2.0.0");
+///
+/// // Pre-release is discarded in the result.
+/// let pre = SemanticVersion { major: 1, minor: 0, patch: 0,
+///                              prerelease: Some("rc.1".to_string()), build: None };
+/// assert_eq!(pre.next_major().to_string(), "2.0.0");
+/// ```
+#[must_use]
+pub fn next_major(&self) -> SemanticVersion {
+    SemanticVersion {
+        major: self.major + 1,
+        minor: 0,
+        patch: 0,
+        prerelease: None,
+        build: None,
+    }
+}
+
+/// Compute the next minor version (x.y+1.0), discarding pre-release and
+/// build metadata from the current version.
+///
+/// # Examples
+///
+/// ```
+/// use release_regent_core::versioning::SemanticVersion;
+///
+/// let v = SemanticVersion { major: 1, minor: 2, patch: 3,
+///                            prerelease: None, build: None };
+/// assert_eq!(v.next_minor().to_string(), "1.3.0");
+/// ```
+#[must_use]
+pub fn next_minor(&self) -> SemanticVersion {
+    SemanticVersion {
+        major: self.major,
+        minor: self.minor + 1,
+        patch: 0,
+        prerelease: None,
+        build: None,
+    }
+}
+
+/// Compute the next patch version (x.y.z+1), discarding pre-release and
+/// build metadata from the current version.
+///
+/// # Examples
+///
+/// ```
+/// use release_regent_core::versioning::SemanticVersion;
+///
+/// let v = SemanticVersion { major: 1, minor: 2, patch: 3,
+///                            prerelease: None, build: None };
+/// assert_eq!(v.next_patch().to_string(), "1.2.4");
+/// ```
+#[must_use]
+pub fn next_patch(&self) -> SemanticVersion {
+    SemanticVersion {
+        major: self.major,
+        minor: self.minor,
+        patch: self.patch + 1,
+        prerelease: None,
+        build: None,
+    }
+}
+```
+
+---
+
+## 3. `apply_bump_floor` — `versioning.rs`
+
+Free function, exported at crate level via `pub`. Place in the free-functions section of
+`versioning.rs` (alphabetically, before `latest_semver_tag`).
+
+### Signature
+
+```rust
+/// Apply a minimum-bump floor to a calculated semantic version.
+///
+/// Computes the version that `floor` would produce from `current`
+/// (`current.next_major()`, `current.next_minor()`, or `current.next_patch()`),
+/// then returns whichever of `calculated` and `floor_version` is the greater
+/// according to semver precedence.
+///
+/// This is a pure function with no I/O and no side effects.
+///
+/// # Arguments
+///
+/// * `current` — the highest released version tag at the time the feature PR
+///   was merged (the baseline from which the floor is computed).
+/// * `calculated` — the version that conventional-commit analysis produced
+///   before any floor is applied.
+/// * `floor` — the minimum bump dimension requested via `!release`.
+///
+/// # Returns
+///
+/// `max(calculated, floor_version)` by semver precedence.
+///
+/// # Examples
+///
+/// ```
+/// use release_regent_core::comment_command_processor::BumpKind;
+/// use release_regent_core::versioning::{apply_bump_floor, SemanticVersion};
+///
+/// let current    = SemanticVersion { major: 1, minor: 2, patch: 3,
+///                                    prerelease: None, build: None };
+/// let calculated = SemanticVersion { major: 1, minor: 2, patch: 4, // patch bump
+///                                    prerelease: None, build: None };
+///
+/// // !release major → floor = 2.0.0, which is greater than 1.2.4.
+/// let effective = apply_bump_floor(&current, &calculated, BumpKind::Major);
+/// assert_eq!(effective.to_string(), "2.0.0");
+///
+/// // !release patch → floor = 1.2.4, which equals the calculated version.
+/// let effective = apply_bump_floor(&current, &calculated, BumpKind::Patch);
+/// assert_eq!(effective.to_string(), "1.2.4");
+///
+/// // If the conventional commits already force a higher version the floor
+/// // has no effect.
+/// let major_calc = SemanticVersion { major: 2, minor: 0, patch: 0,
+///                                    prerelease: None, build: None };
+/// let effective  = apply_bump_floor(&current, &major_calc, BumpKind::Minor);
+/// assert_eq!(effective.to_string(), "2.0.0");
+/// ```
+pub fn apply_bump_floor(
+    current: &SemanticVersion,
+    calculated: &SemanticVersion,
+    floor: BumpKind,
+) -> SemanticVersion {
+    use crate::comment_command_processor::BumpKind;
+    use std::cmp::Ordering;
+
+    let floor_version = match floor {
+        BumpKind::Major => current.next_major(),
+        BumpKind::Minor => current.next_minor(),
+        BumpKind::Patch => current.next_patch(),
+    };
+
+    match calculated.compare_precedence(&floor_version) {
+        Ordering::Less => floor_version,
+        _ => calculated.clone(),
+    }
+}
+```
+
+### Import note
+
+`apply_bump_floor` imports `BumpKind` from `crate::comment_command_processor`. The
+`versioning` module does not currently depend on `comment_command_processor`. The coder
+must add that import. Alternatively (and preferably, to avoid a cyclic dependency risk),
+the coder may move `BumpKind` to `versioning.rs` and re-export it from
+`comment_command_processor` using `pub use`. The current codebase has `BumpKind` in
+`comment_command_processor.rs`; if there is no cyclic dependency between the two modules,
+the import approach is acceptable.
+
+**Recommendation**: Move `BumpKind` to `versioning.rs` (it is a versioning concept, not
+a command-processing concept) and update the import in `comment_command_processor.rs` to
+`use crate::versioning::BumpKind;`. The public re-export from `comment_command_processor`
+preserves the existing public API without breakage.
+
+---
+
+## 4. `!release` handler — `CommentCommandProcessor` (task 9.20.3)
+
+### Location
+
+`crates/core/src/comment_command_processor.rs`
+
+Replace the stub `CommentCommand::ReleaseBump(_kind)` arm in `process_inner` with a full
+implementation. The new private helper `handle_release_bump` is called from that arm.
+
+### Updated match arm
+
+```rust
+CommentCommand::ReleaseBump(kind) => {
+    self.handle_release_bump(owner, repo, issue_number, kind, &event.event_id)
+        .await
+}
+```
+
+### New private method: `handle_release_bump`
+
+```rust
+/// Handle a validated `!release major|minor|patch` command.
+///
+/// Applies an `rr:override-*` label to the commented-upon PR to persist the
+/// minimum-bump intent until the PR is merged. Removes any previously applied
+/// override label first (idempotent removes, 404 is ignored).
+///
+/// Posts a confirmation comment indicating:
+/// - Whether this is a fresh override or a replacement.
+/// - The bump dimension recorded.
+/// - The effect at merge time.
+///
+/// # Guards
+///
+/// The guards (allow_override, PR open, commenter permission) have already
+/// been enforced by `process_inner` before this method is called.
+///
+/// # Errors
+///
+/// - `CoreError::GitHub` / `CoreError::Network` — a GitHub API call failed;
+///   propagated so the event loop can retry if transient.
+async fn handle_release_bump(
+    &self,
+    owner: &str,
+    repo: &str,
+    pr_number: u64,
+    kind: BumpKind,
+    event_id: &str,
+) -> CoreResult<()> {
+    let new_label = match kind {
+        BumpKind::Major => OVERRIDE_LABEL_MAJOR,
+        BumpKind::Minor => OVERRIDE_LABEL_MINOR,
+        BumpKind::Patch => OVERRIDE_LABEL_PATCH,
+    };
+
+    // Determine which (if any) override label was already applied.
+    let existing_labels = self
+        .github
+        .list_pr_labels(owner, repo, pr_number)
+        .await?;
+
+    let previous_kind: Option<BumpKind> = existing_labels.iter().find_map(|l| {
+        match l.name.as_str() {
+            OVERRIDE_LABEL_MAJOR => Some(BumpKind::Major),
+            OVERRIDE_LABEL_MINOR => Some(BumpKind::Minor),
+            OVERRIDE_LABEL_PATCH => Some(BumpKind::Patch),
+            _ => None,
+        }
+    });
+
+    // Remove all existing override labels (idempotent; ignore 404).
+    for label in ALL_OVERRIDE_LABELS {
+        if let Err(e) = self.github.remove_label(owner, repo, pr_number, label).await {
+            warn!(
+                event_id,
+                pr_number,
+                label,
+                error = %e,
+                "Failed to remove existing override label; continuing"
+            );
+        }
+    }
+
+    // Apply the new override label.
+    self.github
+        .add_labels(owner, repo, pr_number, &[new_label])
+        .await?;
+
+    info!(
+        event_id,
+        pr_number,
+        label = new_label,
+        "Override label applied"
+    );
+
+    // Post confirmation comment.
+    let kind_str = match kind {
+        BumpKind::Major => "major",
+        BumpKind::Minor => "minor",
+        BumpKind::Patch => "patch",
+    };
+    let body = if let Some(prev) = &previous_kind {
+        let old_kind_str = match prev {
+            BumpKind::Major => "major",
+            BumpKind::Minor => "minor",
+            BumpKind::Patch => "patch",
+        };
+        format!(
+            "✅ **Release Regent**: `!release {kind_str}` override recorded \
+             (replacing previous `!release {old_kind_str}` override). \
+             When this PR is merged, the next release version will be bumped \
+             by at least one {kind_str} increment."
+        )
+    } else {
+        format!(
+            "✅ **Release Regent**: `!release {kind_str}` override recorded. \
+             When this PR is merged, the next release version will be bumped \
+             by at least one {kind_str} increment."
+        )
+    };
+
+    self.post_comment(owner, repo, pr_number, &body).await
+}
+```
+
+---
+
+## 5. `!set-version` scope guard — `CommentCommandProcessor` (task 9.20.3)
+
+### Change summary
+
+Before invoking `resolve_current_version`, fetch the PR via `get_pull_request` and
+check that its `head.ref_name` starts with `"{branch_prefix}/v"`. If the branch pattern
+does not match, post a rejection comment and return `Ok(())`.
+
+This prevents `!set-version` from being accepted on feature branches, which would allow
+the override to be applied before the relevant work is merged and could create a stale
+release PR.
+
+### Guard code (insert at the top of `handle_set_version`, before `resolve_current_version`)
+
+```rust
+// Guard: !set-version is only accepted when posted on a release PR
+// (head branch must start with "{branch_prefix}/v", e.g. "release/v").
+// Posting on a feature PR would create a stale override for work that
+// may never be merged.
+let pr = self.github.get_pull_request(owner, repo, pr_number).await?;
+let release_branch_prefix = format!(
+    "{}/v",
+    self.config.orchestrator_config.branch_prefix
+);
+if !pr.head.ref_name.starts_with(&release_branch_prefix) {
+    let warning = format!(
+        "⚠️ **Release Regent**: `!set-version` must be posted on the active \
+         release PR (branch `{release_branch_prefix}*`). Please re-post this \
+         command on the release PR."
+    );
+    warn!(
+        pr_number,
+        head_ref = %pr.head.ref_name,
+        branch_prefix = %release_branch_prefix,
+        "Rejecting !set-version: not posted on a release PR branch"
+    );
+    return self.post_comment(owner, repo, pr_number, &warning).await;
+}
+```
+
+### Updated `handle_set_version` method signature (no change — same parameters)
+
+The PR retrieval for the scope guard replaces the existing `get_pull_request` call that
+currently appears later in the method (used to extract `base_branch` and `base_sha`).
+The coder should unify these into a single call: fetch the PR once at the top of
+`handle_set_version`, use it for the scope guard, then use the same `pr` value for
+`base_branch` and `base_sha` extraction. Remove the duplicate `get_pull_request` call.
+
+### Full updated callsite sketch
+
+```rust
+async fn handle_set_version(
+    &self,
+    owner: &str,
+    repo: &str,
+    pr_number: u64,
+    pinned_version: &SemanticVersion,
+    correlation_id: &str,
+) -> CoreResult<()> {
+    // --- NEW: fetch PR once; used for scope guard and branch extraction ---
+    let pr = self.github.get_pull_request(owner, repo, pr_number).await?;
+
+    // --- NEW: scope guard ---
+    let release_branch_prefix = format!(
+        "{}/v",
+        self.config.orchestrator_config.branch_prefix
+    );
+    if !pr.head.ref_name.starts_with(&release_branch_prefix) {
+        let warning = format!(
+            "⚠️ **Release Regent**: `!set-version` must be posted on the active \
+             release PR (branch `{release_branch_prefix}*`). Please re-post this \
+             command on the release PR."
+        );
+        warn!(
+            pr_number,
+            head_ref = %pr.head.ref_name,
+            "Rejecting !set-version: not on a release branch"
+        );
+        return self.post_comment(owner, repo, pr_number, &warning).await;
+    }
+
+    // --- EXISTING: version validation (unchanged) ---
+    let current_version = resolve_current_version(self.github, owner, repo, false).await?;
+    // ... (existing minimum-version checks) ...
+
+    info!(pr_number, pinned = %pinned_version, "!set-version accepted");
+
+    // --- EXISTING: reuse already-fetched PR for branch info (remove duplicate get_pull_request) ---
+    let base_branch = pr.base.ref_name.clone();
+    let base_sha = pr.base.sha.clone();
+
+    let orchestrator =
+        ReleaseOrchestrator::new(self.config.orchestrator_config.clone(), self.github);
+
+    orchestrator
+        .orchestrate(
+            owner,
+            repo,
+            pinned_version,
+            "Version pinned via PR comment override.",
+            &base_branch,
+            &base_sha,
+            correlation_id,
+        )
+        .await
+        .map(|_| ())
+}
+```
+
+---
+
+## 6. `handle_merged_pull_request` changes — `lib.rs` (task 9.20.4)
+
+### Affected method
+
+`ReleaseRegentProcessor::handle_merged_pull_request` in
+`crates/core/src/lib.rs`.
+
+### Branch detection
+
+The merged PR's head branch is read from:
+
+```rust
+let merged_pr_head_ref = event
+    .payload
+    .get("pull_request")
+    .and_then(|pr| pr.get("head"))
+    .and_then(|h| h.get("ref"))
+    .and_then(|v| v.as_str())
+    .unwrap_or_default()
+    .to_string();
+
+// "release/v" is the hardcoded detection prefix; the branch_prefix value
+// from OrchestratorConfig is "release" and the separator "/v" follows the
+// convention established in the ADR.
+let release_branch_prefix = format!(
+    "{}/v",
+    repo_config.release_pr.branch_prefix   // or construct from OrchestratorConfig
+);
+let is_release_pr = merged_pr_head_ref.starts_with(&release_branch_prefix);
+```
+
+> **Clarification**: `repo_config` does not currently expose `branch_prefix` directly;
+> the value is derived when constructing `OrchestratorConfig`. The coder should use the
+> same literal `"release/v"` pattern established throughout the codebase, or extract the
+> prefix from the same place it is passed to `OrchestratorConfig::branch_prefix`.
+
+The merged PR number for label lookup:
+
+```rust
+let merged_pr_number: u64 = event
+    .payload
+    .get("pull_request")
+    .and_then(|pr| pr.get("number"))
+    .and_then(serde_json::Value::as_u64)
+    .ok_or_else(|| {
+        CoreError::invalid_input(
+            "payload",
+            "PullRequestMerged payload is missing pull_request.number",
+        )
+    })?;
+```
+
+---
+
+### 6A. Feature PR path — apply bump floor
+
+Insert the following block **after** version calculation (`calc_result`) and **before**
+the `format_changelog_for_release` call.
+
+```rust
+// ── Bump-floor: read override label from the merged feature PR ──────────
+//
+// A collaborator may have posted `!release major|minor|patch` on this PR
+// before it was merged. That command applied an `rr:override-*` label to
+// the PR. We read that label here and, if present, raise the calculated
+// version to satisfy the requested minimum bump.
+let labels = self
+    .github_operations
+    .list_pr_labels(owner, repo, merged_pr_number)
+    .await?;
+
+let floor_kind: Option<BumpKind> = labels.iter().find_map(|l| {
+    use comment_command_processor::{BumpKind, OVERRIDE_LABEL_MAJOR, OVERRIDE_LABEL_MINOR, OVERRIDE_LABEL_PATCH};
+    match l.name.as_str() {
+        OVERRIDE_LABEL_MAJOR => Some(BumpKind::Major),
+        OVERRIDE_LABEL_MINOR => Some(BumpKind::Minor),
+        OVERRIDE_LABEL_PATCH => Some(BumpKind::Patch),
+        _ => None,
+    }
+});
+
+let effective_version = if let (Some(floor), Some(ref current)) = (floor_kind.as_ref(), &current_version) {
+    versioning::apply_bump_floor(current, &calc_result.next_version, floor.clone())
+} else {
+    calc_result.next_version.clone()
+};
+
+tracing::debug!(
+    owner = %owner,
+    repo = %repo,
+    calculated = %calc_result.next_version,
+    effective  = %effective_version,
+    floor      = ?floor_kind,
+    "Resolved effective release version after bump-floor check"
+);
+```
+
+Then pass `&effective_version` to orchestration instead of `&calc_result.next_version`:
+
+```rust
+orchestrator
+    .orchestrate(
+        owner,
+        repo,
+        &effective_version,   // ← was &calc_result.next_version
+        &changelog,
+        &base_branch,
+        &base_sha,
+        correlation_id,
+    )
+    .await
+```
+
+After the orchestration call returns, if the floor was applied post an audit comment on
+the release PR. The release PR number comes from the `OrchestratorResult`:
+
+```rust
+let orch_result = orchestrator
+    .orchestrate(
+        owner,
+        repo,
+        &effective_version,
+        &changelog,
+        &base_branch,
+        &base_sha,
+        correlation_id,
+    )
+    .await?;
+
+// Post floor-applied audit comment when the effective version differs.
+if effective_version != calc_result.next_version {
+    use comment_command_processor::BumpKind;
+    let kind_str = match floor_kind.as_ref().expect("floor_kind is Some when versions differ") {
+        BumpKind::Major => "major",
+        BumpKind::Minor => "minor",
+        BumpKind::Patch => "patch",
+    };
+    // Extract the release PR number from the orchestration result.
+    let release_pr_number: Option<u64> = match &orch_result {
+        release_orchestrator::OrchestratorResult::Created { pr, .. } => Some(pr.number),
+        release_orchestrator::OrchestratorResult::Updated { pr } => Some(pr.number),
+        release_orchestrator::OrchestratorResult::Renamed { pr } => Some(pr.number),
+        release_orchestrator::OrchestratorResult::NoOp { pr } => Some(pr.number),
+    };
+
+    if let Some(release_pr) = release_pr_number {
+        let audit_body = format!(
+            "🔼 **Release Regent**: Version floor applied from `!release {kind_str}` \
+             override on PR #{merged_pr_number}. The calculated version was \
+             `{calc}` but was raised to `{eff}` to satisfy the requested \
+             minimum {kind_str} bump.",
+            calc = calc_result.next_version,
+            eff  = effective_version,
+        );
+        if let Err(e) = self
+            .github_operations
+            .create_issue_comment(owner, repo, release_pr, &audit_body)
+            .await
+        {
+            tracing::warn!(
+                error = %e,
+                release_pr,
+                merged_pr = merged_pr_number,
+                "Failed to post bump-floor audit comment; continuing"
+            );
+        }
+    }
+}
+
+Ok(orch_result)
+```
+
+---
+
+### 6B. Release PR path — stale label cleanup
+
+After the orchestration call on the release PR path, run cleanup for every open feature
+PR that still carries an override label. Cleanup failures are `warn!`-logged and must
+**not** fail the event.
+
+```rust
+// ── Stale override cleanup ───────────────────────────────────────────────
+//
+// Now that a release has been published, any open feature PRs with
+// rr:override-* labels carry stale intent (the release cycle they were
+// meant to influence has already closed). Remove the labels and post an
+// explanatory comment so the PR author knows they need to re-post their
+// `!release` command if the work still warrants a minimum bump in the
+// next release.
+use comment_command_processor::ALL_OVERRIDE_LABELS;
+
+for &label_name in ALL_OVERRIDE_LABELS {
+    let query = format!("is:open label:{label_name}");
+    match self
+        .github_operations
+        .search_pull_requests(owner, repo, &query)
+        .await
+    {
+        Ok(stale_prs) => {
+            for stale_pr in stale_prs {
+                // Remove the override label (idempotent).
+                if let Err(e) = self
+                    .github_operations
+                    .remove_label(owner, repo, stale_pr.number, label_name)
+                    .await
+                {
+                    tracing::warn!(
+                        error = %e,
+                        pr = stale_pr.number,
+                        label = label_name,
+                        "Failed to remove stale override label; continuing"
+                    );
+                }
+
+                // Determine bump dimension for the comment.
+                let kind_str = label_name
+                    .strip_prefix("rr:override-")
+                    .unwrap_or(label_name);
+
+                let cleanup_body = format!(
+                    "ℹ️ **Release Regent**: The `!release {kind_str}` override on \
+                     this PR has been cleared because a new release was published \
+                     before this PR merged. If the work in this PR still warrants \
+                     a minimum bump for the next release, please re-post your \
+                     `!release` command."
+                );
+
+                if let Err(e) = self
+                    .github_operations
+                    .create_issue_comment(owner, repo, stale_pr.number, &cleanup_body)
+                    .await
+                {
+                    tracing::warn!(
+                        error = %e,
+                        pr = stale_pr.number,
+                        "Failed to post stale-override cleanup comment; continuing"
+                    );
+                }
+            }
+        }
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                label = label_name,
+                "Failed to search for PRs with stale override label; continuing"
+            );
+        }
+    }
+}
+```
+
+### 6C. Complete updated control flow sketch for `handle_merged_pull_request`
+
+```
+handle_merged_pull_request(event)
+│
+├── extract base_branch, base_sha, merged_pr_head_ref, merged_pr_number
+├── load repo_config
+├── resolve current_version from tags
+│
+├── build VersionContext, strategy, options
+├── calculate calc_result (next_version + changelog entries)
+├── format_changelog_for_release → changelog string
+│
+├── if is_release_pr (merged_pr_head_ref.starts_with("release/v"))
+│   │
+│   ├── build OrchestratorConfig, orchestrator
+│   ├── orchestrate(…, &calc_result.next_version, …) → orch_result
+│   │
+│   └── stale label cleanup [6B]
+│       └── for each label in ALL_OVERRIDE_LABELS:
+│           ├── search_pull_requests("is:open label:{label}")
+│           └── for each found PR:
+│               ├── remove_label (warn on error, continue)
+│               └── create_issue_comment cleanup msg (warn on error, continue)
+│
+└── else (feature PR path)
+    │
+    ├── list_pr_labels(merged_pr_number) → labels
+    ├── find floor_kind from labels
+    ├── compute effective_version = apply_bump_floor or calc_result.next_version
+    │
+    ├── build OrchestratorConfig, orchestrator
+    ├── orchestrate(…, &effective_version, …) → orch_result
+    │
+    └── if effective_version != calc_result.next_version:
+        └── create_issue_comment floor audit comment on release PR (warn on error)
+```
+
+---
+
+## 7. `BumpKind` placement (cross-cutting concern)
+
+`BumpKind` is currently defined in `comment_command_processor.rs`. It is used by both
+`comment_command_processor.rs` (to dispatch commands) and `versioning.rs` (in
+`apply_bump_floor`). To avoid a cyclic module dependency:
+
+**Recommended move**: Relocate `BumpKind` to `versioning.rs`. Add a re-export in
+`comment_command_processor.rs`:
+
+```rust
+// In comment_command_processor.rs
+pub use crate::versioning::BumpKind;
+```
+
+This keeps the public API stable and makes the semantic home of `BumpKind` clear (it
+represents a versioning concept). The coder must update all import paths accordingly.
+
+---
+
+## 8. Structured-logging fields reference
+
+All new log events must use structured fields. Mandatory fields per log site:
+
+| Emitter | Required fields |
+|---|---|
+| `handle_release_bump` start | `event_id`, `pr_number`, `label` |
+| `handle_release_bump` remove existing label | `event_id`, `pr_number`, `label`, `error` (on warn) |
+| `handle_release_bump` apply new label | `event_id`, `pr_number`, `label` |
+| `handle_set_version` scope-guard rejection | `pr_number`, `head_ref`, `branch_prefix` |
+| `handle_merged_pull_request` floor debug | `owner`, `repo`, `calculated`, `effective`, `floor` |
+| `handle_merged_pull_request` floor audit comment failure | `error`, `release_pr`, `merged_pr` |
+| `handle_merged_pull_request` stale cleanup — search failure | `error`, `label` |
+| `handle_merged_pull_request` stale cleanup — remove failure | `error`, `pr`, `label` |
+| `handle_merged_pull_request` stale cleanup — comment failure | `error`, `pr` |
+
+---
+
+## 9. Test scenarios required (for coder reference)
+
+### `apply_bump_floor` (unit tests in `versioning_tests.rs`)
+
+| Scenario | Input | Expected |
+|---|---|---|
+| Floor raises patch → major | current=1.2.3, calc=1.2.4, floor=Major | 2.0.0 |
+| Floor raises patch → minor | current=1.2.3, calc=1.2.4, floor=Minor | 1.3.0 |
+| Floor has no effect (calc already exceeds) | current=1.2.3, calc=2.0.0, floor=Minor | 2.0.0 |
+| Floor equals calculated | current=1.2.3, calc=1.2.4, floor=Patch | 1.2.4 |
+| Floor with pre-release current version | current=2.0.0-rc.1, calc=2.0.0, floor=Major | 3.0.0 |
+
+### `handle_release_bump` (unit tests in `comment_command_processor_tests.rs`)
+
+| Scenario | Expected |
+|---|---|
+| Fresh `!release major` — no existing label | Applies `rr:override-major`; posts fresh confirmation |
+| Replacing `!release minor` with `!release major` | Removes `rr:override-minor`, applies `rr:override-major`; posts replacing confirmation |
+| Same override reposted (`!release patch` again) | Removes, re-applies `rr:override-patch`; posts replacing confirmation |
+| `allow_override = false` | Silently ignored (existing guard) |
+| Commenter lacks write permission | Rejection posted (existing guard) |
+| `add_labels` API fails | `CoreError::GitHub` propagated |
+| `remove_label` fails with network error | `warn!` logged; `add_labels` still called |
+
+### `handle_set_version` scope guard (unit tests in `comment_command_processor_tests.rs`)
+
+| Scenario | Expected |
+|---|---|
+| PR on `release/v1.2.3` branch | Guard passes; proceeds to version validation |
+| PR on `feature/my-feature` branch | Rejection comment posted; `Ok(())` returned |
+| PR on `release/some-branch` (no `/v`) | Rejection comment posted; `Ok(())` returned |
+| `branch_prefix = "hotfix"` and PR on `hotfix/v2.0.0` | Guard passes |
+
+### `handle_merged_pull_request` feature-PR path (unit tests in `lib_tests.rs`)
+
+| Scenario | Expected |
+|---|---|
+| Merged PR has `rr:override-major`, calc is minor | `effective = major`; audit comment posted on release PR |
+| Merged PR has `rr:override-patch`, calc is minor | `effective = minor` (floor has no effect); no audit comment |
+| Merged PR has no override labels | `effective = calc`; no audit comment |
+| `list_pr_labels` fails | `CoreError::GitHub` propagated; event retried |
+| Audit comment posting fails | `warn!` logged; `Ok(orch_result)` returned |
+
+### `handle_merged_pull_request` release-PR path (unit tests in `lib_tests.rs`)
+
+| Scenario | Expected |
+|---|---|
+| No open PRs with override labels | No cleanup calls |
+| One open PR with `rr:override-major` | Label removed; cleanup comment posted |
+| Two open PRs with different override labels | Both cleaned up |
+| `search_pull_requests` fails for one label | `warn!` logged; other labels still processed |
+| `remove_label` fails for one PR | `warn!` logged; cleanup comment still attempted |
+| Cleanup comment fails | `warn!` logged; event still succeeds |
+
+---
+
+## 10. Compilation checklist
+
+Before merging the implementation:
+
+- [ ] `cargo check` passes with no errors
+- [ ] `cargo clippy -- -D warnings` passes (pedantic lints active)
+- [ ] All new public items have `///` doc comments with `# Examples` where applicable
+- [ ] No `unwrap()` or `expect()` in production paths
+- [ ] `BumpKind` placement resolved (either moved to `versioning.rs` + re-exported, or
+      import direction verified as acyclic)
+- [ ] `next_major`, `next_minor`, `next_patch` marked `#[must_use]`
+- [ ] `apply_bump_floor` marked `#[must_use]`
+- [ ] Tracing spans and structured fields present for all new code paths
+- [ ] Tests cover all scenarios in section 9

--- a/docs/specs/interfaces/github_operations_additions.md
+++ b/docs/specs/interfaces/github_operations_additions.md
@@ -1,0 +1,518 @@
+# Interface Additions: `GitHubOperations` — ADR-004 bump-override support
+
+**Status**: Ready for implementation
+**ADR**: [ADR-004](../../adr/ADR-004-bump-override-persistence.md)
+**Layer**: Core domain — `crates/core/src/traits/github_operations.rs`
+**Tasks**: 9.20.2
+
+---
+
+## Overview
+
+This document specifies the three new methods added to the `GitHubOperations` trait and
+the new `Label` data type required by the bump-override feature. It also describes the
+extension to the existing `search_pull_requests` method.
+
+These interfaces are consumed by:
+
+- `CommentCommandProcessor::handle_release_bump` — applies/removes override labels
+- `ReleaseRegentProcessor::handle_merged_pull_request` — reads labels on the merged PR
+  and cleans up stale labels after a release PR merges
+
+---
+
+## 1. New type: `Label`
+
+Added alongside the other data types in `github_operations.rs`.
+
+```rust
+/// A GitHub label applied to an issue or pull request.
+///
+/// Returned by [`GitHubOperations::list_pr_labels`].
+///
+/// # GitHub API reference
+///
+/// `GET /repos/{owner}/{repo}/issues/{issue_number}/labels`
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Label {
+    /// GitHub's internal numeric label identifier.
+    pub id: u64,
+    /// Display name of the label (e.g. `"rr:override-major"`).
+    pub name: String,
+    /// Six-character hex colour code without the leading `#` (e.g. `"e11d48"`).
+    pub color: String,
+    /// Optional human-readable description of the label's purpose.
+    pub description: Option<String>,
+}
+```
+
+### Placement
+
+Insert `Label` alphabetically with the other structs in the data-types section of
+`github_operations.rs` (after `GitUser`, before `PullRequest`).
+
+---
+
+## 2. New trait method: `add_labels`
+
+### Signature
+
+```rust
+/// Add one or more labels to an issue or pull request.
+///
+/// The operation is idempotent: if a label is already present on the
+/// issue/PR it is **not** added a second time and no error is returned.
+///
+/// # Parameters
+/// - `owner`: Repository owner name
+/// - `repo`: Repository name
+/// - `issue_number`: Issue or pull request number
+/// - `labels`: Slice of label name strings to add
+///
+/// # Returns
+/// `Ok(())` on success (whether or not labels were already present).
+///
+/// # Errors
+/// - `CoreError::NotFound` — the issue/PR does not exist
+/// - `CoreError::GitHub` — the API call failed for any other reason
+///
+/// # GitHub API
+///
+/// `POST /repos/{owner}/{repo}/issues/{issue_number}/labels`
+///
+/// JSON body: `{ "labels": ["rr:override-major"] }`
+///
+/// GitHub returns `200 OK` with the full updated label list. A 404 means
+/// the issue/PR does not exist and must be surfaced as `CoreError::NotFound`.
+/// An attempt to add a label that does not exist in the repository returns
+/// `422 Unprocessable Entity`; callers must create labels before use.
+async fn add_labels(
+    &self,
+    owner: &str,
+    repo: &str,
+    issue_number: u64,
+    labels: &[&str],
+) -> CoreResult<()>;
+```
+
+### Idempotency contract
+
+The GitHub Labels API returns the full label list on success regardless of duplicates.
+Implementations **must not** return an error when a label is already applied.
+
+---
+
+## 3. New trait method: `remove_label`
+
+### Signature
+
+```rust
+/// Remove a single label from an issue or pull request.
+///
+/// The operation is idempotent: if the label is not present (GitHub returns
+/// `404 Not Found` for the label resource), `Ok(())` is returned rather
+/// than an error.
+///
+/// # Parameters
+/// - `owner`: Repository owner name
+/// - `repo`: Repository name
+/// - `issue_number`: Issue or pull request number
+/// - `label_name`: Exact name of the label to remove
+///
+/// # Returns
+/// `Ok(())` on success or when the label is not currently applied.
+///
+/// # Errors
+/// - `CoreError::NotFound` — the issue/PR itself does not exist (PR 404, not
+///   label 404; distinguish via the response body or endpoint).
+/// - `CoreError::GitHub` — the API call failed for any other reason.
+///
+/// # GitHub API
+///
+/// `DELETE /repos/{owner}/{repo}/issues/{issue_number}/labels/{name}`
+///
+/// - `204 No Content` — label removed successfully.
+/// - `404 Not Found` — label is not on the issue/PR; treat as `Ok(())`.
+/// - `410 Gone` — the issue/PR itself no longer exists; map to
+///   `CoreError::NotFound`.
+///
+/// # Implementation note
+///
+/// Percent-encode the label name in the URL path segment. The colon in
+/// `rr:override-major` must be encoded as `%3A`.
+async fn remove_label(
+    &self,
+    owner: &str,
+    repo: &str,
+    issue_number: u64,
+    label_name: &str,
+) -> CoreResult<()>;
+```
+
+### 404 ambiguity
+
+GitHub uses `404` for both "label not on this PR" and "PR does not exist". The
+implementation **must** distinguish these cases — typically by inspecting the
+response body or by checking whether the PR exists beforehand. Only a "PR does
+not exist" 404 should map to `CoreError::NotFound`; a "label not present" 404
+must return `Ok(())`.
+
+---
+
+## 4. New trait method: `list_pr_labels`
+
+### Signature
+
+```rust
+/// Return all labels currently applied to an issue or pull request.
+///
+/// Used by [`ReleaseRegentProcessor::handle_merged_pull_request`] to read
+/// any `rr:override-*` labels from the merged feature PR before version
+/// calculation.
+///
+/// # Parameters
+/// - `owner`: Repository owner name
+/// - `repo`: Repository name
+/// - `issue_number`: Issue or pull request number
+///
+/// # Returns
+/// All labels on the issue/PR, or an empty `Vec` when none are applied.
+///
+/// # Errors
+/// - `CoreError::NotFound` — the issue/PR does not exist
+/// - `CoreError::GitHub` — the API call failed for any other reason
+///
+/// # GitHub API
+///
+/// `GET /repos/{owner}/{repo}/issues/{issue_number}/labels`
+///
+/// Returns a JSON array of label objects. An empty array is a valid response
+/// and must be returned as `Ok(vec![])`.
+async fn list_pr_labels(
+    &self,
+    owner: &str,
+    repo: &str,
+    issue_number: u64,
+) -> CoreResult<Vec<Label>>;
+```
+
+---
+
+## 5. Extension to existing `search_pull_requests`
+
+The existing `search_pull_requests` method signature is unchanged. However, its
+documented set of supported qualifiers must be extended with `label:NAME`.
+
+### Updated doc comment addition
+
+Append to the method's existing `Supports a subset of GitHub search qualifiers` list:
+
+```
+/// - `label:NAME` — filter PRs that carry the named label
+```
+
+### Behavioural contract
+
+When a `label:NAME` token is present in the query string, the method must return only
+pull requests that currently have a label whose `name` field equals `NAME` exactly
+(case-sensitive, matching GitHub's behaviour).
+
+A query may combine `label:` with other qualifiers:
+
+```
+is:open label:rr:override-major
+```
+
+### Usage in cleanup
+
+After a release PR merges, `handle_merged_pull_request` calls:
+
+```rust
+// For each label name in ALL_OVERRIDE_LABELS:
+github.search_pull_requests(
+    owner,
+    repo,
+    &format!("is:open label:{label_name}"),
+).await?
+```
+
+The mock implementation must filter the pre-configured pull request list using this
+qualifier. See the mock section below.
+
+---
+
+## 6. `MockGitHubOperations` additions
+
+File: `crates/testing/src/mocks/github_operations.rs`
+
+### Struct fields to add
+
+```rust
+/// Per-repository label data keyed `"owner/repo/issue_number"`.
+///
+/// `list_pr_labels` returns the value for the matching key.
+/// `add_labels` and `remove_label` operations update this map at runtime
+/// (tests can chain `with_pr_labels` to seed initial state).
+pr_labels: HashMap<String, Vec<Label>>,
+
+/// Configurable per-method error overrides.
+///
+/// Key: method name (e.g. `"add_labels"`).
+/// Value: `CoreError` to return instead of the normal result.
+///
+/// Populated via `with_method_error`.
+method_errors: HashMap<String, String>,
+```
+
+### Builder methods to add
+
+```rust
+/// Pre-populate labels for a specific issue/PR.
+///
+/// `key` is formatted as `"{owner}/{repo}/{issue_number}"`.
+/// Call this before the test to seed the label state the mock will return.
+pub fn with_pr_labels(
+    mut self,
+    owner: &str,
+    repo: &str,
+    issue_number: u64,
+    labels: Vec<Label>,
+) -> Self {
+    let key = format!("{owner}/{repo}/{issue_number}");
+    self.pr_labels.insert(key, labels);
+    self
+}
+
+/// Configure a specific method to return an error.
+///
+/// Useful for simulating partial failures (e.g. `remove_label` fails while
+/// other operations succeed) without enabling global failure simulation.
+///
+/// `method_name` must exactly match the method name string used internally
+/// (e.g. `"add_labels"`, `"remove_label"`, `"list_pr_labels"`).
+pub fn with_method_error(mut self, method_name: &str, error_message: &str) -> Self {
+    self.method_errors
+        .insert(method_name.to_string(), error_message.to_string());
+    self
+}
+```
+
+### `add_labels` mock implementation
+
+```rust
+async fn add_labels(
+    &self,
+    owner: &str,
+    repo: &str,
+    issue_number: u64,
+    labels: &[&str],
+) -> CoreResult<()> {
+    let method = "add_labels";
+    let params_str = format!(
+        "owner={owner}, repo={repo}, issue={issue_number}, labels={labels:?}"
+    );
+
+    self.check_quota().await?;
+    self.simulate_latency().await;
+
+    if self.should_simulate_failure().await {
+        let error = CoreError::network("Simulated GitHub API error");
+        self.record_call(method, &params_str, CallResult::Error(error.to_string()))
+            .await;
+        return Err(error);
+    }
+
+    // Check per-method error override.
+    if let Some(msg) = self.method_errors.get(method) {
+        let error = CoreError::github(msg.clone());
+        self.record_call(method, &params_str, CallResult::Error(error.to_string()))
+            .await;
+        return Err(error);
+    }
+
+    // Idempotent: add only labels not yet present.
+    let key = format!("{owner}/{repo}/{issue_number}");
+    // NOTE: because &self is an immutable reference the mock cannot mutate
+    // pr_labels here without interior mutability. Tests that need to verify
+    // the post-add state should use a Mutex-wrapped or Arc<RwLock<_>>.
+    // For call-recording purposes the test should inspect call_history().
+
+    self.record_call(method, &params_str, CallResult::Success)
+        .await;
+    Ok(())
+}
+```
+
+> **Interior-mutability note**: The existing `MockGitHubOperations` uses `&self` for all
+> `GitHubOperations` methods (the trait requires `&self`). The `pr_labels` map therefore
+> needs `Arc<RwLock<HashMap<…>>>` (matching the pattern already used for `state`) if
+> runtime mutation is needed. The coder must decide whether to make the field a shared
+> interior-mutable store or document that `add_labels`/`remove_label` are recorded but
+> the in-memory label state is not mutated (tests seed state up-front with
+> `with_pr_labels`). Either approach is acceptable; the latter is simpler and consistent
+> with how `create_branch` is handled today.
+
+### `remove_label` mock implementation
+
+```rust
+async fn remove_label(
+    &self,
+    owner: &str,
+    repo: &str,
+    issue_number: u64,
+    label_name: &str,
+) -> CoreResult<()> {
+    let method = "remove_label";
+    let params_str =
+        format!("owner={owner}, repo={repo}, issue={issue_number}, label={label_name}");
+
+    self.check_quota().await?;
+    self.simulate_latency().await;
+
+    if self.should_simulate_failure().await {
+        let error = CoreError::network("Simulated GitHub API error");
+        self.record_call(method, &params_str, CallResult::Error(error.to_string()))
+            .await;
+        return Err(error);
+    }
+
+    if let Some(msg) = self.method_errors.get(method) {
+        let error = CoreError::github(msg.clone());
+        self.record_call(method, &params_str, CallResult::Error(error.to_string()))
+            .await;
+        return Err(error);
+    }
+
+    // Idempotent: not-found is Ok(()).
+    self.record_call(method, &params_str, CallResult::Success)
+        .await;
+    Ok(())
+}
+```
+
+### `list_pr_labels` mock implementation
+
+```rust
+async fn list_pr_labels(
+    &self,
+    owner: &str,
+    repo: &str,
+    issue_number: u64,
+) -> CoreResult<Vec<Label>> {
+    let method = "list_pr_labels";
+    let params_str = format!("owner={owner}, repo={repo}, issue={issue_number}");
+
+    self.check_quota().await?;
+    self.simulate_latency().await;
+
+    if self.should_simulate_failure().await {
+        let error = CoreError::network("Simulated GitHub API error");
+        self.record_call(method, &params_str, CallResult::Error(error.to_string()))
+            .await;
+        return Err(error);
+    }
+
+    if let Some(msg) = self.method_errors.get(method) {
+        let error = CoreError::github(msg.clone());
+        self.record_call(method, &params_str, CallResult::Error(error.to_string()))
+            .await;
+        return Err(error);
+    }
+
+    let key = format!("{owner}/{repo}/{issue_number}");
+    let labels = self.pr_labels.get(&key).cloned().unwrap_or_default();
+
+    self.record_call(method, &params_str, CallResult::Success)
+        .await;
+    Ok(labels)
+}
+```
+
+### Extension to `search_pull_requests` mock
+
+Extend the existing qualifier-parsing loop to handle `label:`:
+
+```rust
+// Inside the existing search_pull_requests implementation, add to the
+// for token in query.split_whitespace() loop:
+} else if let Some(l) = token.strip_prefix("label:") {
+    label_filter = Some(l.to_string());
+}
+```
+
+Add a `label_filter: Option<String>` variable alongside the existing `state_filter`,
+`head_filter`, and `base_filter`. Apply the filter in the iterator chain:
+
+```rust
+.filter(|pr| {
+    label_filter.as_ref().map_or(true, |label_name| {
+        let key = format!("{owner}/{repo}/{}", pr.number);
+        self.pr_labels
+            .get(&key)
+            .map_or(false, |labels| labels.iter().any(|l| l.name == *label_name))
+    })
+})
+```
+
+---
+
+## 7. Trait method ordering
+
+Per the project's element-ordering convention, methods in `GitHubOperations` are in
+alphabetical order. The new methods sort as follows in the full alphabetical list:
+
+| Position | Method |
+|---|---|
+| … | `create_branch` |
+| … | `create_issue_comment` |
+| … | `create_pull_request` |
+| … | `create_release` |
+| … | `create_tag` |
+| … | `delete_branch` |
+| … | `get_collaborator_permission` |
+| … | `get_latest_release` |
+| … | `get_pull_request` |
+| … | `get_release_by_tag` |
+| **NEW** | `add_labels` — insert before `create_branch` |
+| **NEW** | `list_pr_labels` — insert before `list_pull_requests` |
+| … | `list_pull_requests` |
+| … | `list_releases` |
+| **NEW** | `remove_label` — insert before `search_pull_requests` |
+| … | `search_pull_requests` |
+| … | `update_pull_request` |
+| … | `update_release` |
+
+---
+
+## 8. Error mapping guidance for `github_client` implementation
+
+| HTTP status | Condition | Map to |
+|---|---|---|
+| `200 OK` | `add_labels` success | `Ok(())` |
+| `204 No Content` | `remove_label` success | `Ok(())` |
+| `404 Not Found` (label absent) | `remove_label` | `Ok(())` — idempotent |
+| `404 Not Found` (issue/PR absent) | any method | `CoreError::NotFound` |
+| `422 Unprocessable Entity` | `add_labels` with unknown label | `CoreError::GitHub` — label must be created first |
+| `4xx` other | any method | `CoreError::GitHub` |
+| `5xx` | any method | `CoreError::GitHub` (retryable) |
+| network error | any method | `CoreError::Network` |
+
+---
+
+## 9. Test scenarios required (for coder reference)
+
+The coder must provide unit tests (in the existing `github_operations_tests.rs` file in
+the testing crate) covering at minimum:
+
+| Scenario | Method | Expected |
+|---|---|---|
+| Add single label — not yet applied | `add_labels` | `Ok(())` |
+| Add label already applied | `add_labels` | `Ok(())` (idempotent) |
+| Add multiple labels | `add_labels` | `Ok(())` |
+| Remove label present | `remove_label` | `Ok(())` |
+| Remove label not present (404) | `remove_label` | `Ok(())` (idempotent) |
+| List labels — none | `list_pr_labels` | `Ok(vec![])` |
+| List labels — multiple | `list_pr_labels` | `Ok([...])` |
+| Search with `label:rr:override-major` | `search_pull_requests` | Filtered by label |
+| Search `is:open label:rr:override-minor` | `search_pull_requests` | Filtered by state AND label |
+| Failure simulation | all new methods | `CoreError::Network` |

--- a/docs/specs/requirements/functional-requirements.md
+++ b/docs/specs/requirements/functional-requirements.md
@@ -224,7 +224,94 @@
 - All versions must follow semantic versioning specification
 - Next version must be higher than current version
 - Pre-release versions must include appropriate identifiers
-- Version overrides must be explicitly higher than calculated versions
+- `!set-version` overrides must specify a version strictly greater than the current released version
+- `!release` bump-floor overrides raise the effective version to at least the specified bump kind;
+  they never lower a version that conventional commits have already calculated to be higher
+
+### DR-4: PR Comment Commands
+
+**Requirement**: Accept and process version-override commands posted as PR comments.
+
+**Recognised Commands**:
+
+| Command | Effect |
+|---------|--------|
+| `!set-version X.Y.Z` | Only valid on the active release PR (head branch `release/v*`); pins the next release to exactly version `X.Y.Z` and invokes the release orchestrator immediately |
+| `!release major` | Applies a minimum-bump floor label (`rr:override-major`) to the PR the comment was posted on; the floor is evaluated when that PR is merged |
+| `!release minor` | Applies `rr:override-minor` to the commented-upon PR |
+| `!release patch` | Applies `rr:override-patch` to the commented-upon PR |
+
+**Processing Guards**:
+
+- Commands are only processed when `VersioningConfig::allow_override = true`
+- Commenter must have `Write`, `Maintain`, or `Admin` permission on the repository;
+  commands from users with insufficient permission produce a `❌` rejection comment
+  identifying the commenter and explaining the permission requirement
+- Commands on closed or merged PRs are silently ignored
+- `!set-version` is only accepted when posted on the active release PR (head branch
+  matching `release/v*`); if posted on any other open PR, a scope rejection comment is
+  posted and the event is acknowledged without modifying any PR
+
+**Persistence of `!release` overrides**:
+
+- The override label is applied to the **commented-upon PR** (the feature PR), not to
+  the release PR
+- When a PR carrying an `rr:override-*` label is merged (`PullRequestMerged`), the
+  floor is read from that PR and applied during orchestration
+- If the PR is closed without merging, the label remains on the closed PR and is never
+  consumed — it has no effect on future merges
+- **When the release PR is merged** (head branch `release/v*`), all open PRs bearing
+  `rr:override-*` labels have those labels removed and receive an informational comment
+  explaining that the override was cleared because a release was published. Overrides are
+  scoped to one release cycle; contributors must re-post `!release` if the intent still
+  applies to the next release.
+- Posting a new `!release` command on the same PR replaces the previous override label
+- Operators may cancel an override early by manually removing the `rr:override-*` label
+  from the feature PR in the GitHub UI
+
+**Audit trail**:
+
+- A **confirmation comment** is posted on the feature PR when an override label is
+  recorded, explaining the intent and its scope
+- An **audit comment** is posted on the **release PR** when a floor is actually applied
+  during orchestration, identifying the source PR and explaining the version change
+- A **cleanup comment** is posted on each open feature PR whose override label is cleared
+  when a release PR merges, explaining that the override was scoped to the completed
+  release cycle and instructing the contributor to re-post if still needed
+
+**Validation Rules**:
+
+- `!set-version` version string must be valid semver and strictly greater than the
+  current released version (`>= 0.0.1` when no released version exists); `!set-version`
+  must be posted on the release PR or it is rejected with a scope rejection comment
+- `!release` bump kind must be one of `major`, `minor`, or `patch` (case-insensitive)
+
+### DR-5: Override Floor Computation
+
+**Requirement**: When a `rr:override-*` label is present on the merged PR, compute the
+effective version as the maximum of the conventionally-calculated version and the floor
+version.
+
+**Computation**:
+
+Given `current_version` (latest semver tag) and `calculated_version` (from conventional
+commits on the merged PR):
+
+- `rr:override-major` floor → `floor_version = current_version.next_major()`
+- `rr:override-minor` floor → `floor_version = current_version.next_minor()`
+- `rr:override-patch` floor → `floor_version = current_version.next_patch()`
+- `effective_version = max(calculated_version, floor_version)`
+
+**Precedence Rules**:
+
+1. The floor is a minimum — it can never reduce a version that conventional commits have
+   computed to be higher
+2. `BREAKING CHANGE:` commits always produce a major increment regardless of floor
+3. `!set-version` is restricted to the release PR: it invokes the orchestrator with a
+   specific version immediately when posted on a `release/v*` branch PR; it is rejected
+   with a scope rejection comment when posted on any other PR; any `rr:override-*`
+   labels on other open PRs are unaffected and will still apply their floors when those
+   PRs eventually merge
 
 ## Integration Requirements
 

--- a/docs/specs/requirements/user-stories.md
+++ b/docs/specs/requirements/user-stories.md
@@ -104,13 +104,49 @@
 
 **Acceptance Criteria**:
 
-- Comment with version specification updates the PR
-- Only valid semantic versions accepted
-- Override version must be higher than current version
-- Override triggers full PR update with new version
+**`!set-version X.Y.Z` (explicit pin):**
+
+- A comment containing `!set-version X.Y.Z` on the **active release PR** (head branch
+  matching `release/v*`) updates that release PR to exactly version `X.Y.Z`
+- If the command is posted on any other open PR, a scope rejection comment is posted
+  explaining that `!set-version` must be re-posted on the release PR; no PR is modified
+- Only valid semantic version strings are accepted; malformed strings produce a rejection comment
+- The specified version must be strictly greater than the current released version (latest
+  semver tag); violations produce a rejection comment with the reason
+- Only collaborators with Write access or above may issue commands
+
+**`!release major|minor|patch` (bump-floor override):**
+
+- A comment containing `!release major`, `!release minor`, or `!release patch` applies a
+  `rr:override-major/minor/patch` label to the **PR the comment was posted on** (the feature PR)
+- A confirmation comment is posted on the feature PR confirming the override and its scope
+- When the feature PR is **merged**, the override label is read from that PR and used as a
+  minimum-bump floor during orchestration: `effective_version = max(calculated_version, floor_version)`
+- If the feature PR is **closed without merging**, the label remains on the closed PR and
+  has no effect on any future merges — version decisions are only made based on merged work
+- When the **release PR is merged** (a release is published), any `rr:override-*` labels
+  on open feature PRs are **automatically cleared** and each affected PR receives an
+  informational comment. Overrides are valid for one release cycle only; contributors must
+  re-post `!release` if the intent still applies to the next release.
+- Posting a new `!release` command on the same PR replaces the previous override label
+  and posts an updated confirmation comment
+- The floor is applied as a minimum; it can never reduce a version that conventional
+  commits have computed to be higher
+- A `BREAKING CHANGE:` commit always produces a major bump and cannot be reduced by a
+  `!release minor` or `!release patch` override
+- When a floor is applied during orchestration, an audit comment is posted on the release
+  PR identifying the source feature PR and the version change
+
+**General:**
+
+- Commands are only processed when `VersioningConfig::allow_override = true`
+- Commands on closed or merged PRs are silently ignored
+- Commands from collaborators with Triage or Read access produce a `❌` rejection comment
+  identifying the commenter and explaining the permission requirement; the command has no
+  other effect
 
 **Priority**: Medium
-**Status**: Future Enhancement
+**Status**: In Progress
 
 ### US-5: Error Visibility
 

--- a/docs/specs/testing/behavioral-assertions.md
+++ b/docs/specs/testing/behavioral-assertions.md
@@ -198,18 +198,167 @@ This document defines testable behavioral assertions for Release Regent that ser
 
 **BA-18**: Failed GitHub API calls must retry with exponential backoff up to 5 times.
 
-*Retry Parameters*:
+## PR Comment Command Assertions
 
-- Base delay: 100ms
-- Backoff multiplier: 2x
-- Maximum delay: 30 seconds
-- Jitter: ±25% random variation
-- Maximum attempts: 5
+### Bump-Floor Override (`!release major|minor|patch`)
 
-*Eligible Errors*: Network timeouts, HTTP 429 (rate limited), HTTP 502/503 (server errors)
-*Non-Eligible Errors*: HTTP 401/403 (auth), HTTP 404 (not found), HTTP 422 (validation)
+**BA-19**: A `!release major` command on an open PR must apply label `rr:override-major` to the
+**PR the comment was posted on** (the feature PR), not to the release PR.
 
-**BA-19**: Malformed commit messages must not block release PR creation for valid commits.
+*Preconditions*: `allow_override = true`; commented-upon PR is open; commenter has Write access.
+
+*Expected*:
+
+- Label `rr:override-major` is present on the feature PR after the event is processed.
+- Any previously applied `rr:override-minor` or `rr:override-patch` label on that same
+  feature PR is absent.
+- A confirmation comment is posted on the feature PR stating the override intent and
+  explaining it will apply when the PR is merged.
+- No labels are applied to the release PR at this point.
+
+*Logging*: An `info!` event is recorded with `feature_pr_number`, `commenter_login`, and
+`correlation_id`.
+
+**BA-20**: An `rr:override-*` label on a PR that is closed without merging must have no
+effect on any future orchestration run.
+
+*Sequence*:
+
+1. Feature PR #55 receives `!release major` → `rr:override-major` applied to PR #55.
+2. PR #55 is closed without merging.
+3. An unrelated PR #56 merges.
+
+*Expected*:
+
+- `handle_merged_pull_request` reads labels from the **merged PR #56** (not PR #55).
+- No `rr:override-*` label is found on PR #56.
+- Orchestration proceeds with the normally-calculated version; no floor is applied.
+
+**BA-21**: When a PR carrying an `rr:override-*` label is merged, the floor must be applied
+during that merge's orchestration run.
+
+*Preconditions*: Feature PR #55 has label `rr:override-major`; current released version
+is `1.2.3`; PR #55 contains only a `fix:` commit (calculated next version = `1.2.4`).
+
+*Expected after PR #55 merges*:
+
+- `handle_merged_pull_request` reads `rr:override-major` from merged PR #55.
+- Floor = `next_major(1.2.3)` = `2.0.0`.
+- Effective version = `max(1.2.4, 2.0.0)` = `2.0.0`.
+- Orchestrator is called with `2.0.0` (not `1.2.4`).
+- The resulting release PR reflects version `2.0.0`.
+
+**BA-22**: The bump-floor must be a minimum constraint; it must never lower a version that
+conventional commits determine should be higher.
+
+*Scenario*: Merged PR contains `BREAKING CHANGE:` commits (major bump required, calculated
+version = `2.0.0`); PR carries label `rr:override-minor`.
+
+*Expected*: Effective version is `2.0.0` (calculated), not a minor-bumped version. The
+`BREAKING CHANGE:` commits win regardless of the `rr:override-minor` floor.
+
+**BA-23**: An audit comment must be posted on the release PR when a version floor is applied
+during orchestration.
+
+*Preconditions*: Merged PR carries `rr:override-major`; floor raises effective version from
+`1.2.4` to `2.0.0`.
+
+*Expected*: After orchestration, a comment is posted on the resulting release PR starting
+with `🔼 **Release Regent**:` and identifying the source PR number and the version that
+was raised.
+
+*Not expected*: No audit comment is posted when the floor does not change the effective
+version (i.e. `effective_version == calculated_version`).
+
+**BA-24**: A confirmation comment must be posted on the feature PR when an override label is
+recorded.
+
+*Preconditions*: `!release patch` is posted on open feature PR #77.
+
+*Expected*:
+
+- Label `rr:override-patch` is applied to PR #77.
+- A comment is posted on PR #77 starting with `✅ **Release Regent**:` confirming the
+  override and explaining it will be applied when PR #77 is merged.
+
+**BA-25**: Posting a new `!release` command on the same PR replaces any existing override
+label on that PR.
+
+*Preconditions*: Feature PR #55 already has `rr:override-major`.
+
+*Sequence*: Contributor posts `!release minor` on PR #55.
+
+*Expected*:
+
+- `rr:override-minor` is present on PR #55.
+- `rr:override-major` is absent from PR #55.
+- A new confirmation comment is posted on PR #55 noting the replacement.
+
+**BA-26**: A `!set-version` command posted on a non-release PR must be
+rejected with a scope rejection comment; no PR must be modified and the orchestrator must
+not be called.
+
+*Preconditions*:
+
+- `allow_override = true`.
+- Open feature PR #90, head branch `feat/my-feature` (does not start with `release/v`).
+- Commenter has Write access.
+
+*Sequence*: Contributor posts `!set-version 2.0.0` on PR #90.
+
+*Expected*:
+
+- `get_pull_request` is called to retrieve PR #90.
+- A comment is posted on PR #90 containing `⚠️` and instructing the commenter to re-post
+  on the release PR.
+- The `ReleaseOrchestrator` is **not** called.
+- No label is added to or removed from any PR.
+- The event is acknowledged without error.
+
+**BA-27**: A `!release` or `!set-version` command from a user without sufficient repository
+permissions must produce a rejection comment identifying the commenter and must not modify
+any PR or invoke the orchestrator.
+
+*Preconditions*:
+
+- `allow_override = true`.
+- Open feature PR #88; commenter `@someone` has `Read` access (not Write/Maintain/Admin).
+
+*Sequence*: `@someone` posts `!release major` on PR #88.
+
+*Expected*:
+
+- `get_collaborator_permission` is called and returns `Read`.
+- A comment is posted on PR #88 containing `❌` and explaining that only collaborators
+  with Write access or above may use Release Regent commands.
+- No label is added to or removed from any PR.
+- The `ReleaseOrchestrator` is **not** called.
+- The event is acknowledged without error.
+
+**BA-28**: When a release PR is merged, all open PRs bearing `rr:override-*` labels must
+have those labels removed and receive an informational cleanup comment.
+
+*Preconditions*:
+
+- Feature PR #55 has `rr:override-major`.
+- Feature PR #60 has `rr:override-minor`.
+- Release PR (head: `release/v1.3.0`) is open.
+
+*Sequence*: Release PR merges.
+
+*Expected*:
+
+- `handle_merged_pull_request` detects head branch starts with `release/v`.
+- Normal orchestration runs.
+- `search_pull_requests` (or equivalent) is called for open PRs with `rr:override-major`,
+  `rr:override-minor`, and `rr:override-patch` labels.
+- `rr:override-major` is removed from PR #55; a cleanup comment is posted on PR #55.
+- `rr:override-minor` is removed from PR #60; a cleanup comment is posted on PR #60.
+- Cleanup comments contain `ℹ️` and instruct the contributor to re-post `!release` if the
+  intent still applies.
+- Cleanup errors are logged as `warn!` and do **not** fail the event processing.
+
+**BA-29**: Malformed commit messages must not block release PR creation for valid commits.
 
 *Processing Strategy*:
 
@@ -226,7 +375,7 @@ This document defines testable behavioral assertions for Release Regent that ser
 - [def5678] Update docs (by @maintainer)
 ```
 
-**BA-20**: Concurrent webhook processing must not create duplicate release PRs for the same version.
+**BA-30**: Concurrent webhook processing must not create duplicate release PRs for the same version.
 
 *Concurrency Control*:
 
@@ -237,14 +386,14 @@ This document defines testable behavioral assertions for Release Regent that ser
 
 ### Data Integrity
 
-**BA-21**: All operations must be idempotent and safe to retry on failure.
+**BA-31**: All operations must be idempotent and safe to retry on failure.
 
 *PR Creation*: Check for existing PR before creating new one
 *PR Updates*: Use conditional updates with ETags when possible
 *Tag Creation*: Verify tag doesn't exist before creation
 *Release Creation*: Check for existing release before creation
 
-**BA-22**: Error messages must include correlation IDs for troubleshooting.
+**BA-32**: Error messages must include correlation IDs for troubleshooting.
 
 *Correlation ID Format*: `req_{uuid}` (e.g., "req_abc123def456")
 *Propagation*: Pass correlation ID through all operations and log entries
@@ -252,7 +401,7 @@ This document defines testable behavioral assertions for Release Regent that ser
 
 ### Validation and Security
 
-**BA-23**: Version parsing must strictly follow semantic versioning specification.
+**BA-33**: Version parsing must strictly follow semantic versioning specification.
 
 *Valid Formats*:
 
@@ -266,14 +415,14 @@ This document defines testable behavioral assertions for Release Regent that ser
 - `1.2` (missing patch version)
 - `1.2.3.4` (too many components)
 
-**BA-24**: Webhook signature validation must be enforced for all incoming requests.
+**BA-34**: Webhook signature validation must be enforced for all incoming requests.
 
 *Validation Method*: HMAC-SHA256 using configured webhook secret
 *Header*: Verify `X-Hub-Signature-256` header matches computed signature
 *Timing Attack Prevention*: Use constant-time comparison for signature verification
 *Rejection*: Return HTTP 401 for invalid signatures
 
-**BA-25**: Repository configuration must be validated before processing begins.
+**BA-35**: Repository configuration must be validated before processing begins.
 
 *Validation Scope*:
 


### PR DESCRIPTION
Implements the full bump-override persistence feature (ADR-004) and set-version
improvements, allowing collaborators to record a minimum-version-bump intent on
feature PRs via `!release major|minor|patch` comments, with the override applied
automatically at merge time and stale overrides cleaned up when a release PR ships.

## What Changed

### New GitHub operations
- Added `Label` type and `add_labels`, `remove_label`, `list_pr_labels` methods
  to the `GitHubOperations` trait, with full implementations in `GitHubClient` and
  `MockGitHubOperations`.

### Versioning
- Added `next_major`, `next_minor`, `next_patch` helpers on `SemanticVersion`.
- Added `apply_bump_floor(current, calculated, floor) -> SemanticVersion` free
  function that returns `max(calculated, floor_version)` by semver precedence.
- Added `BumpKind` enum (moved to `versioning.rs`; re-exported from
  `comment_command_processor` to preserve the existing public API).

### Comment command processor
- Override label constants: `OVERRIDE_LABEL_MAJOR/MINOR/PATCH` and
  `ALL_OVERRIDE_LABELS`.
- `handle_release_bump`: applies the corresponding `rr:override-*` label to the
  feature PR, removes any previously applied override label first, and posts a
  confirmation comment (noting replacement when an existing label is replaced,
  including when the same override is reposted).
- `!set-version` scope guard: rejects the command with an explanatory comment when
  the PR's head branch does not match `{branch_prefix}/v*`.
- `handle_set_version`: fetches the existing release PR changelog before invoking
  the orchestrator and posts a typed confirmation comment (`Created`, `Updated`,
  `Renamed`, `NoOp`) after orchestration.

### Merged PR handler (`lib.rs`)
- **Feature PR path**: reads `rr:override-*` labels from the merged PR, applies
  `apply_bump_floor`, posts an audit comment on the release PR when the floor
  raises the version, and removes the consumed override label from the merged PR.
  `list_pr_labels` failures are propagated (not swallowed) so the event loop
  retries on transient API errors.
- **Release PR path**: searches for open PRs with any `rr:override-*` label after
  a release ships, removes the stale label from each, and posts an explanatory
  cleanup comment. Per-label search failures and per-PR remove/comment failures
  are warn-logged and do not abort the event.

### Documentation
- ADR-004 documenting the design decisions behind the feature.
- Interface specs for bump-override implementation and GitHub operations additions.
- Updated functional requirements (DR-4, DR-5), user stories (US-4), and
  behavioral assertions (BA-19 through BA-35).

## Why

Before this change there was no way for a collaborator to signal that a feature PR
requires at least a major or minor version bump. The conventional-commit-based
version calculator could under-estimate the bump (e.g., produce a patch bump for a
PR that the author explicitly wants to treat as a minor release). The `!release`
command and associated label mechanism provide a persistent, auditable way to
record and enforce that intent without any manual intervention at merge time.

## How

Override intent is stored as a GitHub label (`rr:override-major/minor/patch`) on
the feature PR rather than in application state, making it durable across restarts
and visible in the GitHub UI. At merge time the label is read, the floor is computed
via `apply_bump_floor`, and the label is immediately removed so it cannot
accidentally influence future release cycles. Stale labels on already-open PRs that
survived a release cycle are cleaned up in the release-PR-merged handler.

## Testing Evidence

- **Test Coverage:** 17 files changed; 222 unit tests total (up from 192), zero new
  clippy errors, 16 doc-tests passing.
  - `versioning_tests.rs`: `apply_bump_floor` pre-release scenario and
    floor-raises-patch-to-minor scenario.
  - `comment_command_processor_tests.rs`: `add_labels` failure propagation;
    `remove_label` network error does not suppress new label application;
    `!set-version` scope rejection on `release/some-branch` (no `/v`); same
    override repost shows "replacing" confirmation; all BA-28/BA-29 scenarios.
  - `lib_tests.rs`: major/minor/patch floor application; no-floor path; stale
    label cleanup; release-PR search failure continues for other labels;
    `remove_label` failure still posts cleanup comment; cleanup comment failure
    returns Ok; audit comment failure returns Ok.
  - `release_orchestrator_tests.rs`: `extract_changelog_from_pr_body` (7 cases).
- **Test Results:** All 222 unit tests and 16 doc-tests pass.
- **Manual Testing:** None; full coverage via automated tests.

## Reviewer Guidance

- **`list_pr_labels` error propagation** (`lib.rs` feature-PR path): verify that
  replacing `unwrap_or_else` with `?` is the correct behaviour — a transient
  GitHub API failure will now cause the event to be retried rather than silently
  dropping the override floor.
- **`replaced_kind` detection in `handle_release_bump`**: the guard was changed to
  detect when the same override is reposted (not only when a *different* label is
  present), so the confirmation message consistently says "replacing". Confirm the
  wording is appropriate for the same-label case.
- **Stale label cleanup is best-effort**: failures in `search_pull_requests`,
  `remove_label`, and `create_issue_comment` during release-PR cleanup are
  warn-logged and do not fail the event. This is intentional per ADR-004 Q6;
  confirm this is acceptable.
- **`!set-version` scope guard**: only branches matching `{branch_prefix}/v*` are
  accepted (e.g. `release/v1.2.3`). A branch named `release/some-branch` is
  rejected even though it starts with `release/`. Verify this is the intended
  behaviour.
- No breaking changes to existing public APIs; `BumpKind` is re-exported from its
  original location in `comment_command_processor` for backward compatibility.