### PR TITLE
refactor(auth): rename AzureKeyVaultSecretProvider to EnvSecretProvider and fix JWT timestamp bug

### DIFF
--- a/crates/github_client/README.md
+++ b/crates/github_client/README.md
@@ -72,7 +72,7 @@ Release Regent has migrated from octocrab to github-bot-sdk to improve architect
 ## Usage
 
 ```rust
-use release_regent_github_client::{GitHubClient, AuthConfig, AzureKeyVaultSecretProvider};
+use release_regent_github_client::{GitHubClient, AuthConfig, EnvSecretProvider};
 use github_bot_sdk::auth::AuthenticationProvider;
 
 // Configure authentication
@@ -82,7 +82,7 @@ let auth_config = AuthConfig {
     webhook_secret: "webhook-secret".to_string(),
 };
 
-let secret_provider = AzureKeyVaultSecretProvider::new(auth_config)?;
+let secret_provider = EnvSecretProvider::new(auth_config)?;
 
 // Create client
 let client = GitHubClient::new(

--- a/crates/github_client/README.md
+++ b/crates/github_client/README.md
@@ -54,7 +54,7 @@ Release Regent has migrated from octocrab to github-bot-sdk to improve architect
 - Tag operations (list, create, get)
 - Release operations (create, update, get, list)
 - Pull request operations (create, update, get)
-- Authentication via Azure Key Vault
+- Authentication via environment variables (injected by container runtime)
 - Rate limiting and retry logic
 
 ⚠️ **Temporarily Stubbed:**

--- a/crates/github_client/src/auth.rs
+++ b/crates/github_client/src/auth.rs
@@ -139,7 +139,10 @@ impl JwtSigner for DefaultJwtSigner {
                 message: format!("Failed to encode JWT: {e}"),
             })?;
 
-        let expires_at = DateTime::from_timestamp(exp, 0).unwrap_or_else(Utc::now);
+        let expires_at =
+            DateTime::from_timestamp(exp, 0).ok_or_else(|| SigningError::SigningFailed {
+                message: format!("JWT exp timestamp {exp} is out of range for DateTime"),
+            })?;
         Ok(JsonWebToken::new(token_string, app_id, expires_at))
     }
 

--- a/crates/github_client/src/auth.rs
+++ b/crates/github_client/src/auth.rs
@@ -27,19 +27,27 @@ pub struct AuthConfig {
     pub webhook_secret: String,
 }
 
-/// Azure Key Vault-based secret provider
+/// Environment-variable-based secret provider.
 ///
-/// Implements the [`SecretProvider`] trait for github-bot-sdk using Azure Key Vault
-/// for secret storage and retrieval.
+/// Implements the [`SecretProvider`] trait for github-bot-sdk by returning values
+/// that were loaded from environment variables at process startup and passed in via
+/// [`AuthConfig`].
+///
+/// # Deployment model
+///
+/// Release Regent runs as a container. The container runtime (Azure Container Apps,
+/// AKS + CSI Driver, AWS ECS, etc.) injects secrets as environment variables before
+/// the process starts. This struct simply holds those pre-loaded values — there is no
+/// need for the application to call a secret-management API at runtime.
 #[derive(Debug, Clone)]
-pub struct AzureKeyVaultSecretProvider {
+pub struct EnvSecretProvider {
     app_id: GitHubAppId,
     private_key: PrivateKey,
     webhook_secret: String,
 }
 
-impl AzureKeyVaultSecretProvider {
-    /// Create a new Azure Key Vault secret provider.
+impl EnvSecretProvider {
+    /// Create a new environment secret provider from pre-loaded [`AuthConfig`] values.
     ///
     /// # Errors
     ///
@@ -63,26 +71,23 @@ impl AzureKeyVaultSecretProvider {
 }
 
 #[async_trait]
-impl SecretProvider for AzureKeyVaultSecretProvider {
+impl SecretProvider for EnvSecretProvider {
     async fn get_private_key(&self) -> Result<PrivateKey, SecretError> {
-        debug!("Retrieving private key");
-        // In a real implementation, this would fetch from Azure Key Vault
-        // For now, we return the cached key
+        debug!(provider = "env", "Retrieving private key");
         Ok(self.private_key.clone())
     }
 
     async fn get_app_id(&self) -> Result<GitHubAppId, SecretError> {
-        debug!("Retrieving app ID");
+        debug!(provider = "env", "Retrieving app ID");
         Ok(self.app_id)
     }
 
     async fn get_webhook_secret(&self) -> Result<String, SecretError> {
-        debug!("Retrieving webhook secret");
+        debug!(provider = "env", "Retrieving webhook secret");
         Ok(self.webhook_secret.clone())
     }
 
     fn cache_duration(&self) -> Duration {
-        // Cache secrets for 1 hour
         Duration::hours(1)
     }
 }

--- a/crates/github_client/src/auth_tests.rs
+++ b/crates/github_client/src/auth_tests.rs
@@ -22,6 +22,10 @@ fn test_auth_config_create_with_valid_fields_stores_values() {
     };
 
     assert_eq!(config.app_id, 12345);
+    assert_eq!(
+        config.private_key,
+        "-----BEGIN RSA PRIVATE KEY-----\ntest\n-----END RSA PRIVATE KEY-----"
+    );
     assert_eq!(config.webhook_secret, "test-secret");
 }
 

--- a/crates/github_client/src/auth_tests.rs
+++ b/crates/github_client/src/auth_tests.rs
@@ -1,8 +1,19 @@
 use super::*;
-use github_bot_sdk::error::SecretError;
+use github_bot_sdk::auth::GitHubAppId;
+use github_bot_sdk::error::{SecretError, SigningError};
+
+/// A valid RSA-2048 test private key used only in tests.
+///
+/// This key is a development/testing artefact. It is not registered as a
+/// GitHub App key and grants no access to any real system.
+const TEST_RSA_PRIVATE_KEY: &str = include_str!("../test_key.pem");
+
+// ─────────────────────────────────────────────────────────────────────────────
+// AuthConfig
+// ─────────────────────────────────────────────────────────────────────────────
 
 #[test]
-fn test_auth_config_creation() {
+fn test_auth_config_create_with_valid_fields_stores_values() {
     let config = AuthConfig {
         app_id: 12345,
         private_key: "-----BEGIN RSA PRIVATE KEY-----\ntest\n-----END RSA PRIVATE KEY-----"
@@ -15,7 +26,7 @@ fn test_auth_config_creation() {
 }
 
 #[test]
-fn test_auth_config_clone() {
+fn test_auth_config_clone_produces_equal_values() {
     let config = AuthConfig {
         app_id: 12345,
         private_key: "test-key".to_string(),
@@ -27,74 +38,120 @@ fn test_auth_config_clone() {
     assert_eq!(cloned.webhook_secret, config.webhook_secret);
 }
 
-#[tokio::test]
-async fn test_secret_provider_invalid_private_key() {
+// ─────────────────────────────────────────────────────────────────────────────
+// EnvSecretProvider
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_env_secret_provider_new_with_invalid_pem_returns_invalid_format_error() {
     let config = AuthConfig {
         app_id: 12345,
         private_key: "not-a-valid-pem-key".to_string(),
         webhook_secret: "test-secret".to_string(),
     };
 
-    let result = AzureKeyVaultSecretProvider::new(config);
-    assert!(result.is_err());
+    let result = EnvSecretProvider::new(config);
 
+    assert!(result.is_err());
     match result.unwrap_err() {
         SecretError::InvalidFormat { key } => {
             assert_eq!(key, "private_key");
         }
-        _ => panic!("Expected InvalidFormat error"),
+        other => panic!("Expected InvalidFormat error, got: {other:?}"),
     }
 }
 
 #[tokio::test]
-async fn test_secret_provider_get_app_id() {
-    // Use a minimal valid PEM structure for testing
+async fn test_env_secret_provider_get_app_id_returns_configured_app_id() {
     let config = AuthConfig {
         app_id: 54321,
-        private_key:
-            "-----BEGIN RSA PRIVATE KEY-----\nMIIBogIBAAJBALRiMLAA\n-----END RSA PRIVATE KEY-----"
-                .to_string(),
+        private_key: TEST_RSA_PRIVATE_KEY.to_string(),
         webhook_secret: "webhook-secret".to_string(),
     };
 
-    let provider = AzureKeyVaultSecretProvider::new(config);
-    // May fail on PEM parsing, which is expected without a real key
-    if let Ok(provider) = provider {
-        let app_id = provider.get_app_id().await.unwrap();
-        assert_eq!(app_id.as_u64(), 54321);
-    }
+    let provider = EnvSecretProvider::new(config).expect("valid PEM key should succeed");
+    let app_id = provider
+        .get_app_id()
+        .await
+        .expect("get_app_id should succeed");
+
+    assert_eq!(app_id.as_u64(), 54321);
 }
 
 #[tokio::test]
-async fn test_secret_provider_get_webhook_secret() {
+async fn test_env_secret_provider_get_private_key_returns_configured_key() {
     let config = AuthConfig {
         app_id: 12345,
-        private_key:
-            "-----BEGIN RSA PRIVATE KEY-----\nMIIBogIBAAJBALRiMLAA\n-----END RSA PRIVATE KEY-----"
-                .to_string(),
-        webhook_secret: "my-webhook-secret".to_string(),
-    };
-
-    let provider = AzureKeyVaultSecretProvider::new(config);
-    if let Ok(provider) = provider {
-        let secret = provider.get_webhook_secret().await.unwrap();
-        assert_eq!(secret, "my-webhook-secret");
-    }
-}
-
-#[test]
-fn test_secret_provider_cache_duration() {
-    let config = AuthConfig {
-        app_id: 12345,
-        private_key:
-            "-----BEGIN RSA PRIVATE KEY-----\nMIIBogIBAAJBALRiMLAA\n-----END RSA PRIVATE KEY-----"
-                .to_string(),
+        private_key: TEST_RSA_PRIVATE_KEY.to_string(),
         webhook_secret: "test-secret".to_string(),
     };
 
-    let provider = AzureKeyVaultSecretProvider::new(config);
-    if let Ok(provider) = provider {
-        let duration = provider.cache_duration();
-        assert_eq!(duration.num_hours(), 1);
+    let provider = EnvSecretProvider::new(config).expect("valid PEM key should succeed");
+    let key = provider
+        .get_private_key()
+        .await
+        .expect("get_private_key should succeed");
+
+    assert!(!key.key_data().is_empty());
+}
+
+#[tokio::test]
+async fn test_env_secret_provider_get_webhook_secret_returns_configured_secret() {
+    let config = AuthConfig {
+        app_id: 12345,
+        private_key: TEST_RSA_PRIVATE_KEY.to_string(),
+        webhook_secret: "my-webhook-secret".to_string(),
+    };
+
+    let provider = EnvSecretProvider::new(config).expect("valid PEM key should succeed");
+    let secret = provider
+        .get_webhook_secret()
+        .await
+        .expect("get_webhook_secret should succeed");
+
+    assert_eq!(secret, "my-webhook-secret");
+}
+
+#[test]
+fn test_env_secret_provider_cache_duration_is_one_hour() {
+    let config = AuthConfig {
+        app_id: 12345,
+        private_key: TEST_RSA_PRIVATE_KEY.to_string(),
+        webhook_secret: "test-secret".to_string(),
+    };
+
+    let provider = EnvSecretProvider::new(config).expect("valid PEM key should succeed");
+    let duration = provider.cache_duration();
+
+    assert_eq!(duration.num_hours(), 1);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// DefaultJwtSigner
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_sign_jwt_with_out_of_range_exp_returns_signing_failed_error() {
+    let signer = DefaultJwtSigner::new();
+    let private_key = PrivateKey::from_pem(TEST_RSA_PRIVATE_KEY).expect("valid key");
+
+    // i64::MAX seconds since epoch — far beyond any representable DateTime<Utc>
+    let claims = JwtClaims {
+        iss: GitHubAppId::new(123),
+        iat: 0,
+        exp: i64::MAX,
+    };
+
+    let result = signer.sign_jwt(claims, &private_key).await;
+
+    assert!(result.is_err(), "Expected Err for out-of-range exp, got Ok");
+    match result.unwrap_err() {
+        SigningError::SigningFailed { message } => {
+            assert!(
+                message.contains("out of range"),
+                "Expected 'out of range' in error message, got: {message}"
+            );
+        }
+        other => panic!("Expected SigningFailed error, got: {other:?}"),
     }
 }

--- a/crates/github_client/src/lib.rs
+++ b/crates/github_client/src/lib.rs
@@ -47,7 +47,7 @@ pub(crate) const MAX_RETRIES: u32 = 5;
 const SECONDARY_RATE_LIMIT_RETRY_SECS: u64 = 60;
 
 pub mod auth;
-pub use auth::{AuthConfig, AzureKeyVaultSecretProvider};
+pub use auth::{AuthConfig, EnvSecretProvider};
 
 // Re-export SDK types for convenience
 pub use github_bot_sdk::auth::{GitHubAppId, InstallationId as SdkInstallationId, PrivateKey};
@@ -92,7 +92,7 @@ impl GitHubClient {
     /// Create a new GitHub client directly from [`AuthConfig`].
     ///
     /// This convenience constructor wires together all required SDK components:
-    /// - [`auth::AzureKeyVaultSecretProvider`] for secret retrieval
+    /// - [`auth::EnvSecretProvider`] for secret retrieval
     /// - [`auth::DefaultJwtSigner`] for RS256 JWT signing
     /// - [`auth::DefaultGitHubApiClient`] for installation token exchange
     /// - An in-memory token cache
@@ -104,7 +104,7 @@ impl GitHubClient {
     #[allow(clippy::result_large_err)]
     pub fn from_config(auth_config: AuthConfig, installation_id: u64) -> CoreResult<Self> {
         let secret_provider =
-            auth::AzureKeyVaultSecretProvider::new(auth_config).map_err(|e| CoreError::GitHub {
+            auth::EnvSecretProvider::new(auth_config).map_err(|e| CoreError::GitHub {
                 source: Box::new(e),
                 context: None,
             })?;

--- a/crates/server/src/main_tests.rs
+++ b/crates/server/src/main_tests.rs
@@ -247,7 +247,7 @@ async fn test_build_server_processor_with_invalid_pem_returns_github_error() {
         Err(errors::Error::Core {
             source: release_regent_core::CoreError::GitHub { .. },
         }) => {
-            // Expected: the invalid PEM causes AzureKeyVaultSecretProvider::new to return
+            // Expected: the invalid PEM causes EnvSecretProvider::new to return
             // SecretError::InvalidFormat, which is wrapped as CoreError::GitHub by
             // GitHubClient::from_config, then converted to Error::Core here.
         }


### PR DESCRIPTION
Corrects two issues in the github_client authentication module: a misleading type name
and a silent correctness bug in JWT expiry handling.

## What Changed

- **`crates/github_client/src/auth.rs`**:
  - Renamed `AzureKeyVaultSecretProvider` to `EnvSecretProvider`. The struct reads from
    `AuthConfig` fields populated at startup from environment variables — it has never
    contacted Azure Key Vault. The new name accurately describes the behaviour.
  - Updated the struct doc comment to explain the container-injection deployment model:
    secrets are injected as environment variables by the container runtime (ACA, AKS CSI
    Driver, ECS task definition refs, etc.) before the process starts.
  - Removed the stale "In a real implementation, this would fetch from Azure Key Vault" comment.
  - `DefaultJwtSigner::sign_jwt`: replaced `DateTime::from_timestamp(exp, 0).unwrap_or_else(Utc::now)`
    with a proper `SigningError::SigningFailed` return when the exp timestamp is out of range.

- **`crates/github_client/src/lib.rs`**: Updated `pub use` re-export and `from_config` doc
  comment to reference `EnvSecretProvider`.

- **`crates/github_client/README.md`**: Updated usage example to use `EnvSecretProvider`.

- **`crates/github_client/src/auth_tests.rs`**: Rewrote tests to use the renamed type, use the
  real RSA test key fixture for reliable assertions, and follow the project naming convention.
  Added a new test for the JWT out-of-range exp fix.

- **`crates/server/src/main_tests.rs`**: Updated one comment referencing the old type name.

## Why

The old name `AzureKeyVaultSecretProvider` implied the struct performed Key Vault API calls,
which it did not. Release Regent runs as a container; secret injection is the container
runtime's responsibility. Having the app call Key Vault directly would duplicate that
responsibility and add an unnecessary Azure SDK dependency.

The `DateTime::from_timestamp` fallback silently produced a JWT with a meaningless expiry
(`Utc::now()`) when the `exp` claim was out of range for `DateTime<Utc>`. This masked a
programming error and could result in tokens that appear valid but expire immediately or
have unexpected behaviour downstream.

## How

The rename is a pure mechanical rename — no behaviour changed in `EnvSecretProvider`. The
JWT fix replaces the fallback with `ok_or_else(|| SigningError::SigningFailed { message })?`,
propagating the error to the caller with a descriptive message including the out-of-range value.

## Testing Evidence

- **Test Coverage:** 7 tests in `auth_tests.rs`:
  - `test_auth_config_create_with_valid_fields_stores_values`
  - `test_auth_config_clone_produces_equal_values`
  - `test_env_secret_provider_new_with_invalid_pem_returns_invalid_format_error`
  - `test_env_secret_provider_get_app_id_returns_configured_app_id`
  - `test_env_secret_provider_get_private_key_returns_configured_key`
  - `test_env_secret_provider_get_webhook_secret_returns_configured_secret`
  - `test_env_secret_provider_cache_duration_is_one_hour`
  - `test_sign_jwt_with_out_of_range_exp_returns_signing_failed_error`
- **Test Results:** 46/46 tests passing in `release-regent-github-client`; 49/49 passing in
  `release-regent-server`; workspace compiles clean.
- **Manual Testing:** `cargo check --workspace` and `cargo clippy -p release-regent-github-client`
  run locally.

## Reviewer Guidance

- The rename has no runtime behaviour change — `EnvSecretProvider` is identical to the
  old `AzureKeyVaultSecretProvider` in every respect except its name and doc comment.
- The JWT fix changes error semantics: callers of `sign_jwt` that previously received `Ok`
  with a near-immediate expiry on out-of-range timestamps will now receive `Err`. This is
  the correct behaviour, and the change only affects a case that was already broken.
- The old test helpers used a partial PEM string that happened to parse on some key parsers
  but would fail on others. Tests now use `test_key.pem` consistently for reliable assertions.