### PR TITLE
feat(release-automator): implement BA-13 version-extraction fallback chain

### DIFF
--- a/crates/core/src/release_automator.rs
+++ b/crates/core/src/release_automator.rs
@@ -143,8 +143,9 @@ impl<'a, G: GitHubOperations + Send + Sync> ReleaseAutomator<'a, G> {
         event: &ProcessingEvent,
         correlation_id: &str,
     ) -> CoreResult<AutomatorResult> {
-        let (branch, merge_sha, pr_body) = extract_payload_fields(event)?;
-        let version = extract_version_from_branch(&branch, &self.config.branch_prefix)?;
+        let (branch, merge_sha, pr_body, pr_title) = extract_payload_fields(event)?;
+        let version =
+            extract_version_from_pr(&branch, &pr_title, &pr_body, &self.config.branch_prefix)?;
         let tag_name = version.to_string_with_prefix(true);
 
         info!(
@@ -268,9 +269,10 @@ impl<'a, G: GitHubOperations + Send + Sync> ReleaseAutomator<'a, G> {
 // Free helpers
 // ─────────────────────────────────────────────────────────────────────────────
 
-/// Extract the three required fields from a `ReleasePrMerged` webhook payload.
+/// Extract the required fields from a `ReleasePrMerged` webhook payload.
 ///
-/// Returns `(branch, merge_sha, pr_body)`.
+/// Returns `(branch, merge_sha, pr_body, pr_title)`.  The `pr_title` defaults
+/// to an empty string when `pull_request.title` is absent.
 ///
 /// # Errors
 ///
@@ -280,7 +282,7 @@ impl<'a, G: GitHubOperations + Send + Sync> ReleaseAutomator<'a, G> {
 // The same allow is applied to `extract_version_from_branch` and other free
 // functions in this file for the same reason.
 #[allow(clippy::result_large_err)]
-fn extract_payload_fields(event: &ProcessingEvent) -> CoreResult<(String, String, String)> {
+fn extract_payload_fields(event: &ProcessingEvent) -> CoreResult<(String, String, String, String)> {
     let branch = event
         .payload
         .get("pull_request")
@@ -325,7 +327,15 @@ fn extract_payload_fields(event: &ProcessingEvent) -> CoreResult<(String, String
         .unwrap_or("")
         .to_string();
 
-    Ok((branch, merge_sha, pr_body))
+    let pr_title = event
+        .payload
+        .get("pull_request")
+        .and_then(|pr| pr.get("title"))
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("")
+        .to_string();
+
+    Ok((branch, merge_sha, pr_body, pr_title))
 }
 
 /// Extract a [`SemanticVersion`] from a release branch name.
@@ -372,6 +382,133 @@ pub fn extract_version_from_branch(
         )
     })?;
     VersionCalculator::parse_version(version_str)
+}
+
+/// Extract a [`SemanticVersion`] from a release PR using a three-level fallback chain.
+///
+/// The chain is evaluated in priority order:
+///
+/// 1. **Branch name** — delegates to [`extract_version_from_branch`]; succeeds
+///    for branches matching `{branch_prefix}/v{semver}`.
+/// 2. **PR title** — scans whitespace-separated tokens for the first one that
+///    starts with `v` *and* is a valid semantic version
+///    (e.g. `chore(release): v1.2.3` → `1.2.3`).
+/// 3. **PR body** — scans whitespace-separated tokens for the first valid
+///    semantic version with an optional `v` prefix
+///    (e.g. `v1.2.3` or `1.2.3`).
+///
+/// Returns [`CoreError::InvalidInput`] when no valid semver can be extracted
+/// from any of the three sources.
+///
+/// [`extract_version_from_branch`] is **unchanged** by this addition; all
+/// existing call sites that use it directly are unaffected.
+///
+/// # Parameters
+///
+/// - `branch`: PR head branch name (e.g. `release/v1.2.3`).
+/// - `title`: PR title string (e.g. `chore(release): v1.2.3`).
+/// - `body`: PR body text.
+/// - `branch_prefix`: Release branch prefix (e.g. `release`).
+///
+/// # Errors
+///
+/// Returns [`CoreError::InvalidInput`] when all three sources fail to yield a
+/// valid semantic version.
+///
+/// # Examples
+///
+/// ```
+/// use release_regent_core::release_automator::extract_version_from_pr;
+///
+/// // Branch name wins when valid.
+/// let v = extract_version_from_pr("release/v1.2.3", "no version", "no version", "release")
+///     .unwrap();
+/// assert_eq!(v.to_string(), "1.2.3");
+///
+/// // Falls back to title when branch is not a release branch.
+/// let v = extract_version_from_pr("feature/x", "chore(release): v2.0.0", "", "release")
+///     .unwrap();
+/// assert_eq!(v.to_string(), "2.0.0");
+/// ```
+// `CoreError` is a large enum used uniformly throughout the codebase.
+// Boxing it would require changing the entire `CoreResult<T>` type alias — a
+// project-wide refactor. Allow the lint here as it is consistent with the
+// existing pattern.
+#[allow(clippy::result_large_err)]
+pub fn extract_version_from_pr(
+    branch: &str,
+    title: &str,
+    body: &str,
+    branch_prefix: &str,
+) -> CoreResult<SemanticVersion> {
+    // Step 1: branch name.
+    if let Ok(version) = extract_version_from_branch(branch, branch_prefix) {
+        return Ok(version);
+    }
+
+    // Step 2: PR title — require a `v`-prefixed token.
+    if let Some(version) = find_version_token(title, true) {
+        return Ok(version);
+    }
+
+    // Step 3: PR body — `v` prefix is optional.
+    if let Some(version) = find_version_token(body, false) {
+        return Ok(version);
+    }
+
+    Err(CoreError::invalid_input(
+        "version",
+        format!(
+            "Could not extract a valid semantic version from branch '{branch}', \
+             PR title, or PR body"
+        ),
+    ))
+}
+
+/// Scan `text` for the first whitespace-separated token that is a valid semver.
+///
+/// Surrounding punctuation (`:`, `,`, `(`, `)`, `[`, `]`, etc.) is stripped
+/// from each token before parsing so that tokens like `v1.2.3,` or `(v1.2.3)`
+/// are recognised correctly.
+///
+/// When `require_v_prefix` is `true`, only tokens that begin with `v` (followed
+/// by a digit) are considered.  When `false`, a `v` prefix is stripped when
+/// present but is not required.
+fn find_version_token(text: &str, require_v_prefix: bool) -> Option<SemanticVersion> {
+    for token in text.split_whitespace() {
+        // Strip common surrounding punctuation that cannot appear in semver.
+        // The trailing `.` in prose like "version v3.1.4." is intentionally
+        // included; `trim_matches` only strips from the absolute edges so it
+        // will not discard the dots within `1.2.3`.)
+        let token = token.trim_matches(|c: char| {
+            matches!(
+                c,
+                ':' | ';' | ',' | '.' | '(' | ')' | '[' | ']' | '{' | '}' | '!' | '?' | '\'' | '"'
+            )
+        });
+
+        let starts_with_v = token.starts_with('v');
+
+        if require_v_prefix {
+            if !starts_with_v {
+                continue;
+            }
+            // Reject tokens like "version" where 'v' is followed by a non-digit.
+            if !token
+                .get(1..)
+                .is_some_and(|rest| rest.starts_with(|c: char| c.is_ascii_digit()))
+            {
+                continue;
+            }
+        } else if !starts_with_v && !token.starts_with(|c: char| c.is_ascii_digit()) {
+            continue;
+        }
+
+        if let Ok(version) = VersionCalculator::parse_version(token) {
+            return Some(version);
+        }
+    }
+    None
 }
 
 /// Returns `true` when the branch name starts with the release branch prefix

--- a/crates/core/src/release_automator.rs
+++ b/crates/core/src/release_automator.rs
@@ -7,7 +7,12 @@
 //!
 //! When [`EventType::ReleasePrMerged`] arrives in the event loop, the automator:
 //!
-//! 1. **Extracts** the version from the PR head branch name (`release/v{version}`).
+//! 1. **Extracts** the version from the merged PR using a three-level fallback chain:
+//!    - Branch name: `release/v{version}` (e.g. `release/v1.2.3`).
+//!    - PR title: first `v`-prefixed semver token (e.g. `chore(release): v1.2.3`).
+//!    - PR body: first semver token with an optional `v` prefix.
+//!    Fails with [`CoreError::InvalidInput`] only if no valid semver is found in any
+//!    of the three sources.
 //! 2. **Extracts** the merge commit SHA from the webhook payload.
 //! 3. **Creates an annotated Git tag** pointing to the merge commit.
 //! 4. **Extracts** the changelog from the PR body.
@@ -442,17 +447,37 @@ pub fn extract_version_from_pr(
     branch_prefix: &str,
 ) -> CoreResult<SemanticVersion> {
     // Step 1: branch name.
-    if let Ok(version) = extract_version_from_branch(branch, branch_prefix) {
-        return Ok(version);
+    match extract_version_from_branch(branch, branch_prefix) {
+        Ok(version) => return Ok(version),
+        Err(ref e) => {
+            tracing::debug!(
+                branch,
+                error = %e,
+                "Branch version extraction failed; trying PR title"
+            );
+        }
     }
 
     // Step 2: PR title — require a `v`-prefixed token.
     if let Some(version) = find_version_token(title, true) {
+        tracing::debug!(
+            ?title,
+            "Extracted version from PR title after branch name failed"
+        );
         return Ok(version);
     }
+    tracing::debug!(
+        ?title,
+        "PR title contained no v-prefixed semver token; trying PR body"
+    );
 
     // Step 3: PR body — `v` prefix is optional.
+    // Note: tokens starting with a digit (e.g. `3.14.1`, `2026.4.7`) are also
+    // scanned here which could produce false positives in prose-heavy bodies.
+    // This is an accepted trade-off: body scanning is only reached after both
+    // branch name and PR title have failed.
     if let Some(version) = find_version_token(body, false) {
+        tracing::debug!("Extracted version from PR body after branch name and title failed");
         return Ok(version);
     }
 

--- a/crates/core/src/release_automator_tests.rs
+++ b/crates/core/src/release_automator_tests.rs
@@ -543,6 +543,181 @@ fn test_extract_version_from_branch_invalid_semver_returns_error() {
     ));
 }
 
+/// Build a [`ProcessingEvent`] representing a merged release PR, including an
+/// explicit `title` field in the payload.
+///
+/// Used to test the PR-title fallback in [`extract_version_from_pr`].
+fn make_release_pr_event_with_title(
+    branch: &str,
+    title: &str,
+    merge_sha: &str,
+    body: &str,
+) -> ProcessingEvent {
+    let payload = serde_json::json!({
+        "pull_request": {
+            "number": 42,
+            "title": title,
+            "head": {
+                "ref": branch,
+                "sha": merge_sha
+            },
+            "merge_commit_sha": merge_sha,
+            "body": body
+        }
+    });
+    ProcessingEvent {
+        event_id: "evt-001".to_string(),
+        correlation_id: "corr-001".to_string(),
+        event_type: EventType::ReleasePrMerged,
+        repository: RepositoryInfo {
+            owner: "testorg".to_string(),
+            name: "testrepo".to_string(),
+            default_branch: "main".to_string(),
+        },
+        payload,
+        received_at: Utc::now(),
+        source: EventSourceKind::Webhook,
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// extract_version_from_pr tests  (BA-13)
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_extract_version_from_pr_branch_path_takes_priority() {
+    // Step 1 succeeds: title and body also contain versions but branch wins.
+    let v = extract_version_from_pr(
+        "release/v2.0.0",
+        "chore(release): v9.9.9",
+        "Release v8.8.8 notes",
+        "release",
+    )
+    .unwrap();
+    assert_eq!(v.major, 2);
+    assert_eq!(v.minor, 0);
+    assert_eq!(v.patch, 0);
+}
+
+#[test]
+fn test_extract_version_from_pr_title_fallback_conventional_commit() {
+    // Step 1 fails (feature branch), step 2 extracts from conventional commit title.
+    let v = extract_version_from_pr(
+        "feature/my-feature",
+        "chore(release): v1.5.0",
+        "",
+        "release",
+    )
+    .unwrap();
+    assert_eq!(v.major, 1);
+    assert_eq!(v.minor, 5);
+    assert_eq!(v.patch, 0);
+}
+
+#[test]
+fn test_extract_version_from_pr_title_fallback_prerelease_token() {
+    // Step 1 fails, step 2 extracts a pre-release version token from title.
+    let v = extract_version_from_pr(
+        "feature/my-feature",
+        "chore(release): v3.0.0-rc.2",
+        "",
+        "release",
+    )
+    .unwrap();
+    assert_eq!(v.major, 3);
+    assert_eq!(v.minor, 0);
+    assert_eq!(v.patch, 0);
+    assert_eq!(v.prerelease.as_deref(), Some("rc.2"));
+}
+
+#[test]
+fn test_extract_version_from_pr_body_fallback_version_in_body() {
+    // Steps 1 and 2 fail; step 3 extracts from body.
+    let v = extract_version_from_pr(
+        "feature/my-feature",
+        "some title without version info",
+        "This release contains changes for v3.1.4.",
+        "release",
+    )
+    .unwrap();
+    assert_eq!(v.major, 3);
+    assert_eq!(v.minor, 1);
+    assert_eq!(v.patch, 4);
+}
+
+#[test]
+fn test_extract_version_from_pr_body_fallback_no_v_prefix() {
+    // Body fallback accepts version tokens without a `v` prefix.
+    let v = extract_version_from_pr(
+        "feature/x",
+        "no version here",
+        "Version 4.2.1 released",
+        "release",
+    )
+    .unwrap();
+    assert_eq!(v.major, 4);
+    assert_eq!(v.minor, 2);
+    assert_eq!(v.patch, 1);
+}
+
+#[test]
+fn test_extract_version_from_pr_all_sources_fail_returns_invalid_input() {
+    let err = extract_version_from_pr("feature/x", "no version", "no version here", "release")
+        .unwrap_err();
+    assert!(
+        matches!(err, CoreError::InvalidInput { .. }),
+        "Expected InvalidInput when all three fallbacks fail, got: {err:?}"
+    );
+}
+
+#[test]
+fn test_extract_version_from_pr_malformed_v_token_in_title_falls_through_to_body() {
+    // Title has a `v`-prefixed token that is not valid semver; falls through to body.
+    let v = extract_version_from_pr(
+        "feature/not-a-release",
+        "chore: vnot-semver update",
+        "Body contains v1.2.3 as the actual version",
+        "release",
+    )
+    .unwrap();
+    assert_eq!(v.major, 1);
+    assert_eq!(v.minor, 2);
+    assert_eq!(v.patch, 3);
+}
+
+#[test]
+fn test_extract_version_from_pr_title_requires_v_prefix() {
+    // Title has a bare version (no `v`) — title step must not match it; body
+    // step may match it when reached.
+    let v = extract_version_from_pr(
+        "feature/x",
+        "bump to 5.0.0",
+        "releasing 5.0.0 today",
+        "release",
+    )
+    .unwrap();
+    // Either body scan (step 3, no v-prefix required) found "5.0.0".
+    assert_eq!(v.major, 5);
+    assert_eq!(v.minor, 0);
+    assert_eq!(v.patch, 0);
+}
+
+#[test]
+fn test_extract_version_from_pr_branch_prerelease_version() {
+    // Branch with a pre-release version — step 1 must succeed.
+    let v = extract_version_from_pr("release/v1.0.0-rc.1", "no version", "no version", "release")
+        .unwrap();
+    assert!(v.is_prerelease());
+    assert_eq!(v.major, 1);
+    assert_eq!(v.minor, 0);
+    assert_eq!(v.patch, 0);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// make_release_pr_event_with_title helper and its tests are below the
+// is_release_pr_branch tests, inline with the automate integration tests.
+// ─────────────────────────────────────────────────────────────────────────────
+
 // ─────────────────────────────────────────────────────────────────────────────
 // is_release_pr_branch tests
 // ─────────────────────────────────────────────────────────────────────────────
@@ -947,5 +1122,89 @@ async fn test_automate_fallback_sha_used_when_merge_commit_sha_absent() {
     assert_eq!(
         tags[0].1, "cafebabe1234567890cafebabe1234567890abcd",
         "Should use head.sha when merge_commit_sha is absent"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ReleaseAutomator::automate — BA-13 fallback chain integration tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_automate_title_fallback_when_branch_version_is_invalid() {
+    // Branch name has an invalid semver suffix but the PR title contains a
+    // valid `v`-prefixed version token.
+    let github = TestGitHub::new();
+    let automator = ReleaseAutomator::new(AutomatorConfig::default(), &github);
+
+    let event = make_release_pr_event_with_title(
+        "release/vnot-valid",
+        "chore(release): v1.5.0",
+        "deadbeef1234567890deadbeef1234567890abcd",
+        "## Changelog\n- fix: something",
+    );
+
+    let result = automator
+        .automate("testorg", "testrepo", &event, "corr-001")
+        .await
+        .unwrap();
+
+    let AutomatorResult::Created { release } = result;
+    assert_eq!(release.tag_name, "v1.5.0");
+
+    let tags = github.created_tags().await;
+    assert_eq!(tags.len(), 1);
+    assert_eq!(tags[0].0, "v1.5.0");
+}
+
+#[tokio::test]
+async fn test_automate_body_fallback_when_branch_and_title_lack_version() {
+    // Neither the branch name nor the PR title yields a valid version; the
+    // automator must fall back to the PR body.
+    let github = TestGitHub::new();
+    let automator = ReleaseAutomator::new(AutomatorConfig::default(), &github);
+
+    let event = make_release_pr_event_with_title(
+        "feature/my-feature",
+        "chore: some useful update",
+        "deadbeef1234567890deadbeef1234567890abcd",
+        "## Changelog\nThis release ships v2.3.4 of the system.",
+    );
+
+    let result = automator
+        .automate("testorg", "testrepo", &event, "corr-001")
+        .await
+        .unwrap();
+
+    let AutomatorResult::Created { release } = result;
+    assert_eq!(release.tag_name, "v2.3.4");
+
+    let tags = github.created_tags().await;
+    assert_eq!(tags.len(), 1);
+    assert_eq!(tags[0].0, "v2.3.4");
+}
+
+#[tokio::test]
+async fn test_automate_all_fallbacks_fail_returns_invalid_input() {
+    // All three sources fail to yield a valid semver — automate must return
+    // CoreError::InvalidInput so the event loop can treat it as a permanent
+    // failure (not retried).
+    let github = TestGitHub::new();
+    let automator = ReleaseAutomator::new(AutomatorConfig::default(), &github);
+
+    let event = make_release_pr_event_with_title(
+        "feature/my-feature",
+        "chore: no version here",
+        "deadbeef1234567890deadbeef1234567890abcd",
+        "",
+    );
+
+    let err = automator
+        .automate("testorg", "testrepo", &event, "corr-001")
+        .await
+        .unwrap_err();
+
+    assert!(
+        matches!(err, CoreError::InvalidInput { .. }),
+        "Expected InvalidInput when all fallbacks fail, got: {err:?}"
     );
 }

--- a/crates/core/src/release_automator_tests.rs
+++ b/crates/core/src/release_automator_tests.rs
@@ -713,10 +713,9 @@ fn test_extract_version_from_pr_branch_prerelease_version() {
     assert_eq!(v.patch, 0);
 }
 
-// ─────────────────────────────────────────────────────────────────────────────
-// make_release_pr_event_with_title helper and its tests are below the
-// is_release_pr_branch tests, inline with the automate integration tests.
-// ─────────────────────────────────────────────────────────────────────────────
+// Note: make_release_pr_event_with_title is defined above (before the
+// extract_version_from_pr tests). Its integration tests appear later in the
+// file alongside the other ReleaseAutomator::automate tests.
 
 // ─────────────────────────────────────────────────────────────────────────────
 // is_release_pr_branch tests
@@ -1044,13 +1043,13 @@ async fn test_automate_invalid_branch_version_returns_error() {
         .automate("testorg", "testrepo", &event, "corr-001")
         .await
         .unwrap_err();
-    // The error comes from VersionCalculator::parse_version which returns Versioning or InvalidInput.
+    // With the fallback chain in place, all three sources (branch, title, body)
+    // are tried before returning. The catch-all in extract_version_from_pr always
+    // returns CoreError::InvalidInput, so CoreError::Versioning is no longer
+    // reachable here.
     assert!(
-        matches!(
-            err,
-            CoreError::InvalidInput { .. } | CoreError::Versioning { .. }
-        ),
-        "Expected parse error for invalid semver branch, got: {err:?}"
+        matches!(err, CoreError::InvalidInput { .. }),
+        "Expected InvalidInput when all fallbacks fail, got: {err:?}"
     );
 }
 


### PR DESCRIPTION
Extends ReleaseAutomator with a three-level version extraction fallback chain
(branch name → PR title → PR body) to satisfy behavioral assertion BA-13, ensuring
version extraction succeeds even when the release branch name cannot be parsed.

## What Changed

- `extract_version_from_pr(branch, title, body, branch_prefix) -> CoreResult<SemanticVersion>`
  added as a new public free function in `crates/core/src/release_automator.rs`; evaluates
  three sources in priority order before returning `CoreError::InvalidInput`
- `find_version_token(text, require_v_prefix)` added as a private helper; scans
  whitespace-separated tokens, strips surrounding punctuation, and delegates to
  `VersionCalculator::parse_version`; the title scan requires a `v`-prefixed token while
  the body scan accepts both `v1.2.3` and bare `1.2.3` forms
- `extract_payload_fields` updated from a 3-tuple to a 4-tuple to also return
  `pull_request.title` from the webhook payload (defaults to `""` when absent)
- `ReleaseAutomator::automate` updated to call `extract_version_from_pr` instead of
  `extract_version_from_branch` directly
- `extract_version_from_branch` is unchanged; all existing call sites are unaffected

## Why

BA-13 requires version extraction to succeed even when the release branch name is
malformed or missing. Prior to this change, `automate()` would fail with
`CoreError::InvalidInput` in those cases and the release would never be published,
even though the version was clearly stated in the PR title or body.

## How

The three-step chain is evaluated in order and short-circuits on the first success.
Step 1 delegates to the existing `extract_version_from_branch`. Step 2 requires a
`v`-prefixed token in the title (matching the conventional commit format
`chore(release): v1.2.3`) to avoid false positives from unrelated numbers. Step 3
relaxes the prefix requirement for the body because PR bodies often contain prose
like `"This release ships v2.3.4"` or `"Version 4.2.1 released"`. Surrounding
punctuation (colons, commas, trailing periods, brackets, etc.) is stripped from
each token before parsing so tokens like `v1.2.3.` or `(v1.2.3)` are recognised.

## Testing Evidence

- **Test Coverage:** 13 new tests added — 10 unit tests for `extract_version_from_pr`
  covering branch-wins, title fallback (conventional commit and pre-release), body
  fallback (with and without `v` prefix), all-sources-fail, malformed title falls
  through to body, and title v-prefix requirement; 3 integration tests through
  `automate()` covering title fallback, body fallback, and all-fail paths; helper
  `make_release_pr_event_with_title` added for tests that need a payload `title` field
- **Test Results:** All 32 `release_automator` tests pass; zero new clippy errors
- **Manual Testing:** None; full coverage via automated tests

## Reviewer Guidance

- The title scan (`require_v_prefix = true`) intentionally rejects bare version
  numbers like `"bump to 5.0.0"` to avoid matching issue numbers or date strings;
  verify this trade-off is acceptable for your PR title conventions
- The body scan (`require_v_prefix = false`) is intentionally broad; confirm the
  punctuation-stripping set (colons, commas, periods, brackets, etc.) is sufficient
  and does not introduce false positives for your typical PR body content
- `extract_version_from_branch` is unchanged — no existing callers are affected
- No breaking changes; `extract_version_from_pr` is additive