### PR TITLE
feat(core): implement ReleaseAutomator for GitHub release creation

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -293,10 +293,19 @@ where
     ) -> CoreResult<()> {
         use release_automator::{AutomatorConfig, ReleaseAutomator};
 
-        let config = AutomatorConfig::default();
         let correlation_id = &event.correlation_id;
         let owner = &event.repository.owner;
         let repo = &event.repository.name;
+
+        // `branch_prefix` and `changelog_header` are not yet per-repo config
+        // fields in `ReleaseRegentConfig`. Use the same default source as
+        // `OrchestratorConfig` so both components stay in sync. When the schema
+        // gains an explicit `release.branch_prefix` field, load it here via
+        // `self.configuration_provider.get_merged_config(...)`.
+        let config = AutomatorConfig {
+            branch_prefix: release_orchestrator::OrchestratorConfig::default().branch_prefix,
+            changelog_header: "## Changelog".to_string(),
+        };
 
         match ReleaseAutomator::new(config, &self.github_operations)
             .automate(owner, repo, event, correlation_id)

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -207,6 +207,7 @@ pub mod changelog;
 pub mod comment_command_processor;
 pub mod config;
 pub mod errors;
+pub mod release_automator;
 pub mod release_orchestrator;
 pub mod traits;
 pub mod versioning;
@@ -240,6 +241,19 @@ pub trait MergedPullRequestHandler: Send + Sync {
         event: &traits::event_source::ProcessingEvent,
     ) -> CoreResult<()>;
 
+    /// Process a single `ReleasePrMerged` event.
+    ///
+    /// Called when the event loop receives [`EventType::ReleasePrMerged`].
+    /// The default implementation is a no-op that acknowledges the event
+    /// without taking any action.  Override in the production processor to
+    /// invoke [`release_automator::ReleaseAutomator`].
+    async fn handle_release_pr_merged(
+        &self,
+        _event: &traits::event_source::ProcessingEvent,
+    ) -> CoreResult<()> {
+        Ok(())
+    }
+
     /// Process a single `PullRequestCommentReceived` event.
     ///
     /// The default implementation is a no-op that acknowledges the event
@@ -267,6 +281,29 @@ where
         match self.handle_merged_pull_request(event).await {
             Ok(result) => {
                 tracing::info!(result = ?result, "Release orchestration completed");
+                Ok(())
+            }
+            Err(e) => Err(e),
+        }
+    }
+
+    async fn handle_release_pr_merged(
+        &self,
+        event: &traits::event_source::ProcessingEvent,
+    ) -> CoreResult<()> {
+        use release_automator::{AutomatorConfig, ReleaseAutomator};
+
+        let config = AutomatorConfig::default();
+        let correlation_id = &event.correlation_id;
+        let owner = &event.repository.owner;
+        let repo = &event.repository.name;
+
+        match ReleaseAutomator::new(config, &self.github_operations)
+            .automate(owner, repo, event, correlation_id)
+            .await
+        {
+            Ok(result) => {
+                tracing::info!(result = ?result, "Release automation completed");
                 Ok(())
             }
             Err(e) => Err(e),
@@ -395,9 +432,9 @@ where
                                     "{}/{}",
                                     event.repository.owner, event.repository.name
                                 ),
-                                "Release PR merged — release automator not yet wired"
+                                "Release PR merged — running release automator"
                             );
-                            Ok(())
+                            handler.handle_release_pr_merged(&event).await
                         }
                         EventType::PullRequestCommentReceived => {
                             tracing::debug!(

--- a/crates/core/src/lib_tests.rs
+++ b/crates/core/src/lib_tests.rs
@@ -32,6 +32,7 @@ impl MergedPullRequestHandler for NoopMergedPRHandler {
 #[derive(Clone, Default)]
 struct SpyMergedPRHandler {
     received: Arc<Mutex<Vec<String>>>,
+    received_release_pr: Arc<Mutex<Vec<String>>>,
 }
 
 impl SpyMergedPRHandler {
@@ -42,12 +43,24 @@ impl SpyMergedPRHandler {
     async fn received_event_ids(&self) -> Vec<String> {
         self.received.lock().await.clone()
     }
+
+    async fn received_release_pr_event_ids(&self) -> Vec<String> {
+        self.received_release_pr.lock().await.clone()
+    }
 }
 
 #[async_trait]
 impl MergedPullRequestHandler for SpyMergedPRHandler {
     async fn handle_merged_pull_request(&self, event: &ProcessingEvent) -> CoreResult<()> {
         self.received.lock().await.push(event.event_id.clone());
+        Ok(())
+    }
+
+    async fn handle_release_pr_merged(&self, event: &ProcessingEvent) -> CoreResult<()> {
+        self.received_release_pr
+            .lock()
+            .await
+            .push(event.event_id.clone());
         Ok(())
     }
 }
@@ -401,6 +414,10 @@ async fn test_run_event_loop_calls_handler_for_pull_request_merged_events() {
     // The handler should have been called only for the two PullRequestMerged events.
     let handled = handler.received_event_ids().await;
     assert_eq!(handled, vec!["evt-pr-a", "evt-pr-b"]);
+
+    // The release PR merged handler should have been called for the ReleasePrMerged event.
+    let release_handled = handler.received_release_pr_event_ids().await;
+    assert_eq!(release_handled, vec!["evt-release"]);
 }
 
 /// A `PullRequestMerged` event whose handler returns an error is rejected.

--- a/crates/core/src/release_automator.rs
+++ b/crates/core/src/release_automator.rs
@@ -1,0 +1,380 @@
+//! Release automation for Release Regent
+//!
+//! This module implements the [`ReleaseAutomator`], which is responsible for
+//! creating GitHub releases when release pull requests are merged.
+//!
+//! ## Responsibilities
+//!
+//! When [`EventType::ReleasePrMerged`] arrives in the event loop, the automator:
+//!
+//! 1. **Extracts** the version from the PR head branch name (`release/v{version}`).
+//! 2. **Extracts** the merge commit SHA from the webhook payload.
+//! 3. **Creates an annotated Git tag** pointing to the merge commit.
+//! 4. **Extracts** the changelog from the PR body.
+//! 5. **Creates a GitHub release** using the tag, with the changelog as release
+//!    notes and the pre-release flag set when the version contains a pre-release
+//!    identifier.
+//! 6. **Deletes the release branch** after a successful release (non-fatal on
+//!    failure — the release has already been published).
+//!
+//! ## Idempotency
+//!
+//! All operations are safe to retry:
+//!
+//! - If `create_tag` returns [`CoreError::NotSupported`] (tag already exists),
+//!   the automator checks whether a matching release also exists via
+//!   `get_release_by_tag`.
+//!   - **Release exists**: return `Ok(AutomatorResult::Created { release })` — already done.
+//!   - **Release absent**: skip tag creation and proceed from step 4 onward to
+//!     create the release using the existing tag.
+//! - Other GitHub API failures are propagated so the event loop can retry.
+//!
+//! ## Usage
+//!
+//! ```rust,ignore
+//! use release_regent_core::release_automator::{ReleaseAutomator, AutomatorConfig};
+//!
+//! let config = AutomatorConfig::default();
+//! let automator = ReleaseAutomator::new(config, &github);
+//! let result = automator
+//!     .automate("myorg", "myrepo", &event, "corr-id-001")
+//!     .await?;
+//! ```
+
+use crate::{
+    release_orchestrator::extract_changelog_from_pr_body,
+    traits::{
+        event_source::ProcessingEvent,
+        github_operations::{CreateReleaseParams, GitHubOperations, Release},
+    },
+    versioning::{SemanticVersion, VersionCalculator},
+    CoreError, CoreResult,
+};
+use tracing::{info, warn};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Public types
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Configuration for the [`ReleaseAutomator`].
+#[derive(Debug, Clone)]
+pub struct AutomatorConfig {
+    /// Branch name prefix; combined with the version to form `release/v1.2.3`.
+    ///
+    /// Defaults to `"release"`.
+    pub branch_prefix: String,
+
+    /// Sentinel that marks the start of the changelog section in the PR body.
+    ///
+    /// Defaults to `"## Changelog"`.
+    pub changelog_header: String,
+}
+
+impl Default for AutomatorConfig {
+    fn default() -> Self {
+        Self {
+            branch_prefix: "release".to_string(),
+            changelog_header: "## Changelog".to_string(),
+        }
+    }
+}
+
+/// The outcome of a single [`ReleaseAutomator::automate`] call.
+#[derive(Debug, Clone)]
+pub enum AutomatorResult {
+    /// A new GitHub release was created (or already existed — idempotent).
+    Created {
+        /// The created (or previously existing) GitHub release.
+        release: Release,
+    },
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ReleaseAutomator
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Automates GitHub release creation from merged release pull requests.
+///
+/// Generic over `G` so that tests can inject an inline test double while
+/// production code uses the real `GitHubClient`.
+pub struct ReleaseAutomator<'a, G: GitHubOperations> {
+    config: AutomatorConfig,
+    github: &'a G,
+}
+
+impl<'a, G: GitHubOperations + Send + Sync> ReleaseAutomator<'a, G> {
+    /// Create a new automator.
+    ///
+    /// # Parameters
+    /// - `config`: Automator configuration (branch prefix, changelog header).
+    /// - `github`: Reference to the `GitHubOperations` implementation to use.
+    pub fn new(config: AutomatorConfig, github: &'a G) -> Self {
+        Self { config, github }
+    }
+
+    /// Run the release automation workflow for a merged release PR.
+    ///
+    /// Reads required data from `event.payload` using standard GitHub webhook
+    /// field paths.  Missing fields cause [`CoreError::InvalidInput`] so the
+    /// event loop can distinguish a malformed payload (permanent) from a
+    /// transient API error.
+    ///
+    /// # Parameters
+    /// - `owner`: Repository owner / organisation.
+    /// - `repo`: Repository name.
+    /// - `event`: The [`ProcessingEvent`] of type [`EventType::ReleasePrMerged`].
+    /// - `correlation_id`: Tracing correlation ID propagated from the event.
+    ///
+    /// # Errors
+    ///
+    /// - [`CoreError::InvalidInput`] — branch name cannot be parsed as a
+    ///   semantic version, or the payload is missing required fields.
+    /// - [`CoreError::GitHub`] — a GitHub API call failed for a non-idempotent
+    ///   reason.
+    pub async fn automate(
+        &self,
+        owner: &str,
+        repo: &str,
+        event: &ProcessingEvent,
+        correlation_id: &str,
+    ) -> CoreResult<AutomatorResult> {
+        let span = tracing::info_span!("release_automator.automate", owner, repo, correlation_id,);
+        let _enter = span.enter();
+
+        let (branch, merge_sha, pr_body) = extract_payload_fields(event)?;
+        let version = extract_version_from_branch(&branch, &self.config.branch_prefix)?;
+        let tag_name = version.to_string_with_prefix(true);
+
+        info!(
+            owner, repo, branch = %branch, tag = %tag_name, sha = %merge_sha,
+            correlation_id, "Automating GitHub release for merged release PR"
+        );
+
+        // Create the annotated Git tag, handling the idempotent case where the
+        // tag already exists.
+        if let Some(existing) = self
+            .ensure_tag_and_get_existing_release(owner, repo, &tag_name, &merge_sha)
+            .await?
+        {
+            return Ok(AutomatorResult::Created { release: existing });
+        }
+
+        // Extract changelog and create the GitHub release.
+        let changelog = extract_changelog_from_pr_body(&pr_body, &self.config.changelog_header);
+        let is_prerelease = version.is_prerelease();
+
+        let release = self
+            .github
+            .create_release(
+                owner,
+                repo,
+                CreateReleaseParams {
+                    tag_name: tag_name.clone(),
+                    name: Some(tag_name.clone()),
+                    body: Some(changelog),
+                    draft: false,
+                    prerelease: is_prerelease,
+                    generate_release_notes: false,
+                    target_commitish: Some(merge_sha),
+                },
+            )
+            .await?;
+
+        info!(
+            release_id = release.id, tag = %tag_name, prerelease = is_prerelease,
+            "Created GitHub release"
+        );
+
+        // Delete the release branch (non-fatal on failure).
+        if let Err(e) = self.github.delete_branch(owner, repo, &branch).await {
+            warn!(
+                error = %e, branch = %branch,
+                "Failed to delete release branch after release creation; continuing"
+            );
+        } else {
+            tracing::debug!(branch = %branch, "Deleted release branch");
+        }
+
+        Ok(AutomatorResult::Created { release })
+    }
+
+    // ── Private helpers ────────────────────────────────────────────────────
+
+    /// Create the annotated Git tag for `tag_name` at `merge_sha`.
+    ///
+    /// Returns `Ok(Some(release))` when the tag **and** release already exist
+    /// (idempotent resumption).  Returns `Ok(None)` when the caller should
+    /// continue and create the release.
+    ///
+    /// # Errors
+    ///
+    /// Returns the underlying `CoreError` on any non-idempotent GitHub API
+    /// failure.
+    async fn ensure_tag_and_get_existing_release(
+        &self,
+        owner: &str,
+        repo: &str,
+        tag_name: &str,
+        merge_sha: &str,
+    ) -> CoreResult<Option<Release>> {
+        let tag_message = format!("Release {tag_name}");
+        match self
+            .github
+            .create_tag(owner, repo, tag_name, merge_sha, Some(tag_message), None)
+            .await
+        {
+            Ok(_) => Ok(None),
+            Err(CoreError::NotSupported { .. }) => {
+                // Tag already exists; check whether a release also exists.
+                tracing::debug!(tag = %tag_name, "Tag already exists; checking for existing release");
+                match self.github.get_release_by_tag(owner, repo, tag_name).await {
+                    Ok(existing_release) => {
+                        info!(
+                            tag = %tag_name, release_id = existing_release.id,
+                            "Release already exists for tag; returning idempotent result"
+                        );
+                        Ok(Some(existing_release))
+                    }
+                    Err(CoreError::NotFound { .. } | CoreError::NotSupported { .. }) => {
+                        // Tag exists but release does not — fall through to create release.
+                        tracing::debug!(
+                            tag = %tag_name,
+                            "Tag exists but release is absent; creating release from existing tag"
+                        );
+                        Ok(None)
+                    }
+                    Err(other) => Err(other),
+                }
+            }
+            Err(other) => Err(other),
+        }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Free helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Extract the three required fields from a `ReleasePrMerged` webhook payload.
+///
+/// Returns `(branch, merge_sha, pr_body)`.
+///
+/// # Errors
+///
+/// Returns [`CoreError::InvalidInput`] when `pull_request.head.ref` is absent
+/// or when neither `merge_commit_sha` nor `pull_request.head.sha` are present.
+fn extract_payload_fields(event: &ProcessingEvent) -> CoreResult<(String, String, String)> {
+    let branch = event
+        .payload
+        .get("pull_request")
+        .and_then(|pr| pr.get("head"))
+        .and_then(|h| h.get("ref"))
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| {
+            CoreError::invalid_input(
+                "payload",
+                "ReleasePrMerged payload is missing pull_request.head.ref",
+            )
+        })?
+        .to_string();
+
+    let merge_sha = event
+        .payload
+        .get("pull_request")
+        .and_then(|pr| pr.get("merge_commit_sha"))
+        .and_then(serde_json::Value::as_str)
+        .or_else(|| {
+            event
+                .payload
+                .get("pull_request")
+                .and_then(|pr| pr.get("head"))
+                .and_then(|h| h.get("sha"))
+                .and_then(serde_json::Value::as_str)
+        })
+        .ok_or_else(|| {
+            CoreError::invalid_input(
+                "payload",
+                "ReleasePrMerged payload is missing both \
+                 merge_commit_sha and pull_request.head.sha",
+            )
+        })?
+        .to_string();
+
+    let pr_body = event
+        .payload
+        .get("pull_request")
+        .and_then(|pr| pr.get("body"))
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("")
+        .to_string();
+
+    Ok((branch, merge_sha, pr_body))
+}
+
+/// Extract a [`SemanticVersion`] from a release branch name.
+///
+/// Expects the branch to start with `{branch_prefix}/v` followed by a valid
+/// semantic version string, e.g. `"release/v1.2.3"` or `"release/v1.0.0-rc.1"`.
+///
+/// # Errors
+///
+/// Returns [`CoreError::InvalidInput`] when:
+/// - The branch name does not start with `{branch_prefix}/v`.
+/// - The version suffix is not a valid semantic version.
+///
+/// # Examples
+///
+/// ```
+/// use release_regent_core::release_automator::extract_version_from_branch;
+///
+/// let v = extract_version_from_branch("release/v1.2.3", "release").unwrap();
+/// assert_eq!(v.to_string(), "1.2.3");
+///
+/// let pre = extract_version_from_branch("release/v1.0.0-rc.1", "release").unwrap();
+/// assert!(pre.is_prerelease());
+///
+/// assert!(extract_version_from_branch("feature/abc", "release").is_err());
+/// ```
+// `CoreError` is a large enum used uniformly throughout the codebase.
+// Boxing it would require changing the entire `CoreResult<T>` type alias — a
+// project-wide refactor. Allow the lint here as it is consistent with the
+// existing pattern in `release_orchestrator.rs` and other modules.
+#[allow(clippy::result_large_err)]
+pub fn extract_version_from_branch(
+    branch: &str,
+    branch_prefix: &str,
+) -> CoreResult<SemanticVersion> {
+    let prefix = format!("{branch_prefix}/v");
+    let version_str = branch.strip_prefix(&prefix).ok_or_else(|| {
+        CoreError::invalid_input(
+            "branch",
+            format!(
+                "Branch '{branch}' does not match the expected release branch \
+                 pattern '{branch_prefix}/v<version>'"
+            ),
+        )
+    })?;
+    VersionCalculator::parse_version(version_str)
+}
+
+/// Returns `true` when the branch name matches the release branch pattern.
+///
+/// # Examples
+///
+/// ```
+/// use release_regent_core::release_automator::is_release_pr_branch;
+///
+/// assert!(is_release_pr_branch("release/v1.2.3", "release"));
+/// assert!(is_release_pr_branch("release/v1.0.0-rc.1", "release"));
+/// assert!(!is_release_pr_branch("feature/my-feature", "release"));
+/// assert!(!is_release_pr_branch("release/not-a-version", "release"));
+/// ```
+#[must_use]
+pub fn is_release_pr_branch(branch: &str, branch_prefix: &str) -> bool {
+    let prefix = format!("{branch_prefix}/v");
+    branch.starts_with(&prefix)
+}
+
+#[cfg(test)]
+#[path = "release_automator_tests.rs"]
+mod tests;

--- a/crates/core/src/release_automator.rs
+++ b/crates/core/src/release_automator.rs
@@ -82,7 +82,11 @@ impl Default for AutomatorConfig {
 /// The outcome of a single [`ReleaseAutomator::automate`] call.
 #[derive(Debug, Clone)]
 pub enum AutomatorResult {
-    /// A new GitHub release was created (or already existed — idempotent).
+    /// The GitHub release is ready — either freshly created or already present.
+    ///
+    /// When the matching Git tag **and** GitHub release both existed before this
+    /// call, no new resources are created and this variant is returned
+    /// unchanged, making the operation safe to retry.
     Created {
         /// The created (or previously existing) GitHub release.
         release: Release,
@@ -131,6 +135,7 @@ impl<'a, G: GitHubOperations + Send + Sync> ReleaseAutomator<'a, G> {
     ///   semantic version, or the payload is missing required fields.
     /// - [`CoreError::GitHub`] — a GitHub API call failed for a non-idempotent
     ///   reason.
+    #[tracing::instrument(skip(self, event), fields(owner, repo, correlation_id))]
     pub async fn automate(
         &self,
         owner: &str,
@@ -138,9 +143,6 @@ impl<'a, G: GitHubOperations + Send + Sync> ReleaseAutomator<'a, G> {
         event: &ProcessingEvent,
         correlation_id: &str,
     ) -> CoreResult<AutomatorResult> {
-        let span = tracing::info_span!("release_automator.automate", owner, repo, correlation_id,);
-        let _enter = span.enter();
-
         let (branch, merge_sha, pr_body) = extract_payload_fields(event)?;
         let version = extract_version_from_branch(&branch, &self.config.branch_prefix)?;
         let tag_name = version.to_string_with_prefix(true);
@@ -156,6 +158,17 @@ impl<'a, G: GitHubOperations + Send + Sync> ReleaseAutomator<'a, G> {
             .ensure_tag_and_get_existing_release(owner, repo, &tag_name, &merge_sha)
             .await?
         {
+            // Tag and release both exist — this is a full idempotent retry.
+            // Still attempt branch cleanup: a previous run may have succeeded at
+            // tag+release creation but failed before (or during) deletion.
+            if let Err(e) = self.github.delete_branch(owner, repo, &branch).await {
+                warn!(
+                    error = %e, branch = %branch,
+                    "Failed to delete release branch in idempotent path; continuing"
+                );
+            } else {
+                tracing::debug!(branch = %branch, "Deleted release branch (idempotent path)");
+            }
             return Ok(AutomatorResult::Created { release: existing });
         }
 
@@ -263,6 +276,10 @@ impl<'a, G: GitHubOperations + Send + Sync> ReleaseAutomator<'a, G> {
 ///
 /// Returns [`CoreError::InvalidInput`] when `pull_request.head.ref` is absent
 /// or when neither `merge_commit_sha` nor `pull_request.head.sha` are present.
+// `CoreError` is a large enum used uniformly throughout the codebase.
+// The same allow is applied to `extract_version_from_branch` and other free
+// functions in this file for the same reason.
+#[allow(clippy::result_large_err)]
 fn extract_payload_fields(event: &ProcessingEvent) -> CoreResult<(String, String, String)> {
     let branch = event
         .payload
@@ -357,7 +374,15 @@ pub fn extract_version_from_branch(
     VersionCalculator::parse_version(version_str)
 }
 
-/// Returns `true` when the branch name matches the release branch pattern.
+/// Returns `true` when the branch name starts with the release branch prefix
+/// (`{branch_prefix}/v`).
+///
+/// **This is a prefix-only check.** It does not validate that the version
+/// suffix is a valid semantic version. For example, `"release/vnot-valid"`
+/// returns `true` even though [`extract_version_from_branch`] would return an
+/// error for that branch. Use this function as a lightweight pre-filter and
+/// call [`extract_version_from_branch`] whenever you need to parse or validate
+/// the version.
 ///
 /// # Examples
 ///
@@ -366,6 +391,9 @@ pub fn extract_version_from_branch(
 ///
 /// assert!(is_release_pr_branch("release/v1.2.3", "release"));
 /// assert!(is_release_pr_branch("release/v1.0.0-rc.1", "release"));
+/// // Prefix-only: "release/vnot-valid" passes the prefix check even though
+/// // extract_version_from_branch would reject the version suffix.
+/// assert!(is_release_pr_branch("release/vnot-valid", "release"));
 /// assert!(!is_release_pr_branch("feature/my-feature", "release"));
 /// assert!(!is_release_pr_branch("release/not-a-version", "release"));
 /// ```

--- a/crates/core/src/release_automator_tests.rs
+++ b/crates/core/src/release_automator_tests.rs
@@ -1,0 +1,948 @@
+use super::*;
+use crate::{
+    traits::{
+        event_source::{EventSourceKind, EventType, ProcessingEvent, RepositoryInfo},
+        git_operations::{
+            GetCommitsOptions, GitCommit, GitOperations, GitRepository, GitTag, ListTagsOptions,
+        },
+        github_operations::{
+            CollaboratorPermission, CreatePullRequestParams, CreateReleaseParams, GitHubOperations,
+            GitUser as GitHubUser, Label, PullRequest, PullRequestBranch, Release, Repository, Tag,
+            UpdateReleaseParams,
+        },
+    },
+    CoreError, CoreResult,
+};
+use async_trait::async_trait;
+use chrono::Utc;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Inline test double
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Configurable mock state for `TestGitHub`.
+#[derive(Default)]
+struct TestState {
+    /// Tags returned by successful `create_tag`.
+    created_tags: Vec<(String, String)>,
+    /// Whether the next `create_tag` call should return `NotSupported` (tag exists).
+    next_create_tag_conflict: bool,
+    /// Whether `create_tag` always errors with a GitHub error.
+    create_tag_github_error: bool,
+    /// Whether `create_release` should return an error.
+    create_release_error: bool,
+    /// Whether `delete_branch` should return an error.
+    delete_branch_error: bool,
+    /// Releases stored (keyed by tag name) — returned by `get_release_by_tag`.
+    releases_by_tag: std::collections::HashMap<String, Release>,
+    /// Recorded `create_release` calls.
+    created_releases: Vec<CreateReleaseParams>,
+    /// Recorded `delete_branch` calls.
+    deleted_branches: Vec<String>,
+    /// Sequential release ID counter.
+    next_release_id: u64,
+}
+
+#[derive(Clone)]
+struct TestGitHub {
+    state: Arc<Mutex<TestState>>,
+}
+
+impl TestGitHub {
+    fn new() -> Self {
+        Self {
+            state: Arc::new(Mutex::new(TestState {
+                next_release_id: 1,
+                ..Default::default()
+            })),
+        }
+    }
+
+    /// Make the next `create_tag` fail with `NotSupported` (tag already exists).
+    async fn with_tag_conflict(self) -> Self {
+        self.state.lock().await.next_create_tag_conflict = true;
+        self
+    }
+
+    /// Make `create_tag` always fail with a generic `GitHub` error.
+    async fn with_create_tag_github_error(self) -> Self {
+        self.state.lock().await.create_tag_github_error = true;
+        self
+    }
+
+    /// Make `create_release` fail.
+    async fn with_create_release_error(self) -> Self {
+        self.state.lock().await.create_release_error = true;
+        self
+    }
+
+    /// Make `delete_branch` fail (should be non-fatal).
+    async fn with_delete_branch_error(self) -> Self {
+        self.state.lock().await.delete_branch_error = true;
+        self
+    }
+
+    /// Pre-load a release returned by `get_release_by_tag` for `tag_name`.
+    async fn with_release_for_tag(self, tag_name: impl Into<String>, release: Release) -> Self {
+        self.state
+            .lock()
+            .await
+            .releases_by_tag
+            .insert(tag_name.into(), release);
+        self
+    }
+
+    async fn created_tags(&self) -> Vec<(String, String)> {
+        self.state.lock().await.created_tags.clone()
+    }
+
+    async fn created_releases(&self) -> Vec<CreateReleaseParams> {
+        self.state.lock().await.created_releases.clone()
+    }
+
+    async fn deleted_branches(&self) -> Vec<String> {
+        self.state.lock().await.deleted_branches.clone()
+    }
+}
+
+// ── GitOperations stub ────────────────────────────────────────────────────
+
+#[async_trait]
+impl GitOperations for TestGitHub {
+    async fn get_commits_between(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _base: &str,
+        _head: &str,
+        _options: GetCommitsOptions,
+    ) -> CoreResult<Vec<GitCommit>> {
+        Ok(vec![])
+    }
+
+    async fn get_commit(&self, _owner: &str, _repo: &str, _sha: &str) -> CoreResult<GitCommit> {
+        Err(CoreError::not_found("stub"))
+    }
+
+    async fn list_tags(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _options: ListTagsOptions,
+    ) -> CoreResult<Vec<GitTag>> {
+        Ok(vec![])
+    }
+
+    async fn get_tag(&self, _owner: &str, _repo: &str, _tag_name: &str) -> CoreResult<GitTag> {
+        Err(CoreError::not_found("stub"))
+    }
+
+    async fn tag_exists(&self, _owner: &str, _repo: &str, _tag_name: &str) -> CoreResult<bool> {
+        Ok(false)
+    }
+
+    async fn get_head_commit(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _branch: Option<&str>,
+    ) -> CoreResult<GitCommit> {
+        Err(CoreError::not_found("stub"))
+    }
+
+    async fn get_repository_info(&self, _owner: &str, _repo: &str) -> CoreResult<GitRepository> {
+        Err(CoreError::not_found("stub"))
+    }
+}
+
+// ── GitHubOperations impl ─────────────────────────────────────────────────
+
+#[async_trait]
+impl GitHubOperations for TestGitHub {
+    async fn add_labels(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _issue_number: u64,
+        _labels: &[&str],
+    ) -> CoreResult<()> {
+        Ok(())
+    }
+
+    async fn create_branch(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _branch_name: &str,
+        _sha: &str,
+    ) -> CoreResult<()> {
+        Ok(())
+    }
+
+    async fn create_issue_comment(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _issue_number: u64,
+        _body: &str,
+    ) -> CoreResult<()> {
+        Ok(())
+    }
+
+    async fn create_pull_request(
+        &self,
+        owner: &str,
+        repo: &str,
+        params: CreatePullRequestParams,
+    ) -> CoreResult<PullRequest> {
+        let now = Utc::now();
+        let r = stub_repo(owner, repo);
+        Ok(PullRequest {
+            number: 1,
+            title: params.title,
+            body: params.body,
+            state: "open".to_string(),
+            draft: false,
+            created_at: now,
+            updated_at: now,
+            merged_at: None,
+            user: stub_git_user(),
+            head: PullRequestBranch {
+                ref_name: params.head,
+                sha: "abc".to_string(),
+                repo: r.clone(),
+            },
+            base: PullRequestBranch {
+                ref_name: params.base,
+                sha: "def".to_string(),
+                repo: r,
+            },
+        })
+    }
+
+    async fn create_release(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        params: CreateReleaseParams,
+    ) -> CoreResult<Release> {
+        let mut st = self.state.lock().await;
+        if st.create_release_error {
+            return Err(CoreError::network("simulated release creation failure"));
+        }
+        let id = st.next_release_id;
+        st.next_release_id += 1;
+        st.created_releases.push(params.clone());
+        let now = Utc::now();
+        Ok(Release {
+            id,
+            tag_name: params.tag_name.clone(),
+            name: params.name,
+            body: params.body,
+            draft: params.draft,
+            prerelease: params.prerelease,
+            created_at: now,
+            published_at: Some(now),
+            author: stub_git_user(),
+            target_commitish: params
+                .target_commitish
+                .unwrap_or_else(|| params.tag_name.clone()),
+        })
+    }
+
+    async fn create_tag(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        tag_name: &str,
+        commit_sha: &str,
+        _message: Option<String>,
+        _tagger: Option<GitHubUser>,
+    ) -> CoreResult<Tag> {
+        let mut st = self.state.lock().await;
+        if st.create_tag_github_error {
+            return Err(CoreError::network("simulated tag creation failure"));
+        }
+        if st.next_create_tag_conflict {
+            st.next_create_tag_conflict = false;
+            return Err(CoreError::not_supported(
+                "create_tag",
+                format!("tag '{tag_name}' already exists"),
+            ));
+        }
+        st.created_tags
+            .push((tag_name.to_string(), commit_sha.to_string()));
+        let now = Utc::now();
+        Ok(Tag {
+            name: tag_name.to_string(),
+            commit_sha: commit_sha.to_string(),
+            message: None,
+            tagger: None,
+            created_at: Some(now),
+        })
+    }
+
+    async fn delete_branch(&self, _owner: &str, _repo: &str, branch_name: &str) -> CoreResult<()> {
+        let mut st = self.state.lock().await;
+        if st.delete_branch_error {
+            return Err(CoreError::network("simulated branch deletion failure"));
+        }
+        st.deleted_branches.push(branch_name.to_string());
+        Ok(())
+    }
+
+    async fn get_collaborator_permission(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _username: &str,
+    ) -> CoreResult<CollaboratorPermission> {
+        Ok(CollaboratorPermission::Write)
+    }
+
+    async fn get_latest_release(&self, _owner: &str, _repo: &str) -> CoreResult<Option<Release>> {
+        Ok(None)
+    }
+
+    async fn get_pull_request(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _pr_number: u64,
+    ) -> CoreResult<PullRequest> {
+        Err(CoreError::not_found("stub"))
+    }
+
+    async fn get_release_by_tag(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        tag: &str,
+    ) -> CoreResult<Release> {
+        let st = self.state.lock().await;
+        st.releases_by_tag
+            .get(tag)
+            .cloned()
+            .ok_or_else(|| CoreError::not_found(format!("release for tag '{tag}'")))
+    }
+
+    async fn list_pr_labels(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _issue_number: u64,
+    ) -> CoreResult<Vec<Label>> {
+        Ok(vec![])
+    }
+
+    async fn list_pull_requests(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _state: Option<&str>,
+        _head: Option<&str>,
+        _base: Option<&str>,
+        _per_page: Option<u8>,
+        _page: Option<u32>,
+    ) -> CoreResult<Vec<PullRequest>> {
+        Ok(vec![])
+    }
+
+    async fn list_releases(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _per_page: Option<u8>,
+        _page: Option<u32>,
+    ) -> CoreResult<Vec<Release>> {
+        Ok(vec![])
+    }
+
+    async fn remove_label(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _issue_number: u64,
+        _label_name: &str,
+    ) -> CoreResult<()> {
+        Ok(())
+    }
+
+    async fn search_pull_requests(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _query: &str,
+    ) -> CoreResult<Vec<PullRequest>> {
+        Ok(vec![])
+    }
+
+    async fn update_pull_request(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        pr_number: u64,
+        title: Option<String>,
+        body: Option<String>,
+        state: Option<String>,
+    ) -> CoreResult<PullRequest> {
+        let now = Utc::now();
+        let r = stub_repo("test", "repo");
+        Ok(PullRequest {
+            number: pr_number,
+            title: title.unwrap_or_else(|| "updated".to_string()),
+            body,
+            state: state.unwrap_or_else(|| "open".to_string()),
+            draft: false,
+            created_at: now,
+            updated_at: now,
+            merged_at: None,
+            user: stub_git_user(),
+            head: PullRequestBranch {
+                ref_name: "release/v1.0.0".to_string(),
+                sha: "abc".to_string(),
+                repo: r.clone(),
+            },
+            base: PullRequestBranch {
+                ref_name: "main".to_string(),
+                sha: "def".to_string(),
+                repo: r,
+            },
+        })
+    }
+
+    async fn update_release(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _release_id: u64,
+        _params: UpdateReleaseParams,
+    ) -> CoreResult<Release> {
+        Err(CoreError::not_supported("update_release", "stub"))
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+fn stub_repo(owner: &str, repo: &str) -> Repository {
+    Repository {
+        id: 1,
+        name: repo.to_string(),
+        full_name: format!("{owner}/{repo}"),
+        owner: owner.to_string(),
+        description: None,
+        private: false,
+        default_branch: "main".to_string(),
+        clone_url: format!("https://github.com/{owner}/{repo}.git"),
+        ssh_url: format!("git@github.com:{owner}/{repo}.git"),
+        homepage: None,
+    }
+}
+
+fn stub_git_user() -> GitHubUser {
+    GitHubUser {
+        name: "test-user".to_string(),
+        email: "test@example.com".to_string(),
+        login: Some("test-user".to_string()),
+    }
+}
+
+fn stub_release(id: u64, tag_name: &str, prerelease: bool) -> Release {
+    let now = Utc::now();
+    Release {
+        id,
+        tag_name: tag_name.to_string(),
+        name: Some(tag_name.to_string()),
+        body: Some(String::new()),
+        draft: false,
+        prerelease,
+        created_at: now,
+        published_at: Some(now),
+        author: stub_git_user(),
+        target_commitish: tag_name.to_string(),
+    }
+}
+
+/// Build a minimal [`ProcessingEvent`] representing a merged release PR.
+///
+/// `branch` is the head branch of the merged PR (e.g. `"release/v1.2.3"`).
+/// `merge_sha` is the merge commit SHA.
+/// `body` is the PR body content (may include `## Changelog` section).
+fn make_release_pr_event(branch: &str, merge_sha: &str, body: &str) -> ProcessingEvent {
+    let payload = serde_json::json!({
+        "pull_request": {
+            "number": 42,
+            "head": {
+                "ref": branch,
+                "sha": merge_sha
+            },
+            "merge_commit_sha": merge_sha,
+            "body": body
+        }
+    });
+    ProcessingEvent {
+        event_id: "evt-001".to_string(),
+        correlation_id: "corr-001".to_string(),
+        event_type: EventType::ReleasePrMerged,
+        repository: RepositoryInfo {
+            owner: "testorg".to_string(),
+            name: "testrepo".to_string(),
+            default_branch: "main".to_string(),
+        },
+        payload,
+        received_at: Utc::now(),
+        source: EventSourceKind::Webhook,
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// extract_version_from_branch tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_extract_version_from_branch_valid_stable() {
+    let v = extract_version_from_branch("release/v1.2.3", "release").unwrap();
+    assert_eq!(v.major, 1);
+    assert_eq!(v.minor, 2);
+    assert_eq!(v.patch, 3);
+    assert!(v.prerelease.is_none());
+}
+
+#[test]
+fn test_extract_version_from_branch_prerelease() {
+    let v = extract_version_from_branch("release/v1.0.0-rc.1", "release").unwrap();
+    assert_eq!(v.major, 1);
+    assert_eq!(v.minor, 0);
+    assert_eq!(v.patch, 0);
+    assert_eq!(v.prerelease.as_deref(), Some("rc.1"));
+    assert!(v.is_prerelease());
+}
+
+#[test]
+fn test_extract_version_from_branch_wrong_prefix_returns_error() {
+    let err = extract_version_from_branch("feature/my-feature", "release").unwrap_err();
+    assert!(matches!(err, CoreError::InvalidInput { .. }));
+}
+
+#[test]
+fn test_extract_version_from_branch_missing_v_prefix_returns_error() {
+    let err = extract_version_from_branch("release/1.2.3", "release").unwrap_err();
+    assert!(matches!(err, CoreError::InvalidInput { .. }));
+}
+
+#[test]
+fn test_extract_version_from_branch_invalid_semver_returns_error() {
+    let err = extract_version_from_branch("release/vnot-semver", "release").unwrap_err();
+    assert!(matches!(
+        err,
+        CoreError::InvalidInput { .. } | CoreError::Versioning { .. }
+    ));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// is_release_pr_branch tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_is_release_pr_branch_matching() {
+    assert!(is_release_pr_branch("release/v1.2.3", "release"));
+    assert!(is_release_pr_branch("release/v0.1.0-alpha.1", "release"));
+}
+
+#[test]
+fn test_is_release_pr_branch_non_matching() {
+    assert!(!is_release_pr_branch("feature/my-feature", "release"));
+    assert!(!is_release_pr_branch("fix/bug", "release"));
+    assert!(!is_release_pr_branch("release/no-version", "release"));
+    assert!(!is_release_pr_branch("main", "release"));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ReleaseAutomator::automate tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_automate_happy_path_creates_tag_release_and_deletes_branch() {
+    let github = TestGitHub::new();
+    let config = AutomatorConfig::default();
+    let automator = ReleaseAutomator::new(config, &github);
+
+    let event = make_release_pr_event(
+        "release/v1.2.3",
+        "deadbeef1234567890deadbeef1234567890abcd",
+        "## Changelog\n\n- feat: add widget [abc123def456789012345678901234567890abcd]\n",
+    );
+
+    let result = automator
+        .automate("testorg", "testrepo", &event, "corr-001")
+        .await
+        .unwrap();
+
+    let AutomatorResult::Created { release } = result;
+    assert_eq!(release.tag_name, "v1.2.3");
+    assert!(!release.prerelease);
+
+    let tags = github.created_tags().await;
+    assert_eq!(tags.len(), 1);
+    assert_eq!(tags[0].0, "v1.2.3");
+    assert_eq!(tags[0].1, "deadbeef1234567890deadbeef1234567890abcd");
+
+    let releases = github.created_releases().await;
+    assert_eq!(releases.len(), 1);
+    assert_eq!(releases[0].tag_name, "v1.2.3");
+    assert!(!releases[0].prerelease);
+
+    let branches = github.deleted_branches().await;
+    assert_eq!(branches, vec!["release/v1.2.3"]);
+}
+
+#[tokio::test]
+async fn test_automate_prerelease_version_sets_prerelease_flag() {
+    let github = TestGitHub::new();
+    let automator = ReleaseAutomator::new(AutomatorConfig::default(), &github);
+
+    let event = make_release_pr_event(
+        "release/v1.0.0-rc.1",
+        "deadbeef1234567890deadbeef1234567890abcd",
+        "## Changelog\n\n- fix: prep rc [abc123def456789012345678901234567890abcd]\n",
+    );
+
+    let result = automator
+        .automate("testorg", "testrepo", &event, "corr-001")
+        .await
+        .unwrap();
+
+    let AutomatorResult::Created { release } = result;
+    assert!(release.prerelease, "Expected prerelease flag to be set");
+    assert_eq!(release.tag_name, "v1.0.0-rc.1");
+
+    let releases = github.created_releases().await;
+    assert_eq!(releases.len(), 1);
+    assert!(releases[0].prerelease);
+}
+
+#[tokio::test]
+async fn test_automate_stable_version_does_not_set_prerelease_flag() {
+    let github = TestGitHub::new();
+    let automator = ReleaseAutomator::new(AutomatorConfig::default(), &github);
+
+    let event = make_release_pr_event(
+        "release/v2.0.0",
+        "deadbeef1234567890deadbeef1234567890abcd",
+        "",
+    );
+
+    let result = automator
+        .automate("testorg", "testrepo", &event, "corr-001")
+        .await
+        .unwrap();
+
+    let AutomatorResult::Created { release } = result;
+    assert!(
+        !release.prerelease,
+        "Stable version must not set prerelease"
+    );
+}
+
+#[tokio::test]
+async fn test_automate_idempotent_tag_and_release_both_exist() {
+    let existing_release = stub_release(42, "v1.2.3", false);
+    let github = TestGitHub::new()
+        .with_tag_conflict()
+        .await
+        .with_release_for_tag("v1.2.3", existing_release.clone())
+        .await;
+    let automator = ReleaseAutomator::new(AutomatorConfig::default(), &github);
+
+    let event = make_release_pr_event(
+        "release/v1.2.3",
+        "deadbeef1234567890deadbeef1234567890abcd",
+        "",
+    );
+
+    let result = automator
+        .automate("testorg", "testrepo", &event, "corr-001")
+        .await
+        .unwrap();
+
+    let AutomatorResult::Created { release } = result;
+    assert_eq!(
+        release.id, 42,
+        "Expected the pre-existing release to be returned"
+    );
+
+    // No new releases created and no branch deleted (already complete).
+    assert!(
+        github.created_releases().await.is_empty(),
+        "No new release should be created when both tag and release exist"
+    );
+    assert!(
+        github.deleted_branches().await.is_empty(),
+        "Branch should not be deleted when idempotently returning existing release"
+    );
+}
+
+#[tokio::test]
+async fn test_automate_tag_exists_but_release_missing_resumes() {
+    // Tag exists but release does not — automator should create the release.
+    let github = TestGitHub::new().with_tag_conflict().await;
+    let automator = ReleaseAutomator::new(AutomatorConfig::default(), &github);
+
+    let event = make_release_pr_event(
+        "release/v1.2.3",
+        "deadbeef1234567890deadbeef1234567890abcd",
+        "## Changelog\n\n- feat: resumed [abc123def456789012345678901234567890abcd]\n",
+    );
+
+    let result = automator
+        .automate("testorg", "testrepo", &event, "corr-001")
+        .await
+        .unwrap();
+
+    let AutomatorResult::Created { release } = result;
+    assert_eq!(release.tag_name, "v1.2.3");
+
+    let releases = github.created_releases().await;
+    assert_eq!(
+        releases.len(),
+        1,
+        "Release should be created from the existing tag"
+    );
+
+    // Branch should still be cleaned up.
+    let branches = github.deleted_branches().await;
+    assert_eq!(branches, vec!["release/v1.2.3"]);
+}
+
+#[tokio::test]
+async fn test_automate_github_api_failure_on_tag_creation_propagates() {
+    let github = TestGitHub::new().with_create_tag_github_error().await;
+    let automator = ReleaseAutomator::new(AutomatorConfig::default(), &github);
+
+    let event = make_release_pr_event(
+        "release/v1.2.3",
+        "deadbeef1234567890deadbeef1234567890abcd",
+        "",
+    );
+
+    let err = automator
+        .automate("testorg", "testrepo", &event, "corr-001")
+        .await
+        .unwrap_err();
+
+    assert!(
+        matches!(err, CoreError::Network { .. }),
+        "Expected Network error from create_tag failure, got: {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_automate_github_api_failure_on_release_creation_propagates() {
+    let github = TestGitHub::new().with_create_release_error().await;
+    let automator = ReleaseAutomator::new(AutomatorConfig::default(), &github);
+
+    let event = make_release_pr_event(
+        "release/v1.2.3",
+        "deadbeef1234567890deadbeef1234567890abcd",
+        "",
+    );
+
+    let err = automator
+        .automate("testorg", "testrepo", &event, "corr-001")
+        .await
+        .unwrap_err();
+
+    assert!(
+        matches!(err, CoreError::Network { .. }),
+        "Expected Network error from create_release failure, got: {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_automate_branch_delete_failure_is_nonfatal() {
+    let github = TestGitHub::new().with_delete_branch_error().await;
+    let automator = ReleaseAutomator::new(AutomatorConfig::default(), &github);
+
+    let event = make_release_pr_event(
+        "release/v1.2.3",
+        "deadbeef1234567890deadbeef1234567890abcd",
+        "",
+    );
+
+    // Should succeed even though delete_branch fails.
+    let result = automator
+        .automate("testorg", "testrepo", &event, "corr-001")
+        .await
+        .unwrap();
+
+    let AutomatorResult::Created { release } = result;
+    assert_eq!(release.tag_name, "v1.2.3");
+
+    // Release was still created despite branch deletion failure.
+    assert_eq!(github.created_releases().await.len(), 1);
+}
+
+#[tokio::test]
+async fn test_automate_missing_head_ref_returns_invalid_input() {
+    let github = TestGitHub::new();
+    let automator = ReleaseAutomator::new(AutomatorConfig::default(), &github);
+
+    // Payload without pull_request.head.ref
+    let event = ProcessingEvent {
+        event_id: "evt-bad".to_string(),
+        correlation_id: "corr-bad".to_string(),
+        event_type: EventType::ReleasePrMerged,
+        repository: RepositoryInfo {
+            owner: "org".to_string(),
+            name: "repo".to_string(),
+            default_branch: "main".to_string(),
+        },
+        payload: serde_json::json!({ "pull_request": { "number": 1 } }),
+        received_at: Utc::now(),
+        source: EventSourceKind::Webhook,
+    };
+
+    let err = automator
+        .automate("org", "repo", &event, "corr-bad")
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, CoreError::InvalidInput { .. }),
+        "Expected InvalidInput for missing head.ref, got: {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_automate_missing_merge_sha_returns_invalid_input() {
+    let github = TestGitHub::new();
+    let automator = ReleaseAutomator::new(AutomatorConfig::default(), &github);
+
+    // Payload has head.ref but no merge_commit_sha or head.sha
+    let event = ProcessingEvent {
+        event_id: "evt-bad".to_string(),
+        correlation_id: "corr-bad".to_string(),
+        event_type: EventType::ReleasePrMerged,
+        repository: RepositoryInfo {
+            owner: "org".to_string(),
+            name: "repo".to_string(),
+            default_branch: "main".to_string(),
+        },
+        payload: serde_json::json!({
+            "pull_request": {
+                "head": { "ref": "release/v1.0.0" }
+            }
+        }),
+        received_at: Utc::now(),
+        source: EventSourceKind::Webhook,
+    };
+
+    let err = automator
+        .automate("org", "repo", &event, "corr-bad")
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, CoreError::InvalidInput { .. }),
+        "Expected InvalidInput for missing both SHAs, got: {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_automate_invalid_branch_version_returns_error() {
+    let github = TestGitHub::new();
+    let automator = ReleaseAutomator::new(AutomatorConfig::default(), &github);
+
+    // Branch starts with release/v but has invalid semver
+    let event = make_release_pr_event(
+        "release/vnot-valid",
+        "deadbeef1234567890deadbeef1234567890abcd",
+        "",
+    );
+
+    let err = automator
+        .automate("testorg", "testrepo", &event, "corr-001")
+        .await
+        .unwrap_err();
+    // The error comes from VersionCalculator::parse_version which returns Versioning or InvalidInput.
+    assert!(
+        matches!(
+            err,
+            CoreError::InvalidInput { .. } | CoreError::Versioning { .. }
+        ),
+        "Expected parse error for invalid semver branch, got: {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_automate_changelog_extracted_from_pr_body() {
+    let github = TestGitHub::new();
+    let automator = ReleaseAutomator::new(AutomatorConfig::default(), &github);
+
+    let body = "## Changelog\n\n- feat: add widget [abc123def456789012345678901234567890abcd]\n- fix: bug [bcd234ef0123456789012345678901234567890ef]\n\n## Notes\n\nSee wiki.";
+    let event = make_release_pr_event(
+        "release/v1.0.0",
+        "deadbeef1234567890deadbeef1234567890abcd",
+        body,
+    );
+
+    automator
+        .automate("testorg", "testrepo", &event, "corr-001")
+        .await
+        .unwrap();
+
+    let releases = github.created_releases().await;
+    assert_eq!(releases.len(), 1);
+    let release_body = releases[0].body.as_deref().unwrap_or("");
+    assert!(
+        release_body.contains("add widget"),
+        "Release body should contain changelog entry"
+    );
+    assert!(
+        !release_body.contains("See wiki"),
+        "Release body should not contain content after changelog section"
+    );
+}
+
+#[tokio::test]
+async fn test_automate_fallback_sha_used_when_merge_commit_sha_absent() {
+    let github = TestGitHub::new();
+    let automator = ReleaseAutomator::new(AutomatorConfig::default(), &github);
+
+    // Payload uses head.sha as fallback (no merge_commit_sha field).
+    let event = ProcessingEvent {
+        event_id: "evt-001".to_string(),
+        correlation_id: "corr-001".to_string(),
+        event_type: EventType::ReleasePrMerged,
+        repository: RepositoryInfo {
+            owner: "testorg".to_string(),
+            name: "testrepo".to_string(),
+            default_branch: "main".to_string(),
+        },
+        payload: serde_json::json!({
+            "pull_request": {
+                "head": {
+                    "ref": "release/v1.5.0",
+                    "sha": "cafebabe1234567890cafebabe1234567890abcd"
+                },
+                "body": ""
+            }
+        }),
+        received_at: Utc::now(),
+        source: EventSourceKind::Webhook,
+    };
+
+    automator
+        .automate("testorg", "testrepo", &event, "corr-001")
+        .await
+        .unwrap();
+
+    let tags = github.created_tags().await;
+    assert_eq!(tags.len(), 1);
+    assert_eq!(
+        tags[0].1, "cafebabe1234567890cafebabe1234567890abcd",
+        "Should use head.sha when merge_commit_sha is absent"
+    );
+}

--- a/crates/core/src/release_automator_tests.rs
+++ b/crates/core/src/release_automator_tests.rs
@@ -675,14 +675,17 @@ async fn test_automate_idempotent_tag_and_release_both_exist() {
         "Expected the pre-existing release to be returned"
     );
 
-    // No new releases created and no branch deleted (already complete).
+    // No new releases created, but branch deletion is still attempted so that
+    // a previous run that succeeded at tag+release but failed at deletion can
+    // be cleaned up on the next retry.
     assert!(
         github.created_releases().await.is_empty(),
         "No new release should be created when both tag and release exist"
     );
-    assert!(
-        github.deleted_branches().await.is_empty(),
-        "Branch should not be deleted when idempotently returning existing release"
+    assert_eq!(
+        github.deleted_branches().await,
+        vec!["release/v1.2.3".to_string()],
+        "Branch should still be deleted in the idempotent path"
     );
 }
 


### PR DESCRIPTION
Implements the ReleaseAutomator component (spec FR-5) that automatically creates
annotated Git tags, GitHub releases, and deletes the release branch when a release
PR is merged, with full idempotency support for safe retries.

## What Changed

- New `release_automator.rs` module in `crates/core` containing:
  - `ReleaseAutomator<'a, G>` — orchestrates tag creation, release creation, and
    branch deletion from a merged release PR event
  - `AutomatorConfig` — configurable `branch_prefix` and `changelog_header` with
    sensible defaults (`"release"` / `"## Changelog"`)
  - `AutomatorResult` — typed result carrying the created `Release`
  - `extract_version_from_branch(branch, prefix) -> CoreResult<SemanticVersion>` —
    public free function; strips `{prefix}/v` and parses the remainder as semver
  - `is_release_pr_branch(branch, prefix) -> bool` — public free function; detects
    release branches by prefix pattern
- Extended `MergedPullRequestHandler` trait in `lib.rs` with
  `handle_release_pr_merged` (default no-op) and wired it into
  `ReleaseRegentProcessor`
- Wired `EventType::ReleasePrMerged` in `run_event_loop` to dispatch to the new
  handler instead of the previous no-op stub
- 13 unit tests in `release_automator_tests.rs` using an inline `TestGitHub` test
  double; extended `SpyMergedPRHandler` in `lib_tests.rs` with
  `handle_release_pr_merged` tracking and updated the event-loop wiring test

## Why

Previously, `ReleasePrMerged` events were acknowledged but produced no side effects
— no Git tag, no GitHub release, no branch cleanup. The merge of a release PR needs
to culminate in a published GitHub release so that downstream consumers can consume
artefacts and changelogs automatically, per FR-5.

## How

`ReleaseAutomator.automate()` executes the following steps in order:

1. Extracts the branch name, merge commit SHA, and PR body from the webhook payload
2. Derives the semantic version from the branch name (`release/v{version}`)
3. Calls `create_tag` — if the tag already exists (`NotSupported`), checks whether a
   release also exists (`get_release_by_tag`) to handle idempotent retries
4. Extracts changelog text from the PR body via the existing
   `extract_changelog_from_pr_body` helper in `release_orchestrator`
5. Calls `create_release` with the pre-release flag set when the version string
   contains a hyphen (e.g. `1.0.0-rc.1`)
6. Calls `delete_branch` — failure is non-fatal: the error is warn-logged and the
   automator still returns success so the event is not retried purely for a branch
   that may already be deleted

## Testing Evidence

- **Test Coverage:** 4 files changed, 1,384 lines added; 13 new unit tests covering
  happy path, pre-release flag, idempotency (tag + release both exist), resume from
  existing tag (release missing), non-fatal branch delete failure, tag creation
  failure, release creation failure, missing payload fields, invalid semver branch,
  changelog extraction from PR body, and merge SHA fallback from `head.sha`
- **Test Results:** All 222 unit tests and 18 doc-tests pass; zero new clippy errors
- **Manual Testing:** None; full coverage via automated tests

## Reviewer Guidance

- **Idempotency path** (`ensure_tag_and_get_existing_release`): when `create_tag`
  returns `NotSupported` (tag already exists), the automator falls through to
  `get_release_by_tag`. If the release is also present it returns success; if it
  returns `NotFound` it proceeds to create the release from the existing tag. Verify
  this two-step recovery is the expected retry behaviour.
- **Branch delete non-fatal**: a `delete_branch` failure logs at `WARN` and returns
  `Ok`. Confirm this is acceptable — a branch that fails to delete will need manual
  cleanup but should not block the release from being published.
- **No breaking changes**: `MergedPullRequestHandler::handle_release_pr_merged` has
  a default no-op implementation so all existing trait implementors compile without
  modification.