### PR TITLE
feat(observability): fix async span propagation and structured logging in orchestrator and GitHub client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1444,7 +1444,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.2",
+ "socket2",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -2571,7 +2571,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2609,7 +2609,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -2799,6 +2799,7 @@ dependencies = [
  "tokio-util",
  "toml 0.8.23",
  "tracing",
+ "tracing-test",
 ]
 
 [[package]]
@@ -3133,7 +3134,7 @@ dependencies = [
  "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3505,16 +3506,6 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "socket2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
@@ -3795,7 +3786,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.2",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -4058,6 +4049,27 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
+]
+
+[[package]]
+name = "tracing-test"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19a4c448db514d4f24c5ddb9f73f2ee71bfb24c526cf0c570ba142d1119e0051"
+dependencies = [
+ "tracing-core",
+ "tracing-subscriber",
+ "tracing-test-macro",
+]
+
+[[package]]
+name = "tracing-test-macro"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad06847b7afb65c7866a36664b75c40b895e318cea4f71299f013fb22965329d"
+dependencies = [
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ azure_security_keyvault_secrets = "0.10"
 
 # Test dependencies
 tempfile = "3.8"
+tracing-test = "0.2"
 tokio-test = "0.4"
 mockall = "0.13"
 pretty_assertions = "=1.4.1"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -28,4 +28,5 @@ toml = { workspace = true }
 
 [dev-dependencies]
 tokio-test = { workspace = true }
+tracing-test = { workspace = true }
 release_regent_testing = { path = "../testing" }

--- a/crates/core/src/release_orchestrator.rs
+++ b/crates/core/src/release_orchestrator.rs
@@ -176,6 +176,7 @@ impl<'a, G: GitHubOperations> ReleaseOrchestrator<'a, G> {
     /// `CoreError::InvalidInput` when a version cannot be parsed from an
     /// existing PR branch name.
     #[allow(clippy::too_many_arguments)] // owner/repo/version/changelog/branch/sha/correlation_id is the minimal release operation surface
+    #[tracing::instrument(skip(self, changelog, version), fields(owner, repo, correlation_id, version = %version))]
     pub async fn orchestrate(
         &self,
         owner: &str,
@@ -186,16 +187,7 @@ impl<'a, G: GitHubOperations> ReleaseOrchestrator<'a, G> {
         base_sha: &str,
         correlation_id: &str,
     ) -> CoreResult<OrchestratorResult> {
-        let span = tracing::info_span!(
-            "release_orchestrator.orchestrate",
-            owner,
-            repo,
-            version = %version,
-            correlation_id,
-        );
-        let _enter = span.enter();
-
-        info!(owner, repo, version = %version, "Starting release orchestration");
+        info!(owner, repo, version = %version, correlation_id, "Starting release orchestration");
 
         let existing = self.search_for_existing_release_pr(owner, repo).await?;
 

--- a/crates/core/src/release_orchestrator.rs
+++ b/crates/core/src/release_orchestrator.rs
@@ -176,7 +176,7 @@ impl<'a, G: GitHubOperations> ReleaseOrchestrator<'a, G> {
     /// `CoreError::InvalidInput` when a version cannot be parsed from an
     /// existing PR branch name.
     #[allow(clippy::too_many_arguments)] // owner/repo/version/changelog/branch/sha/correlation_id is the minimal release operation surface
-    #[tracing::instrument(skip(self, changelog, version), fields(owner, repo, correlation_id, version = %version))]
+    #[tracing::instrument(skip(self, changelog, version), fields(owner, repo, base_branch, base_sha, correlation_id, version = %version))]
     pub async fn orchestrate(
         &self,
         owner: &str,

--- a/crates/core/src/release_orchestrator_tests.rs
+++ b/crates/core/src/release_orchestrator_tests.rs
@@ -16,6 +16,7 @@ use async_trait::async_trait;
 use chrono::Utc;
 use std::sync::Arc;
 use tokio::sync::Mutex;
+use tracing_test::traced_test;
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Inline test double
@@ -1030,4 +1031,96 @@ fn test_extract_changelog_from_pr_body_empty_section_returns_empty() {
 fn test_extract_changelog_from_pr_body_empty_body_returns_empty() {
     let result = extract_changelog_from_pr_body("", "## Changelog");
     assert_eq!(result, "");
+}
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// Structured logging / span propagation tests
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+/// `orchestrate` must include the `correlation_id` as a structured field in its
+/// span so that ALL log lines emitted during orchestration are correlated.
+///
+/// This test will fail if the function uses `span.enter()` without also
+/// including `correlation_id` in a log event, or if `#[tracing::instrument]`
+/// is absent and the span is never opened.
+#[tokio::test]
+#[traced_test]
+async fn test_orchestrate_logs_contain_correlation_id() {
+    let github = TestGitHub::new();
+    let orchestrator = ReleaseOrchestrator::new(default_config(), &github);
+
+    orchestrator
+        .orchestrate(
+            "testorg",
+            "testrepo",
+            &ver(1, 0, 0),
+            "- feat: something",
+            "main",
+            "sha-001",
+            "unique-corr-id-ALPHA",
+        )
+        .await
+        .expect("orchestrate should succeed");
+
+    assert!(
+        logs_contain("unique-corr-id-ALPHA"),
+        "correlation_id must appear in structured log output"
+    );
+}
+
+/// `orchestrate` must record `owner` and `repo` as structured fields so that
+/// log lines are filterable by repository in production monitoring.
+#[tokio::test]
+#[traced_test]
+async fn test_orchestrate_logs_contain_owner_and_repo() {
+    let github = TestGitHub::new();
+    let orchestrator = ReleaseOrchestrator::new(default_config(), &github);
+
+    orchestrator
+        .orchestrate(
+            "unique-owner-BETA",
+            "unique-repo-BETA",
+            &ver(2, 0, 0),
+            "- fix: something",
+            "main",
+            "sha-002",
+            "corr-002",
+        )
+        .await
+        .expect("orchestrate should succeed");
+
+    assert!(
+        logs_contain("unique-owner-BETA"),
+        "owner must appear in structured log output"
+    );
+    assert!(
+        logs_contain("unique-repo-BETA"),
+        "repo must appear in structured log output"
+    );
+}
+
+/// `orchestrate` must record the version as a structured field.
+#[tokio::test]
+#[traced_test]
+async fn test_orchestrate_logs_contain_version() {
+    let github = TestGitHub::new();
+    let orchestrator = ReleaseOrchestrator::new(default_config(), &github);
+
+    orchestrator
+        .orchestrate(
+            "testorg",
+            "testrepo",
+            &ver(9, 8, 7),
+            "- chore: bump",
+            "main",
+            "sha-003",
+            "corr-003",
+        )
+        .await
+        .expect("orchestrate should succeed");
+
+    assert!(
+        logs_contain("9.8.7"),
+        "version must appear in structured log output"
+    );
 }

--- a/crates/core/src/release_orchestrator_tests.rs
+++ b/crates/core/src/release_orchestrator_tests.rs
@@ -16,7 +16,6 @@ use async_trait::async_trait;
 use chrono::Utc;
 use std::sync::Arc;
 use tokio::sync::Mutex;
-use tracing_test::traced_test;
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Inline test double
@@ -49,12 +48,12 @@ struct TestState {
 }
 
 #[derive(Clone, Default)]
-struct TestGitHub {
+pub(super) struct TestGitHub {
     state: Arc<Mutex<TestState>>,
 }
 
 impl TestGitHub {
-    fn new() -> Self {
+    pub(super) fn new() -> Self {
         Self {
             state: Arc::new(Mutex::new(TestState {
                 next_pr_number: 100,
@@ -403,7 +402,7 @@ impl GitHubOperations for TestGitHub {
 }
 // ─────────────────────────────────────────────────────────────────────────────
 
-fn stub_repo(owner: &str, repo: &str) -> Repository {
+pub(super) fn stub_repo(owner: &str, repo: &str) -> Repository {
     Repository {
         id: 1,
         name: repo.to_string(),
@@ -418,7 +417,7 @@ fn stub_repo(owner: &str, repo: &str) -> Repository {
     }
 }
 
-fn stub_git_user() -> GitHubUser {
+pub(super) fn stub_git_user() -> GitHubUser {
     GitHubUser {
         name: "test-user".to_string(),
         email: "test@example.com".to_string(),
@@ -426,7 +425,7 @@ fn stub_git_user() -> GitHubUser {
     }
 }
 
-fn make_open_release_pr(number: u64, branch: &str, body: Option<&str>) -> PullRequest {
+pub(super) fn make_open_release_pr(number: u64, branch: &str, body: Option<&str>) -> PullRequest {
     let now = Utc::now();
     let r = stub_repo("testorg", "testrepo");
     PullRequest {
@@ -452,7 +451,7 @@ fn make_open_release_pr(number: u64, branch: &str, body: Option<&str>) -> PullRe
     }
 }
 
-fn ver(major: u64, minor: u64, patch: u64) -> SemanticVersion {
+pub(super) fn ver(major: u64, minor: u64, patch: u64) -> SemanticVersion {
     SemanticVersion {
         major,
         minor,
@@ -462,9 +461,17 @@ fn ver(major: u64, minor: u64, patch: u64) -> SemanticVersion {
     }
 }
 
-fn default_config() -> OrchestratorConfig {
+pub(super) fn default_config() -> OrchestratorConfig {
     OrchestratorConfig::default()
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Structured logging sub-module
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+#[path = "release_orchestrator_tracing_tests.rs"]
+mod tracing_tests;
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Tests
@@ -1031,96 +1038,4 @@ fn test_extract_changelog_from_pr_body_empty_section_returns_empty() {
 fn test_extract_changelog_from_pr_body_empty_body_returns_empty() {
     let result = extract_changelog_from_pr_body("", "## Changelog");
     assert_eq!(result, "");
-}
-
-// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-// Structured logging / span propagation tests
-// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-/// `orchestrate` must include the `correlation_id` as a structured field in its
-/// span so that ALL log lines emitted during orchestration are correlated.
-///
-/// This test will fail if the function uses `span.enter()` without also
-/// including `correlation_id` in a log event, or if `#[tracing::instrument]`
-/// is absent and the span is never opened.
-#[tokio::test]
-#[traced_test]
-async fn test_orchestrate_logs_contain_correlation_id() {
-    let github = TestGitHub::new();
-    let orchestrator = ReleaseOrchestrator::new(default_config(), &github);
-
-    orchestrator
-        .orchestrate(
-            "testorg",
-            "testrepo",
-            &ver(1, 0, 0),
-            "- feat: something",
-            "main",
-            "sha-001",
-            "unique-corr-id-ALPHA",
-        )
-        .await
-        .expect("orchestrate should succeed");
-
-    assert!(
-        logs_contain("unique-corr-id-ALPHA"),
-        "correlation_id must appear in structured log output"
-    );
-}
-
-/// `orchestrate` must record `owner` and `repo` as structured fields so that
-/// log lines are filterable by repository in production monitoring.
-#[tokio::test]
-#[traced_test]
-async fn test_orchestrate_logs_contain_owner_and_repo() {
-    let github = TestGitHub::new();
-    let orchestrator = ReleaseOrchestrator::new(default_config(), &github);
-
-    orchestrator
-        .orchestrate(
-            "unique-owner-BETA",
-            "unique-repo-BETA",
-            &ver(2, 0, 0),
-            "- fix: something",
-            "main",
-            "sha-002",
-            "corr-002",
-        )
-        .await
-        .expect("orchestrate should succeed");
-
-    assert!(
-        logs_contain("unique-owner-BETA"),
-        "owner must appear in structured log output"
-    );
-    assert!(
-        logs_contain("unique-repo-BETA"),
-        "repo must appear in structured log output"
-    );
-}
-
-/// `orchestrate` must record the version as a structured field.
-#[tokio::test]
-#[traced_test]
-async fn test_orchestrate_logs_contain_version() {
-    let github = TestGitHub::new();
-    let orchestrator = ReleaseOrchestrator::new(default_config(), &github);
-
-    orchestrator
-        .orchestrate(
-            "testorg",
-            "testrepo",
-            &ver(9, 8, 7),
-            "- chore: bump",
-            "main",
-            "sha-003",
-            "corr-003",
-        )
-        .await
-        .expect("orchestrate should succeed");
-
-    assert!(
-        logs_contain("9.8.7"),
-        "version must appear in structured log output"
-    );
 }

--- a/crates/core/src/release_orchestrator_tracing_tests.rs
+++ b/crates/core/src/release_orchestrator_tracing_tests.rs
@@ -1,0 +1,100 @@
+//! Structured logging and span propagation tests for [`ReleaseOrchestrator`].
+//!
+//! These tests verify that `orchestrate` emits all required structured fields
+//! so that log lines are filterable and traceable in production monitoring.
+
+use super::super::ReleaseOrchestrator;
+use super::{default_config, ver, TestGitHub};
+use tracing_test::traced_test;
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// Structured logging / span propagation tests
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+/// `orchestrate` must include the `correlation_id` as a structured field in its
+/// span so that ALL log lines emitted during orchestration are correlated.
+///
+/// This test will fail if the function uses `span.enter()` without also
+/// including `correlation_id` in a log event, or if `#[tracing::instrument]`
+/// is absent and the span is never opened.
+#[tokio::test]
+#[traced_test]
+async fn test_orchestrate_logs_contain_correlation_id() {
+    let github = TestGitHub::new();
+    let orchestrator = ReleaseOrchestrator::new(default_config(), &github);
+
+    orchestrator
+        .orchestrate(
+            "testorg",
+            "testrepo",
+            &ver(1, 0, 0),
+            "- feat: something",
+            "main",
+            "sha-001",
+            "unique-corr-id-ALPHA",
+        )
+        .await
+        .expect("orchestrate should succeed");
+
+    assert!(
+        logs_contain("unique-corr-id-ALPHA"),
+        "correlation_id must appear in structured log output"
+    );
+}
+
+/// `orchestrate` must record `owner` and `repo` as structured fields so that
+/// log lines are filterable by repository in production monitoring.
+#[tokio::test]
+#[traced_test]
+async fn test_orchestrate_logs_contain_owner_and_repo() {
+    let github = TestGitHub::new();
+    let orchestrator = ReleaseOrchestrator::new(default_config(), &github);
+
+    orchestrator
+        .orchestrate(
+            "unique-owner-BETA",
+            "unique-repo-BETA",
+            &ver(2, 0, 0),
+            "- fix: something",
+            "main",
+            "sha-002",
+            "corr-002",
+        )
+        .await
+        .expect("orchestrate should succeed");
+
+    assert!(
+        logs_contain("unique-owner-BETA"),
+        "owner must appear in structured log output"
+    );
+    assert!(
+        logs_contain("unique-repo-BETA"),
+        "repo must appear in structured log output"
+    );
+}
+
+/// `orchestrate` must record the version as a structured field.
+#[tokio::test]
+#[traced_test]
+async fn test_orchestrate_logs_contain_version() {
+    let github = TestGitHub::new();
+    let orchestrator = ReleaseOrchestrator::new(default_config(), &github);
+
+    orchestrator
+        .orchestrate(
+            "testorg",
+            "testrepo",
+            &ver(9, 8, 7),
+            "- chore: bump",
+            "main",
+            "sha-003",
+            "corr-003",
+        )
+        .await
+        .expect("orchestrate should succeed");
+
+    assert!(
+        logs_contain("9.8.7"),
+        "version must appear in structured log output"
+    );
+}

--- a/crates/github_client/src/lib.rs
+++ b/crates/github_client/src/lib.rs
@@ -182,10 +182,7 @@ impl GitOperations for GitHubClient {
         head: &str,
         _options: GetCommitsOptions,
     ) -> CoreResult<Vec<GitCommit>> {
-        info!(
-            "Getting commits between {} and {} for {}/{}",
-            base, head, owner, repo
-        );
+        info!(owner, repo, base, head, "Getting commits between");
 
         let installation = self.installation().await?;
         let comparison = installation
@@ -202,7 +199,7 @@ impl GitOperations for GitHubClient {
 
     #[instrument(skip(self))]
     async fn get_commit(&self, owner: &str, repo: &str, commit_sha: &str) -> CoreResult<GitCommit> {
-        info!("Getting commit {} for {}/{}", commit_sha, owner, repo);
+        info!(owner, repo, commit_sha, "Getting commit");
 
         let installation = self.installation().await?;
         let sdk_commit = installation
@@ -220,7 +217,7 @@ impl GitOperations for GitHubClient {
         repo: &str,
         options: ListTagsOptions,
     ) -> CoreResult<Vec<GitTag>> {
-        info!("Listing tags for {}/{}", owner, repo);
+        info!(owner, repo, "Listing tags");
 
         let installation = self.installation().await?;
         let sdk_tags = installation
@@ -249,7 +246,7 @@ impl GitOperations for GitHubClient {
 
     #[instrument(skip(self))]
     async fn get_tag(&self, owner: &str, repo: &str, tag_name: &str) -> CoreResult<GitTag> {
-        info!("Getting tag {} for {}/{}", tag_name, owner, repo);
+        info!(owner, repo, tag_name, "Getting tag");
 
         // SDK doesn't have get_tag, so we list all tags and find the one we need
         let installation = self.installation().await?;
@@ -267,7 +264,7 @@ impl GitOperations for GitHubClient {
 
     #[instrument(skip(self))]
     async fn tag_exists(&self, owner: &str, repo: &str, tag_name: &str) -> CoreResult<bool> {
-        debug!("Checking if tag {} exists for {}/{}", tag_name, owner, repo);
+        debug!(owner, repo, tag_name, "Checking if tag exists");
 
         match self.get_tag(owner, repo, tag_name).await {
             Ok(_) => Ok(true),
@@ -283,10 +280,7 @@ impl GitOperations for GitHubClient {
         repo: &str,
         branch: Option<&str>,
     ) -> CoreResult<GitCommit> {
-        info!(
-            "Getting HEAD commit for {}/{} (branch: {:?})",
-            owner, repo, branch
-        );
+        info!(owner, repo, branch = ?branch, "Getting HEAD commit");
 
         let installation = self.installation().await?;
 
@@ -317,7 +311,7 @@ impl GitOperations for GitHubClient {
 
     #[instrument(skip(self))]
     async fn get_repository_info(&self, owner: &str, repo: &str) -> CoreResult<GitRepository> {
-        info!("Getting repository info for {}/{}", owner, repo);
+        info!(owner, repo, "Getting repository info");
 
         let installation = self.installation().await?;
         let sdk_repo = installation
@@ -347,10 +341,7 @@ impl GitHubOperations for GitHubClient {
         repo: &str,
         params: CreatePullRequestParams,
     ) -> CoreResult<PullRequest> {
-        info!(
-            "Creating pull request in {}/{}: {}",
-            owner, repo, params.title
-        );
+        info!(owner, repo, title = %params.title, "Creating pull request");
 
         let installation = self.installation().await?;
 
@@ -379,10 +370,7 @@ impl GitHubOperations for GitHubClient {
         repo: &str,
         params: CreateReleaseParams,
     ) -> CoreResult<Release> {
-        info!(
-            "Creating release in {}/{}: {}",
-            owner, repo, params.tag_name
-        );
+        info!(owner, repo, tag_name = %params.tag_name, "Creating release");
 
         let installation = self.installation().await?;
 
@@ -414,10 +402,7 @@ impl GitHubOperations for GitHubClient {
         message: Option<String>,
         tagger: Option<GitHubUser>,
     ) -> CoreResult<Tag> {
-        info!(
-            "Creating tag {} at {} for {}/{}",
-            tag_name, commit_sha, owner, repo
-        );
+        info!(owner, repo, tag_name, commit_sha, "Creating tag");
 
         let installation = self.installation().await?;
 
@@ -438,7 +423,7 @@ impl GitHubOperations for GitHubClient {
 
     #[instrument(skip(self))]
     async fn get_latest_release(&self, owner: &str, repo: &str) -> CoreResult<Option<Release>> {
-        info!("Getting latest release for {}/{}", owner, repo);
+        info!(owner, repo, "Getting latest release");
 
         let installation = self.installation().await?;
 
@@ -458,7 +443,7 @@ impl GitHubOperations for GitHubClient {
         repo: &str,
         pr_number: u64,
     ) -> CoreResult<PullRequest> {
-        info!("Getting pull request #{} for {}/{}", pr_number, owner, repo);
+        info!(owner, repo, pr_number, "Getting pull request");
 
         let installation = self.installation().await?;
         let sdk_pr = installation
@@ -471,7 +456,7 @@ impl GitHubOperations for GitHubClient {
 
     #[instrument(skip(self))]
     async fn get_release_by_tag(&self, owner: &str, repo: &str, tag: &str) -> CoreResult<Release> {
-        info!("Getting release by tag {} for {}/{}", tag, owner, repo);
+        info!(owner, repo, tag, "Getting release by tag");
 
         let installation = self.installation().await?;
         let sdk_release = installation
@@ -490,7 +475,7 @@ impl GitHubOperations for GitHubClient {
         _per_page: Option<u8>,
         _page: Option<u32>,
     ) -> CoreResult<Vec<Release>> {
-        info!("Listing releases for {}/{}", owner, repo);
+        info!(owner, repo, "Listing releases");
 
         let installation = self.installation().await?;
         let sdk_releases = installation
@@ -514,10 +499,7 @@ impl GitHubOperations for GitHubClient {
         body: Option<String>,
         state: Option<String>,
     ) -> CoreResult<PullRequest> {
-        info!(
-            "Updating pull request #{} for {}/{}",
-            pr_number, owner, repo
-        );
+        info!(owner, repo, pr_number, "Updating pull request");
 
         let installation = self.installation().await?;
 
@@ -610,10 +592,7 @@ impl GitHubOperations for GitHubClient {
         repo: &str,
         query: &str,
     ) -> CoreResult<Vec<PullRequest>> {
-        info!(
-            "Searching pull requests for {}/{} with query: {}",
-            owner, repo, query
-        );
+        info!(owner, repo, query, "Searching pull requests");
 
         // Determine desired state from the query.  Default to "open" if
         // not specified, which matches the most common usage pattern.
@@ -678,7 +657,7 @@ impl GitHubOperations for GitHubClient {
         release_id: u64,
         params: UpdateReleaseParams,
     ) -> CoreResult<Release> {
-        info!("Updating release {} for {}/{}", release_id, owner, repo);
+        info!(owner, repo, release_id, "Updating release");
 
         let installation = self.installation().await?;
 
@@ -706,7 +685,7 @@ impl GitHubOperations for GitHubClient {
         branch_name: &str,
         sha: &str,
     ) -> CoreResult<()> {
-        info!("Creating branch {branch_name} at {sha} for {owner}/{repo}");
+        info!(owner, repo, branch_name, sha, "Creating branch");
 
         let installation = self.installation().await?;
 
@@ -726,7 +705,7 @@ impl GitHubOperations for GitHubClient {
     }
 
     async fn delete_branch(&self, owner: &str, repo: &str, branch_name: &str) -> CoreResult<()> {
-        info!("Deleting branch {branch_name} for {owner}/{repo}");
+        info!(owner, repo, branch_name, "Deleting branch");
 
         let installation = self.installation().await?;
 

--- a/crates/github_client/src/lib.rs
+++ b/crates/github_client/src/lib.rs
@@ -678,6 +678,7 @@ impl GitHubOperations for GitHubClient {
         Ok(convert_sdk_release_to_release_regent_release(sdk_release))
     }
 
+    #[instrument(skip(self))]
     async fn create_branch(
         &self,
         owner: &str,
@@ -704,6 +705,7 @@ impl GitHubOperations for GitHubClient {
         Ok(())
     }
 
+    #[instrument(skip(self))]
     async fn delete_branch(&self, owner: &str, repo: &str, branch_name: &str) -> CoreResult<()> {
         info!(owner, repo, branch_name, "Deleting branch");
 
@@ -717,6 +719,7 @@ impl GitHubOperations for GitHubClient {
         Ok(())
     }
 
+    #[instrument(skip(self, body))]
     async fn create_issue_comment(
         &self,
         owner: &str,
@@ -739,6 +742,7 @@ impl GitHubOperations for GitHubClient {
         Ok(())
     }
 
+    #[instrument(skip(self))]
     async fn get_collaborator_permission(
         &self,
         owner: &str,
@@ -781,6 +785,7 @@ impl GitHubOperations for GitHubClient {
         })
     }
 
+    #[instrument(skip(self, labels))]
     async fn add_labels(
         &self,
         owner: &str,
@@ -800,6 +805,7 @@ impl GitHubOperations for GitHubClient {
         Ok(())
     }
 
+    #[instrument(skip(self))]
     async fn remove_label(
         &self,
         owner: &str,
@@ -829,6 +835,7 @@ impl GitHubOperations for GitHubClient {
         }
     }
 
+    #[instrument(skip(self))]
     async fn list_pr_labels(
         &self,
         owner: &str,


### PR DESCRIPTION
Fixes a silent observability bug where correlation IDs were lost across async boundaries during
orchestration, and converts all bare format-string log calls in the GitHub client to structured
tracing fields for machine-queryable production logs.

## What Changed

- **`crates/core/src/release_orchestrator.rs`**: Replaced `span.enter()` (a synchronous guard
  that is dropped at every `.await` yield point in tokio's multi-thread scheduler) with
  `#[tracing::instrument]` on `ReleaseOrchestrator::orchestrate`. The instrument macro generates
  correct `.instrument()` wrapping internally, ensuring `correlation_id`, `owner`, `repo`, and
  `version` are recorded as structured fields and remain visible in all child spans across `.await`
  points.

- **`crates/github_client/src/lib.rs`**: Converted 19 bare format-string `info!`/`debug!` calls
  (e.g. `info!("Getting tag {} for {}/{}", tag_name, owner, repo)`) to structured key=value tracing
  fields (e.g. `info!(owner, repo, tag_name, "Getting tag")`). All GitHubClient API methods now
  emit consistent, filterable log fields rather than unstructured message strings.

- **`crates/core/src/release_orchestrator_tests.rs`** and **`Cargo.toml`/`crates/core/Cargo.toml`**:
  Added `tracing-test` dev-dependency and three regression tests using `#[traced_test]` to verify
  that `correlation_id`, `owner`, `repo`, and `version` appear in structured log output from
  `orchestrate`.

## Why

The `.tech-decisions.yml` mandates `structured_logging_only` — all tracing macros must use
key=value fields, not positional format strings. The `span.enter()` pattern is a documented
Rust pitfall: in tokio's multi-thread runtime, the guard is dropped when the future yields at an
`.await` point, meaning any child spans created after that point are parented to the wrong span
and `correlation_id` would not appear in their output. This made distributed traces unreadable
and correlation IDs unreliable in production logs.

## How

`#[tracing::instrument]` on an `async fn` is the idiomatic fix: the macro wraps the entire
future returned by the function in an `Instrument` combinator, so the span is correctly
re-entered and exited at each `.await` suspension boundary regardless of which tokio thread
picks up execution. The structured field conversion is mechanical — each positional placeholder
`{}` maps directly to a named field using the variable already in scope.

## Testing Evidence

- **Test Coverage:** Added 3 regression tests (`test_orchestrate_logs_contain_correlation_id`,
  `test_orchestrate_logs_contain_owner_and_repo`, `test_orchestrate_logs_contain_version`) using
  `tracing_test::traced_test` to assert that the named fields appear in captured log output.
- **Test Results:** All workspace tests pass; `cargo clippy -p release-regent-core
  -p release-regent-github-client -- -D warnings -D clippy::pedantic -D clippy::unwrap_used
  -D clippy::expect_used` produces zero diagnostics.
- **Manual Testing:** `cargo test --workspace` confirmed clean locally.

## Reviewer Guidance

- The `span.enter()` → `#[tracing::instrument]` change on `orchestrate` is the highest-risk
  item: verify the instrument fields list (`skip(self, changelog, version)`,
  `fields(owner, repo, correlation_id, version = %version)`) correctly captures all diagnostic
  context without logging sensitive data.
- The 19 structured-field conversions in `GitHubClient` are mechanical but should be scanned to
  confirm no field name collides with a tracing reserved keyword and that all previously
  logged values are still present in the new form.
- `ReleaseAutomator::automate` and `CommentCommandProcessor::process` were already correctly
  instrumented (`#[tracing::instrument]` and `.instrument(span)` respectively) — no changes
  needed there.
- No runtime behaviour changed; this is a pure observability fix.