### PR TITLE
refactor(server): decouple release branch prefix from hardcoded string in event classifier

### DIFF
--- a/crates/server/src/handler.rs
+++ b/crates/server/src/handler.rs
@@ -118,31 +118,29 @@ impl SecretProvider for WebhookSecretProvider {
 ///
 /// ## Routing table
 ///
-/// | `X-GitHub-Event`              | Conditions                                     | Result                             |
-/// |-------------------------------|------------------------------------------------|------------------------------------|
-/// | `pull_request`                | `action=closed`, `merged=true`, non-release branch | `PullRequestMerged`            |
-/// | `pull_request`                | `action=closed`, `merged=true`, `release/v*` branch | `ReleasePrMerged`             |
-/// | `pull_request`                | any other action or not merged                 | `Unknown("pull_request:<action>")` |
-/// | `issue_comment`               | `issue.pull_request` field present in payload  | `PullRequestCommentReceived`       |
-/// | `issue_comment`               | no `issue.pull_request` field (plain issue)    | `Unknown("issue_comment:issue")`   |
-/// | `pull_request_review_comment` | always                                         | `PullRequestCommentReceived`       |
-/// | everything else               | always                                         | `Unknown("<event_type>")`          |
-///
-/// # Release branch prefix
-///
-/// The `release/v` branch prefix is currently hardcoded. Repositories using a
-/// different convention (e.g. `releases/v`, `rel/v`) will have their release
-/// PR merges classified as [`EventType::PullRequestMerged`] instead of
-/// [`EventType::ReleasePrMerged`]. This will be made configurable once branch
-/// prefix support is added to the configuration loading infrastructure.
+/// | `X-GitHub-Event`              | Conditions                                                      | Result                             |
+/// |-------------------------------|----------------------------------------------------------------|------------------------------------|
+/// | `pull_request`                | `action=closed`, `merged=true`, non-release branch             | `PullRequestMerged`                |
+/// | `pull_request`                | `action=closed`, `merged=true`, `{release_branch_prefix}/v*`  | `ReleasePrMerged`                  |
+/// | `pull_request`                | any other action or not merged                                  | `Unknown("pull_request:<action>")` |
+/// | `issue_comment`               | `issue.pull_request` field present in payload                   | `PullRequestCommentReceived`       |
+/// | `issue_comment`               | no `issue.pull_request` field (plain issue)                     | `Unknown("issue_comment:issue")`   |
+/// | `pull_request_review_comment` | always                                                          | `PullRequestCommentReceived`       |
+/// | everything else               | always                                                          | `Unknown("<event_type>")`          |
 ///
 /// # Parameters
 ///
 /// - `event_type` — The raw `X-GitHub-Event` string (e.g. `"pull_request"`).
 /// - `payload` — The parsed JSON body of the webhook.
-pub fn classify_event(event_type: &str, payload: &serde_json::Value) -> EventType {
+/// - `release_branch_prefix` — The configured release branch prefix (e.g. `"release"`);
+///   combined with `/v` to form the expected branch head prefix (e.g. `"release/v"`).
+pub fn classify_event(
+    event_type: &str,
+    payload: &serde_json::Value,
+    release_branch_prefix: &str,
+) -> EventType {
     match event_type {
-        "pull_request" => classify_pull_request_event(payload),
+        "pull_request" => classify_pull_request_event(payload, release_branch_prefix),
         "issue_comment" => classify_issue_comment_event(payload),
         "pull_request_review_comment" => EventType::PullRequestCommentReceived,
         other => EventType::Unknown(other.to_string()),
@@ -173,7 +171,14 @@ fn classify_issue_comment_event(payload: &serde_json::Value) -> EventType {
 /// Non-closed and non-merged events return `Unknown("pull_request:<action>")`
 /// so that the action is visible in logs when diagnosing which events are being
 /// discarded.
-fn classify_pull_request_event(payload: &serde_json::Value) -> EventType {
+///
+/// A merged PR whose head branch starts with `{release_branch_prefix}/v` is
+/// classified as [`EventType::ReleasePrMerged`]; all others map to
+/// [`EventType::PullRequestMerged`].
+fn classify_pull_request_event(
+    payload: &serde_json::Value,
+    release_branch_prefix: &str,
+) -> EventType {
     let action = payload
         .get("action")
         .and_then(serde_json::Value::as_str)
@@ -193,7 +198,8 @@ fn classify_pull_request_event(payload: &serde_json::Value) -> EventType {
         .and_then(serde_json::Value::as_str)
         .unwrap_or("");
 
-    if head_ref.starts_with("release/v") {
+    let release_prefix = format!("{release_branch_prefix}/v");
+    if head_ref.starts_with(release_prefix.as_str()) {
         EventType::ReleasePrMerged
     } else {
         EventType::PullRequestMerged
@@ -213,7 +219,13 @@ fn classify_pull_request_event(payload: &serde_json::Value) -> EventType {
 ///
 /// Returns [`Error::Internal`] when `repository.full_name` does not contain
 /// a `/` separator.
-pub fn convert_envelope(envelope: &EventEnvelope) -> Result<ProcessingEvent, Error> {
+// `CoreError` is a large enum; boxing it here would complicate callers.
+// This is the established pattern across the codebase.
+#[allow(clippy::result_large_err)]
+pub fn convert_envelope(
+    envelope: &EventEnvelope,
+    release_branch_prefix: &str,
+) -> Result<ProcessingEvent, Error> {
     let full_name = &envelope.repository.full_name;
 
     let (owner, name) = full_name.split_once('/').ok_or_else(|| Error::Internal {
@@ -226,7 +238,11 @@ pub fn convert_envelope(envelope: &EventEnvelope) -> Result<ProcessingEvent, Err
         default_branch: envelope.repository.default_branch.clone(),
     };
 
-    let event_type = classify_event(envelope.event_type.as_str(), envelope.payload.raw());
+    let event_type = classify_event(
+        envelope.event_type.as_str(),
+        envelope.payload.raw(),
+        release_branch_prefix,
+    );
 
     Ok(ProcessingEvent {
         event_id: envelope.event_id.to_string(),
@@ -253,6 +269,7 @@ pub fn convert_envelope(envelope: &EventEnvelope) -> Result<ProcessingEvent, Err
 pub struct ReleaseRegentWebhookHandler {
     tx: mpsc::Sender<ProcessingEvent>,
     allowed_repos: Vec<String>,
+    release_branch_prefix: String,
 }
 
 impl ReleaseRegentWebhookHandler {
@@ -265,8 +282,18 @@ impl ReleaseRegentWebhookHandler {
     ///   - Empty `Vec` → deny all repositories.
     ///   - `vec!["*"]` → allow all repositories.
     ///   - Otherwise → exact `"owner/repo"` match.
-    pub fn new(tx: mpsc::Sender<ProcessingEvent>, allowed_repos: Vec<String>) -> Self {
-        Self { tx, allowed_repos }
+    /// - `release_branch_prefix` — The configured release branch prefix (e.g. `"release"`);
+    ///   forwarded to [`classify_event`] during envelope conversion.
+    pub fn new(
+        tx: mpsc::Sender<ProcessingEvent>,
+        allowed_repos: Vec<String>,
+        release_branch_prefix: String,
+    ) -> Self {
+        Self {
+            tx,
+            allowed_repos,
+            release_branch_prefix,
+        }
     }
 
     /// Return `true` if `full_name` matches the allow-list policy.
@@ -299,7 +326,7 @@ impl WebhookHandler for ReleaseRegentWebhookHandler {
             return Ok(());
         }
 
-        let processing_event = match convert_envelope(envelope) {
+        let processing_event = match convert_envelope(envelope, &self.release_branch_prefix) {
             Ok(e) => e,
             Err(e) => {
                 warn!(
@@ -408,13 +435,16 @@ impl EventSource for WebhookEventSource {
 ///
 /// - `allowed_repos` — Repository allow-list; see [`ReleaseRegentWebhookHandler::new`].
 /// - `channel_capacity` — Bounded channel depth.
+/// - `release_branch_prefix` — The configured release branch prefix (e.g. `"release"`);
+///   forwarded to [`classify_event`] to distinguish release PRs from regular PRs.
 pub fn create_webhook_components(
     allowed_repos: Vec<String>,
     channel_capacity: usize,
+    release_branch_prefix: String,
 ) -> (ReleaseRegentWebhookHandler, WebhookEventSource) {
     let (tx, rx) = mpsc::channel(channel_capacity);
     (
-        ReleaseRegentWebhookHandler::new(tx, allowed_repos),
+        ReleaseRegentWebhookHandler::new(tx, allowed_repos, release_branch_prefix),
         WebhookEventSource::new(rx),
     )
 }

--- a/crates/server/src/handler.rs
+++ b/crates/server/src/handler.rs
@@ -111,8 +111,18 @@ impl SecretProvider for WebhookSecretProvider {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Event classification
+// Event classification helpers
 // ─────────────────────────────────────────────────────────────────────────────
+
+/// Build the full branch head prefix that identifies a release PR.
+///
+/// The convention is `"{branch_prefix}/v"`, e.g. `"release/v"` for the
+/// default configuration. This is the single place in the server crate that
+/// encodes the `/v` suffix; `ReleaseOrchestrator` has an equivalent private
+/// method in the core crate.
+fn release_v_prefix(branch_prefix: &str) -> String {
+    format!("{branch_prefix}/v")
+}
 
 /// Classify a raw GitHub webhook event into a domain [`EventType`].
 ///
@@ -175,6 +185,13 @@ fn classify_issue_comment_event(payload: &serde_json::Value) -> EventType {
 /// A merged PR whose head branch starts with `{release_branch_prefix}/v` is
 /// classified as [`EventType::ReleasePrMerged`]; all others map to
 /// [`EventType::PullRequestMerged`].
+///
+/// # Panics
+///
+/// Does not panic. An empty `release_branch_prefix` is treated as a
+/// programming error: a `WARN` log is emitted and the event is classified as
+/// [`EventType::PullRequestMerged`] rather than silently matching any branch
+/// that starts with `"/v"`.
 fn classify_pull_request_event(
     payload: &serde_json::Value,
     release_branch_prefix: &str,
@@ -193,13 +210,17 @@ fn classify_pull_request_event(
         return EventType::Unknown(format!("pull_request:{action}"));
     }
 
+    if release_branch_prefix.is_empty() {
+        warn!("release_branch_prefix is empty; classifying merged PR as PullRequestMerged to avoid matching any /v* branch");
+        return EventType::PullRequestMerged;
+    }
+
     let head_ref = payload
         .pointer("/pull_request/head/ref")
         .and_then(serde_json::Value::as_str)
         .unwrap_or("");
 
-    let release_prefix = format!("{release_branch_prefix}/v");
-    if head_ref.starts_with(release_prefix.as_str()) {
+    if head_ref.starts_with(release_v_prefix(release_branch_prefix).as_str()) {
         EventType::ReleasePrMerged
     } else {
         EventType::PullRequestMerged

--- a/crates/server/src/handler_tests.rs
+++ b/crates/server/src/handler_tests.rs
@@ -203,14 +203,14 @@ async fn test_webhook_secret_provider_get_app_id_returns_not_found() {
 #[test]
 fn test_classify_event_pull_request_closed_merged_regular_returns_pr_merged() {
     let payload = merged_pr_payload();
-    let result = classify_event("pull_request", &payload);
+    let result = classify_event("pull_request", &payload, "release");
     assert_eq!(result, EventType::PullRequestMerged);
 }
 
 #[test]
 fn test_classify_event_pull_request_closed_merged_release_branch_returns_release_pr_merged() {
     let payload = merged_release_pr_payload();
-    let result = classify_event("pull_request", &payload);
+    let result = classify_event("pull_request", &payload, "release");
     assert_eq!(result, EventType::ReleasePrMerged);
 }
 
@@ -220,7 +220,7 @@ fn test_classify_event_pull_request_not_merged_returns_unknown_with_action() {
         "action": "closed",
         "pull_request": { "merged": false, "head": { "ref": "feature/x" } }
     });
-    let result = classify_event("pull_request", &payload);
+    let result = classify_event("pull_request", &payload, "release");
     assert!(
         matches!(result, EventType::Unknown(ref s) if s == "pull_request:closed"),
         "non-merged closed PR must return Unknown with action suffix"
@@ -233,7 +233,7 @@ fn test_classify_event_pull_request_opened_returns_unknown_with_action() {
         "action": "opened",
         "pull_request": { "merged": false, "head": { "ref": "feature/x" } }
     });
-    let result = classify_event("pull_request", &payload);
+    let result = classify_event("pull_request", &payload, "release");
     assert!(
         matches!(result, EventType::Unknown(ref s) if s == "pull_request:opened"),
         "opened PR must return Unknown with action suffix"
@@ -252,7 +252,7 @@ fn test_classify_event_issue_comment_on_pr_returns_pr_comment_received() {
             }
         }
     });
-    let result = classify_event("issue_comment", &payload);
+    let result = classify_event("issue_comment", &payload, "release");
     assert_eq!(result, EventType::PullRequestCommentReceived);
 }
 
@@ -267,7 +267,7 @@ fn test_classify_event_issue_comment_on_regular_issue_returns_unknown() {
             // no "pull_request" key
         }
     });
-    let result = classify_event("issue_comment", &payload);
+    let result = classify_event("issue_comment", &payload, "release");
     assert!(
         matches!(result, EventType::Unknown(ref s) if s == "issue_comment:issue"),
         "issue_comment on a plain issue must not be classified as PullRequestCommentReceived"
@@ -276,20 +276,75 @@ fn test_classify_event_issue_comment_on_regular_issue_returns_unknown() {
 
 #[test]
 fn test_classify_event_pull_request_review_comment_returns_pr_comment_received() {
-    let result = classify_event("pull_request_review_comment", &json!({}));
+    let result = classify_event("pull_request_review_comment", &json!({}), "release");
     assert_eq!(result, EventType::PullRequestCommentReceived);
 }
 
 #[test]
 fn test_classify_event_push_returns_unknown() {
-    let result = classify_event("push", &json!({}));
+    let result = classify_event("push", &json!({}), "release");
     assert!(matches!(result, EventType::Unknown(s) if s == "push"));
 }
 
 #[test]
 fn test_classify_event_empty_string_returns_unknown() {
-    let result = classify_event("", &json!({}));
+    let result = classify_event("", &json!({}), "release");
     assert!(matches!(result, EventType::Unknown(_)));
+}
+
+#[test]
+fn test_classify_event_custom_prefix_matching_branch_returns_release_pr_merged() {
+    // A deployment that uses "custom" as the branch prefix should have
+    // "custom/v1.2.3" branches classified as ReleasePrMerged.
+    let payload = json!({
+        "action": "closed",
+        "pull_request": {
+            "merged": true,
+            "head": { "ref": "custom/v1.2.3" }
+        }
+    });
+    let result = classify_event("pull_request", &payload, "custom");
+    assert_eq!(
+        result,
+        EventType::ReleasePrMerged,
+        "merged PR on custom/v1.2.3 with prefix='custom' must be ReleasePrMerged"
+    );
+}
+
+#[test]
+fn test_classify_event_custom_prefix_non_matching_branch_returns_pr_merged() {
+    // With prefix "custom", the standard "release/v*" branch is NOT a release PR.
+    let payload = json!({
+        "action": "closed",
+        "pull_request": {
+            "merged": true,
+            "head": { "ref": "release/v1.2.3" }
+        }
+    });
+    let result = classify_event("pull_request", &payload, "custom");
+    assert_eq!(
+        result,
+        EventType::PullRequestMerged,
+        "merged PR on release/v1.2.3 with prefix='custom' must NOT be ReleasePrMerged"
+    );
+}
+
+#[test]
+fn test_classify_event_default_prefix_unchanged_behavior_for_release_branch() {
+    // Regression guard: default "release" prefix keeps existing behavior.
+    let payload = json!({
+        "action": "closed",
+        "pull_request": {
+            "merged": true,
+            "head": { "ref": "release/v2.0.0" }
+        }
+    });
+    let result = classify_event("pull_request", &payload, "release");
+    assert_eq!(
+        result,
+        EventType::ReleasePrMerged,
+        "default prefix='release' must still classify release/v2.0.0 as ReleasePrMerged"
+    );
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -299,7 +354,7 @@ fn test_classify_event_empty_string_returns_unknown() {
 #[test]
 fn test_convert_envelope_valid_maps_repository_owner_and_name() {
     let envelope = make_envelope("pull_request", merged_pr_payload());
-    let event = convert_envelope(&envelope).expect("conversion must succeed");
+    let event = convert_envelope(&envelope, "release").expect("conversion must succeed");
     assert_eq!(event.repository.owner, "owner");
     assert_eq!(event.repository.name, "test-repo");
 }
@@ -307,21 +362,21 @@ fn test_convert_envelope_valid_maps_repository_owner_and_name() {
 #[test]
 fn test_convert_envelope_valid_maps_default_branch() {
     let envelope = make_envelope("pull_request", merged_pr_payload());
-    let event = convert_envelope(&envelope).expect("conversion must succeed");
+    let event = convert_envelope(&envelope, "release").expect("conversion must succeed");
     assert_eq!(event.repository.default_branch, "main");
 }
 
 #[test]
 fn test_convert_envelope_valid_sets_webhook_source_kind() {
     let envelope = make_envelope("pull_request", merged_pr_payload());
-    let event = convert_envelope(&envelope).expect("conversion must succeed");
+    let event = convert_envelope(&envelope, "release").expect("conversion must succeed");
     assert_eq!(event.source, EventSourceKind::Webhook);
 }
 
 #[test]
 fn test_convert_envelope_valid_classifies_event_type() {
     let envelope = make_envelope("pull_request", merged_pr_payload());
-    let event = convert_envelope(&envelope).expect("conversion must succeed");
+    let event = convert_envelope(&envelope, "release").expect("conversion must succeed");
     assert_eq!(event.event_type, EventType::PullRequestMerged);
 }
 
@@ -334,7 +389,7 @@ fn test_convert_envelope_invalid_full_name_returns_error() {
     repo.full_name = "no-slash-here".to_string();
 
     let envelope = EventEnvelope::new("push".to_string(), repo, EventPayload::new(json!({})));
-    let result = convert_envelope(&envelope);
+    let result = convert_envelope(&envelope, "release");
     assert!(result.is_err());
 }
 
@@ -342,7 +397,7 @@ fn test_convert_envelope_invalid_full_name_returns_error() {
 fn test_convert_envelope_payload_is_preserved() {
     let payload = merged_pr_payload();
     let envelope = make_envelope("pull_request", payload.clone());
-    let event = convert_envelope(&envelope).expect("conversion must succeed");
+    let event = convert_envelope(&envelope, "release").expect("conversion must succeed");
     assert_eq!(event.payload, payload);
 }
 
@@ -353,14 +408,15 @@ fn test_convert_envelope_payload_is_preserved() {
 #[test]
 fn test_is_allowed_empty_list_denies_all() {
     let (tx, _rx) = mpsc::channel(1);
-    let handler = ReleaseRegentWebhookHandler::new(tx, vec![]);
+    let handler = ReleaseRegentWebhookHandler::new(tx, vec![], "release".to_string());
     assert!(!handler.is_allowed("owner/repo"));
 }
 
 #[test]
 fn test_is_allowed_wildcard_allows_any_repo() {
     let (tx, _rx) = mpsc::channel(1);
-    let handler = ReleaseRegentWebhookHandler::new(tx, vec!["*".to_string()]);
+    let handler =
+        ReleaseRegentWebhookHandler::new(tx, vec!["*".to_string()], "release".to_string());
     assert!(handler.is_allowed("any/repo"));
     assert!(handler.is_allowed("another/project"));
 }
@@ -368,14 +424,22 @@ fn test_is_allowed_wildcard_allows_any_repo() {
 #[test]
 fn test_is_allowed_explicit_match_allows_listed_repo() {
     let (tx, _rx) = mpsc::channel(1);
-    let handler = ReleaseRegentWebhookHandler::new(tx, vec!["owner/allowed-repo".to_string()]);
+    let handler = ReleaseRegentWebhookHandler::new(
+        tx,
+        vec!["owner/allowed-repo".to_string()],
+        "release".to_string(),
+    );
     assert!(handler.is_allowed("owner/allowed-repo"));
 }
 
 #[test]
 fn test_is_allowed_explicit_match_denies_unlisted_repo() {
     let (tx, _rx) = mpsc::channel(1);
-    let handler = ReleaseRegentWebhookHandler::new(tx, vec!["owner/allowed-repo".to_string()]);
+    let handler = ReleaseRegentWebhookHandler::new(
+        tx,
+        vec!["owner/allowed-repo".to_string()],
+        "release".to_string(),
+    );
     assert!(!handler.is_allowed("owner/other-repo"));
 }
 
@@ -386,7 +450,8 @@ fn test_is_allowed_explicit_match_denies_unlisted_repo() {
 #[tokio::test]
 async fn test_handle_event_allowed_repo_sends_processing_event() {
     let (tx, mut rx) = mpsc::channel(4);
-    let handler = ReleaseRegentWebhookHandler::new(tx, vec!["*".to_string()]);
+    let handler =
+        ReleaseRegentWebhookHandler::new(tx, vec!["*".to_string()], "release".to_string());
 
     let envelope = make_envelope("pull_request", merged_pr_payload());
     handler
@@ -405,7 +470,7 @@ async fn test_handle_event_allowed_repo_sends_processing_event() {
 #[tokio::test]
 async fn test_handle_event_denied_repo_sends_nothing_to_channel() {
     let (tx, mut rx) = mpsc::channel(4);
-    let handler = ReleaseRegentWebhookHandler::new(tx, vec![]); // deny all
+    let handler = ReleaseRegentWebhookHandler::new(tx, vec![], "release".to_string()); // deny all
 
     let envelope = make_envelope("pull_request", merged_pr_payload());
     handler
@@ -422,7 +487,8 @@ async fn test_handle_event_denied_repo_sends_nothing_to_channel() {
 #[tokio::test]
 async fn test_handle_event_release_pr_sends_release_pr_merged_event() {
     let (tx, mut rx) = mpsc::channel(4);
-    let handler = ReleaseRegentWebhookHandler::new(tx, vec!["*".to_string()]);
+    let handler =
+        ReleaseRegentWebhookHandler::new(tx, vec!["*".to_string()], "release".to_string());
 
     let envelope = make_envelope("pull_request", merged_release_pr_payload());
     handler
@@ -455,7 +521,8 @@ async fn test_handle_event_full_channel_drops_event_without_error() {
     };
     tx.try_send(filler).expect("pre-fill must succeed");
 
-    let handler = ReleaseRegentWebhookHandler::new(tx, vec!["*".to_string()]);
+    let handler =
+        ReleaseRegentWebhookHandler::new(tx, vec!["*".to_string()], "release".to_string());
     let envelope = make_envelope("pull_request", merged_pr_payload());
 
     // Must not error even though the channel is full.
@@ -664,7 +731,11 @@ async fn test_receive_webhook_valid_request_invokes_handler_and_sends_event() {
     const SECRET: &str = "handler-integration-secret";
 
     let (tx, mut rx) = mpsc::channel(4);
-    let handler = Arc::new(ReleaseRegentWebhookHandler::new(tx, vec!["*".to_string()]));
+    let handler = Arc::new(ReleaseRegentWebhookHandler::new(
+        tx,
+        vec!["*".to_string()],
+        "release".to_string(),
+    ));
 
     let secret_provider = Arc::new(WebhookSecretProvider::new(SECRET));
     let processor = EventProcessor::new(ProcessorConfig::default());

--- a/crates/server/src/handler_tests.rs
+++ b/crates/server/src/handler_tests.rs
@@ -347,6 +347,25 @@ fn test_classify_event_default_prefix_unchanged_behavior_for_release_branch() {
     );
 }
 
+#[test]
+fn test_classify_event_empty_prefix_merged_pr_returns_pr_merged() {
+    // An empty prefix is a programming error. Rather than matching any "/v*" branch,
+    // the classifier must fall back to PullRequestMerged and emit a warning.
+    let payload = json!({
+        "action": "closed",
+        "pull_request": {
+            "merged": true,
+            "head": { "ref": "/v1.0.0" }
+        }
+    });
+    let result = classify_event("pull_request", &payload, "");
+    assert_eq!(
+        result,
+        EventType::PullRequestMerged,
+        "empty prefix must not silently match /v* branches as ReleasePrMerged"
+    );
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // convert_envelope tests
 // ─────────────────────────────────────────────────────────────────────────────

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -353,8 +353,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     // ── Event source + processing loop ─────────────────────────────────────
 
     // Build matched handler/source pair sharing a bounded mpsc channel.
+    // The release branch prefix is sourced from the orchestrator configuration so that the
+    // webhook classifier and the orchestrator always agree on what constitutes a release branch.
+    let release_branch_prefix =
+        release_regent_core::release_orchestrator::OrchestratorConfig::default().branch_prefix;
     let (webhook_event_handler, event_source) =
-        handler::create_webhook_components(allowed_repos, channel_capacity);
+        handler::create_webhook_components(allowed_repos, channel_capacity, release_branch_prefix);
 
     // Spawn the event processing loop.  It runs until the shutdown token is
     // cancelled, processing each `ProcessingEvent` from the mpsc channel.


### PR DESCRIPTION
Removes a hardcoded `"release/v"` literal from the webhook event classifier so that deployments
using a non-default branch prefix correctly route release PR merges through the automator path.

## What Changed

- **`crates/server/src/handler.rs`**:
  - `classify_event` and `classify_pull_request_event` now accept a `release_branch_prefix: &str`
    parameter; the expected branch prefix is constructed at runtime as
    `format!("{release_branch_prefix}/v")`.
  - `convert_envelope` gains the same parameter and forwards it to `classify_event`.
  - `ReleaseRegentWebhookHandler` stores `release_branch_prefix: String` and forwards it
    during envelope conversion inside `handle_event`.
  - `create_webhook_components` gains a `release_branch_prefix: String` parameter so callers
    control the prefix at construction time.

- **`crates/server/src/main.rs`**:
  - Reads the branch prefix from `OrchestratorConfig::default().branch_prefix` at startup
    and passes it to `create_webhook_components`, ensuring the webhook classifier and the
    orchestrator always agree on what constitutes a release PR branch.

- **`crates/server/src/handler_tests.rs`**:
  - Updated all existing `classify_event`, `convert_envelope`, and
    `ReleaseRegentWebhookHandler::new` call-sites to pass the prefix argument.
  - Added three new tests:
    - `test_classify_event_custom_prefix_matching_branch_returns_release_pr_merged`
    - `test_classify_event_custom_prefix_non_matching_branch_returns_pr_merged`
    - `test_classify_event_default_prefix_unchanged_behavior_for_release_branch`

## Why

The classifier previously checked `head_ref.starts_with("release/v")` unconditionally.
`OrchestratorConfig::branch_prefix` defaults to `"release"` but is configurable per deployment.
A deployment using a different prefix (e.g. `"rel"`) would have its release PR merges classified
as `PullRequestMerged` instead of `ReleasePrMerged`, silently triggering a new orchestration
cycle rather than handing off to the `ReleaseAutomator`. No error or warning was emitted.

## How

The prefix is threaded as a plain `&str` / `String` through the call chain rather than read
from a global or closure, keeping every function pure and easily testable. The startup path
in `main.rs` reads the orchestrator default so that the single source of truth for the prefix
remains `OrchestratorConfig`.

## Testing Evidence

- **Test Coverage:** 3 new unit tests added (custom prefix match, custom prefix non-match,
  default prefix regression guard); 24 existing call-sites updated to supply the prefix.
- **Test Results:** All 52 tests in `release-regent-server` pass; 0 new clippy errors
  introduced in the server crate.
- **Manual Testing:** `cargo check --workspace` and
  `cargo clippy -p release-regent-server --no-deps` run locally.

## Reviewer Guidance

- The behaviour with the default `"release"` prefix is identical to before; all previously
  passing tests still pass unchanged.
- The `create_webhook_components` signature change is a breaking change for any external
  caller, but this function is crate-private to the server binary.
- If a future task makes the branch prefix runtime-configurable (loaded from the repo config
  file), only the `main.rs` startup path needs updating — the rest of the chain already
  accepts it as a parameter.
```

- **`crates/github_client/README.md`**: Updated usage example to use `EnvSecretProvider`.

- **`crates/github_client/src/auth_tests.rs`**: Rewrote tests to use the renamed type, use the
  real RSA test key fixture for reliable assertions, and follow the project naming convention.
  Added a new test for the JWT out-of-range exp fix.

- **`crates/server/src/main_tests.rs`**: Updated one comment referencing the old type name.

## Why

The old name `AzureKeyVaultSecretProvider` implied the struct performed Key Vault API calls,
which it did not. Release Regent runs as a container; secret injection is the container
runtime's responsibility. Having the app call Key Vault directly would duplicate that
responsibility and add an unnecessary Azure SDK dependency.

The `DateTime::from_timestamp` fallback silently produced a JWT with a meaningless expiry
(`Utc::now()`) when the `exp` claim was out of range for `DateTime<Utc>`. This masked a
programming error and could result in tokens that appear valid but expire immediately or
have unexpected behaviour downstream.

## How

The rename is a pure mechanical rename — no behaviour changed in `EnvSecretProvider`. The
JWT fix replaces the fallback with `ok_or_else(|| SigningError::SigningFailed { message })?`,
propagating the error to the caller with a descriptive message including the out-of-range value.

## Testing Evidence

- **Test Coverage:** 7 tests in `auth_tests.rs`:
  - `test_auth_config_create_with_valid_fields_stores_values`
  - `test_auth_config_clone_produces_equal_values`
  - `test_env_secret_provider_new_with_invalid_pem_returns_invalid_format_error`
  - `test_env_secret_provider_get_app_id_returns_configured_app_id`
  - `test_env_secret_provider_get_private_key_returns_configured_key`
  - `test_env_secret_provider_get_webhook_secret_returns_configured_secret`
  - `test_env_secret_provider_cache_duration_is_one_hour`
  - `test_sign_jwt_with_out_of_range_exp_returns_signing_failed_error`
- **Test Results:** 46/46 tests passing in `release-regent-github-client`; 49/49 passing in
  `release-regent-server`; workspace compiles clean.
- **Manual Testing:** `cargo check --workspace` and `cargo clippy -p release-regent-github-client`
  run locally.

## Reviewer Guidance

- The rename has no runtime behaviour change — `EnvSecretProvider` is identical to the
  old `AzureKeyVaultSecretProvider` in every respect except its name and doc comment.
- The JWT fix changes error semantics: callers of `sign_jwt` that previously received `Ok`
  with a near-immediate expiry on out-of-range timestamps will now receive `Err`. This is
  the correct behaviour, and the change only affects a case that was already broken.
- The old test helpers used a partial PEM string that happened to parse on some key parsers
  but would fail on others. Tests now use `test_key.pem` consistently for reliable assertions.