### PR TITLE
feat(ci): add Dockerfile and container release workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -23,8 +23,10 @@ target/
 # Documentation sources (not needed in the container)
 docs/
 
-# Test fixtures and examples
-crates/testing/
+# Exclude test sources and fixtures from the build context but keep the
+# Cargo.toml manifest — Cargo requires it to resolve the workspace graph.
+crates/testing/src/
+crates/testing/tests/
 
 # Root-level markdown files
 *.md

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,30 @@
+# Exclude the build output directory — it is large and rebuilt inside Docker.
+target/
+
+# Version control metadata
+.git/
+.gitignore
+.gitattributes
+
+# GitHub-specific directories (not needed at build time)
+.github/
+
+# Developer tooling
+.llm/
+.vscode/
+.idea/
+
+# Temporary and local files
+*.tmp
+*.log
+*.swp
+*.bak
+
+# Documentation sources (not needed in the container)
+docs/
+
+# Test fixtures and examples
+crates/testing/
+
+# Root-level markdown files
+*.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,10 +150,10 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@b5329b9eff1a4046a31eb26e6af4a0c3abd9e5de # v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Build Docker image
-        uses: docker/build-push-action@471d1dc4e07e5a3c3ece6c1f15e58eed2b71e5dc # v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           push: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,8 @@ jobs:
       - uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2
 
       - name: Generate code coverage
-        run: cargo llvm-cov --all-features --workspace --codecov --output-path codecov.json
+        run: cargo llvm-cov --all-features --workspace --codecov --output-path
+          codecov.json
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5
         with:
@@ -166,8 +167,9 @@ jobs:
         run: |
           # Without credentials the server must exit non-zero with a clear
           # message identifying which environment variable is missing.
+          # timeout 10 prevents a hung binary from blocking the job indefinitely.
           set +e
-          output=$(docker run --rm release-regent:ci-test 2>&1)
+          output=$(timeout 10 docker run --rm release-regent:ci-test 2>&1)
           exit_code=$?
           set -e
 
@@ -186,7 +188,6 @@ jobs:
           fi
 
           echo "Smoke test passed: binary exits with expected credential error"
-
   # bench_test:
   #   name: bench-tests
   #   runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,6 +143,50 @@ jobs:
       - name: Run doc-tests
         run: cargo test --doc --all-features
 
+  docker-build:
+    name: docker-build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@b5329b9eff1a4046a31eb26e6af4a0c3abd9e5de # v3
+
+      - name: Build Docker image
+        uses: docker/build-push-action@471d1dc4e07e5a3c3ece6c1f15e58eed2b71e5dc # v6
+        with:
+          context: .
+          push: false
+          load: true
+          tags: release-regent:ci-test
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Smoke-test container startup
+        run: |
+          # Without credentials the server must exit non-zero with a clear
+          # message identifying which environment variable is missing.
+          set +e
+          output=$(docker run --rm release-regent:ci-test 2>&1)
+          exit_code=$?
+          set -e
+
+          echo "Exit code : ${exit_code}"
+          echo "Output    : ${output}"
+
+          if [ "${exit_code}" -eq 0 ]; then
+            echo "ERROR: server should have exited due to missing credentials" >&2
+            exit 1
+          fi
+
+          if ! echo "${output}" | grep -q "GITHUB_WEBHOOK_SECRET"; then
+            printf 'ERROR: expected GITHUB_WEBHOOK_SECRET in error output, got:\n%s\n' \
+              "${output}" >&2
+            exit 1
+          fi
+
+          echo "Smoke test passed: binary exits with expected credential error"
+
   # bench_test:
   #   name: bench-tests
   #   runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,10 @@ name: Release
 #
 # Once self-hosted, the release PR workflow will create these tags automatically.
 #
+# Safety note: always push release tags on commits where CI is green.
+# This workflow does not gate on CI status; a tag pushed on a red commit
+# will still produce and publish an image.
+#
 # Image registry
 # --------------
 # Images are published to GitHub Container Registry:
@@ -42,11 +46,6 @@ jobs:
                   # Full history is not required for image builds, but fetch-depth: 1
                   # is the default and is correct here.
                   fetch-depth: 1
-
-            # QEMU enables cross-compilation for non-native platforms if required
-            # in the future. For now we target linux/amd64 only.
-            - name: Set up QEMU
-              uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
             - name: Set up Docker Buildx
               uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,9 @@ jobs:
                   # is the default and is correct here.
                   fetch-depth: 1
 
+            - name: Set up QEMU
+              uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
+
             - name: Set up Docker Buildx
               uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
@@ -84,7 +87,7 @@ jobs:
               uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
               with:
                   context: .
-                  platforms: linux/amd64
+                  platforms: linux/amd64,linux/arm64
                   push: true
                   tags: ${{ steps.meta.outputs.tags }}
                   labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,13 +46,13 @@ jobs:
             # QEMU enables cross-compilation for non-native platforms if required
             # in the future. For now we target linux/amd64 only.
             - name: Set up QEMU
-              uses: docker/setup-qemu-action@29109295f81e9208d7d86ff9f51bd44b8e6d4b59 # v3
+              uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
             - name: Set up Docker Buildx
-              uses: docker/setup-buildx-action@b5329b9eff1a4046a31eb26e6af4a0c3abd9e5de # v3
+              uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
             - name: Login to GitHub Container Registry
-              uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
+              uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
               with:
                   registry: ghcr.io
                   username: ${{ github.actor }}
@@ -67,7 +67,7 @@ jobs:
             #   ghcr.io/pvandervelde/release-regent:sha-<abbrev>
             - name: Extract Docker metadata
               id: meta
-              uses: docker/metadata-action@902fa8ec7d6ecbea8a63e9a91f87a1ee4f39c66c # v5
+              uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
               with:
                   images: ghcr.io/${{ github.repository_owner }}/release-regent
                   tags: |
@@ -82,7 +82,7 @@ jobs:
                       org.opencontainers.image.documentation=https://github.com/pvandervelde/release_regent/blob/master/README.md
 
             - name: Build and push container image
-              uses: docker/build-push-action@471d1dc4e07e5a3c3ece6c1f15e58eed2b71e5dc # v6
+              uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
               with:
                   context: .
                   platforms: linux/amd64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,93 @@
+name: Release
+
+# Triggered by a push of a semantic-version tag (e.g. v0.1.0, v1.2.3-beta.1).
+#
+# Versioning strategy (pre-self-hosting)
+# ---------------------------------------
+# Until Release Regent processes its own repository, versions are managed via
+# manually pushed git tags on the master branch:
+#
+#   git tag -a v0.1.0 -m "Release v0.1.0"
+#   git push origin v0.1.0
+#
+# Once self-hosted, the release PR workflow will create these tags automatically.
+#
+# Image registry
+# --------------
+# Images are published to GitHub Container Registry:
+#   ghcr.io/pvandervelde/release-regent:<version>
+#   ghcr.io/pvandervelde/release-regent:latest   (stable releases only)
+#   ghcr.io/pvandervelde/release-regent:sha-<short-sha>
+
+on:
+    push:
+        tags:
+            # Stable releases: v0.1.0, v1.2.3
+            - "v[0-9]+.[0-9]+.[0-9]+"
+            # Pre-releases: v0.1.0-beta.1, v1.0.0-rc.2
+            - "v[0-9]+.[0-9]+.[0-9]+-*"
+
+permissions:
+    contents: read
+    packages: write
+
+jobs:
+    release-container:
+        name: Build and publish container image
+        runs-on: ubuntu-latest
+
+        steps:
+            - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+              with:
+                  # Full history is not required for image builds, but fetch-depth: 1
+                  # is the default and is correct here.
+                  fetch-depth: 1
+
+            # QEMU enables cross-compilation for non-native platforms if required
+            # in the future. For now we target linux/amd64 only.
+            - name: Set up QEMU
+              uses: docker/setup-qemu-action@29109295f81e9208d7d86ff9f51bd44b8e6d4b59 # v3
+
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@b5329b9eff1a4046a31eb26e6af4a0c3abd9e5de # v3
+
+            - name: Login to GitHub Container Registry
+              uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
+              with:
+                  registry: ghcr.io
+                  username: ${{ github.actor }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
+
+            # Extract OCI-compatible tags and labels from the Git context.
+            # For a tag push of v0.1.0 this produces:
+            #   ghcr.io/pvandervelde/release-regent:0.1.0
+            #   ghcr.io/pvandervelde/release-regent:0.1
+            #   ghcr.io/pvandervelde/release-regent:0
+            #   ghcr.io/pvandervelde/release-regent:latest  (stable only)
+            #   ghcr.io/pvandervelde/release-regent:sha-<abbrev>
+            - name: Extract Docker metadata
+              id: meta
+              uses: docker/metadata-action@902fa8ec7d6ecbea8a63e9a91f87a1ee4f39c66c # v5
+              with:
+                  images: ghcr.io/${{ github.repository_owner }}/release-regent
+                  tags: |
+                      type=semver,pattern={{version}}
+                      type=semver,pattern={{major}}.{{minor}}
+                      type=semver,pattern={{major}}
+                      type=sha,prefix=sha-
+                  labels: |
+                      org.opencontainers.image.title=Release Regent
+                      org.opencontainers.image.description=Automated semantic versioning and release management webhook server
+                      org.opencontainers.image.vendor=pvandervelde
+                      org.opencontainers.image.documentation=https://github.com/pvandervelde/release_regent/blob/master/README.md
+
+            - name: Build and push container image
+              uses: docker/build-push-action@471d1dc4e07e5a3c3ece6c1f15e58eed2b71e5dc # v6
+              with:
+                  context: .
+                  platforms: linux/amd64
+                  push: true
+                  tags: ${{ steps.meta.outputs.tags }}
+                  labels: ${{ steps.meta.outputs.labels }}
+                  cache-from: type=gha
+                  cache-to: type=gha,mode=max

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3144,9 +3144,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,10 @@
 # This layer is cached as long as Cargo.toml / Cargo.lock are unchanged,
 # so external crate compilation is skipped on source-only changes.
 # =============================================================================
-FROM rust:1-slim AS deps
+# Pin to a specific Rust release so that builds on different days produce
+# identical binaries.  Update this together with rust-version in Cargo.toml
+# when raising the MSRV.  Current stable at the time of writing: 1.85.
+FROM rust:1.85-slim AS deps
 
 # aws-lc-sys (pulled in by rustls through azure and reqwest) requires cmake,
 # clang, and nasm.  pkg-config is used by several crates to locate system libs.
@@ -70,7 +73,7 @@ RUN mkdir -p \
     && printf 'pub fn _stub() {}\n' > crates/github_client/src/lib.rs \
     && printf 'fn main() {}\n' > crates/server/src/main.rs \
     && printf 'pub fn _stub() {}\n' > crates/testing/src/lib.rs \
-    && cargo build --release --package release-regent-server || true
+    && cargo build --release --locked --package release-regent-server || true
 
 # =============================================================================
 # Stage 2 — final compilation
@@ -85,7 +88,7 @@ COPY crates/ crates/
 
 # Touch all .rs files so that Cargo detects them as newer than the stubs.
 RUN find crates -name '*.rs' -exec touch {} + \
-    && cargo build --release --package release-regent-server
+    && cargo build --release --locked --package release-regent-server
 
 # =============================================================================
 # Stage 3 — minimal runtime image
@@ -111,5 +114,10 @@ USER rr
 
 # Webhook server port.
 EXPOSE 8080
+
+# Container health check — polls the /health endpoint.
+# start-period gives the server time to bind and start accepting connections.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD wget -q --spider http://localhost:8080/health || exit 1
 
 ENTRYPOINT ["/usr/local/bin/rr-server"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,17 +32,22 @@
 # =============================================================================
 # Pin to a specific Rust release so that builds on different days produce
 # identical binaries.  Update this together with rust-version in Cargo.toml
-# when raising the MSRV.  Current stable at the time of writing: 1.85.
-FROM rust:1.85-slim AS deps
+# when raising the MSRV.  Current stable at the time of writing: 1.95.
+FROM rust:1.95-slim AS deps
 
-# aws-lc-sys (pulled in by rustls through azure and reqwest) requires cmake,
-# clang, and nasm.  pkg-config is used by several crates to locate system libs.
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    cmake \
-    clang \
-    nasm \
-    pkg-config \
-    && rm -rf /var/lib/apt/lists/*
+# TARGETARCH is injected by BuildKit (values: amd64, arm64, etc.).
+# nasm is only available for x86/amd64 in Debian; aws-lc-sys uses it for
+# x86 assembly optimisations.  On arm64 it is not available and not needed
+# (aws-lc-sys uses ARMv8 crypto intrinsics instead).
+# cmake, clang, and pkg-config are required on all platforms.
+ARG TARGETARCH
+RUN set -e; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends cmake clang pkg-config; \
+    if [ "${TARGETARCH}" = "amd64" ]; then \
+    apt-get install -y --no-install-recommends nasm; \
+    fi; \
+    rm -rf /var/lib/apt/lists/*
 
 WORKDIR /build
 
@@ -96,8 +101,10 @@ RUN find crates -name '*.rs' -exec touch {} + \
 FROM debian:bookworm-slim AS runtime
 
 # ca-certificates is required for outbound TLS connections to the GitHub API.
+# wget is used by the HEALTHCHECK instruction below.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
+    wget \
     && rm -rf /var/lib/apt/lists/*
 
 # Run as a dedicated non-root system account.

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,14 +36,17 @@
 FROM rust:1.95-slim AS deps
 
 # TARGETARCH is injected by BuildKit (values: amd64, arm64, etc.).
+# cmake, clang, pkg-config are required on all platforms by aws-lc-sys.
+# libssl-dev provides OpenSSL headers required by openssl-sys, which is a
+# transitive dependency: typespec_client_core (Azure SDK) and jsonschema pull
+# in reqwest 0.12 whose default TLS backend on Linux is native-tls → openssl.
 # nasm is only available for x86/amd64 in Debian; aws-lc-sys uses it for
 # x86 assembly optimisations.  On arm64 it is not available and not needed
 # (aws-lc-sys uses ARMv8 crypto intrinsics instead).
-# cmake, clang, and pkg-config are required on all platforms.
 ARG TARGETARCH
 RUN set -e; \
     apt-get update; \
-    apt-get install -y --no-install-recommends cmake clang pkg-config; \
+    apt-get install -y --no-install-recommends cmake clang pkg-config libssl-dev; \
     if [ "${TARGETARCH}" = "amd64" ]; then \
     apt-get install -y --no-install-recommends nasm; \
     fi; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,115 @@
+# =============================================================================
+# Release Regent — multi-stage Docker build
+#
+# Produces a minimal runtime image containing only the `rr-server` binary.
+#
+# Required environment variables at runtime
+# -----------------------------------------
+# GITHUB_WEBHOOK_SECRET  – HMAC-SHA256 secret shared with the GitHub App
+# GITHUB_APP_ID          – Numeric GitHub App identifier
+# GITHUB_PRIVATE_KEY     – PEM-encoded GitHub App private key
+# GITHUB_INSTALLATION_ID – GitHub App installation identifier
+#
+# Optional environment variables
+# -----------------------------------------
+# CONFIG_DIR             – Directory containing .release-regent.toml (default: cwd)
+# ALLOWED_REPOS          – Comma-separated owner/repo list, or * for all (default: *)
+# EVENT_CHANNEL_CAPACITY – In-flight event queue depth (default: 1024)
+# PORT                   – TCP port to listen on (default: 8080)
+# RUST_LOG               – Log filter string (default: info)
+#
+# Health check
+# -----------------------------------------
+# GET /health returns {"status":"healthy","service":"release-regent-webhook"}
+# =============================================================================
+
+# =============================================================================
+# Stage 1 — dependency compilation cache
+#
+# Copy only the workspace manifests and create minimal stub source files.
+# This layer is cached as long as Cargo.toml / Cargo.lock are unchanged,
+# so external crate compilation is skipped on source-only changes.
+# =============================================================================
+FROM rust:1-slim AS deps
+
+# aws-lc-sys (pulled in by rustls through azure and reqwest) requires cmake,
+# clang, and nasm.  pkg-config is used by several crates to locate system libs.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    cmake \
+    clang \
+    nasm \
+    pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build
+
+# Copy workspace and per-crate manifests.
+COPY Cargo.toml Cargo.lock ./
+COPY crates/cli/Cargo.toml           crates/cli/Cargo.toml
+COPY crates/config_provider/Cargo.toml crates/config_provider/Cargo.toml
+COPY crates/core/Cargo.toml          crates/core/Cargo.toml
+COPY crates/github_client/Cargo.toml crates/github_client/Cargo.toml
+COPY crates/server/Cargo.toml        crates/server/Cargo.toml
+COPY crates/testing/Cargo.toml       crates/testing/Cargo.toml
+
+# Create minimal stub sources for every workspace member so that Cargo can
+# resolve and compile external dependencies.  The stubs intentionally omit
+# symbols that the server imports from workspace crates, so the overall build
+# will fail (expected); the || true absorbs that failure while Cargo's
+# dependency compilation output remains cached in target/.
+RUN mkdir -p \
+    crates/cli/src \
+    crates/config_provider/src \
+    crates/core/src \
+    crates/github_client/src \
+    crates/server/src \
+    crates/testing/src \
+    && printf 'fn main() {}\n' > crates/cli/src/main.rs \
+    && printf 'pub fn _stub() {}\n' > crates/config_provider/src/lib.rs \
+    && printf 'pub fn _stub() {}\n' > crates/core/src/lib.rs \
+    && printf 'pub fn _stub() {}\n' > crates/github_client/src/lib.rs \
+    && printf 'fn main() {}\n' > crates/server/src/main.rs \
+    && printf 'pub fn _stub() {}\n' > crates/testing/src/lib.rs \
+    && cargo build --release --package release-regent-server || true
+
+# =============================================================================
+# Stage 2 — final compilation
+#
+# Copy the real source code on top of the stub layer.  Cargo reuses the
+# cached external-crate artifacts from Stage 1 and only recompiles the
+# workspace crates whose source has changed.
+# =============================================================================
+FROM deps AS builder
+
+COPY crates/ crates/
+
+# Touch all .rs files so that Cargo detects them as newer than the stubs.
+RUN find crates -name '*.rs' -exec touch {} + \
+    && cargo build --release --package release-regent-server
+
+# =============================================================================
+# Stage 3 — minimal runtime image
+# =============================================================================
+FROM debian:bookworm-slim AS runtime
+
+# ca-certificates is required for outbound TLS connections to the GitHub API.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Run as a dedicated non-root system account.
+RUN useradd \
+    --system \
+    --no-create-home \
+    --shell /bin/false \
+    --uid 10001 \
+    rr
+
+COPY --from=builder /build/target/release/rr-server /usr/local/bin/rr-server
+
+USER rr
+
+# Webhook server port.
+EXPOSE 8080
+
+ENTRYPOINT ["/usr/local/bin/rr-server"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -100,8 +100,14 @@ RUN find crates -name '*.rs' -exec touch {} + \
 
 # =============================================================================
 # Stage 3 — minimal runtime image
+#
+# Must use the same Debian release as the builder image so that the compiled
+# binary and the glibc version in the runtime layer match.
+# rust:1.95-slim is based on Debian trixie (glibc 2.41).
+# bookworm-slim only ships glibc 2.36 and would fail with a version-not-found
+# error at startup.  Keep this in sync with the FROM in the deps stage.
 # =============================================================================
-FROM debian:bookworm-slim AS runtime
+FROM debian:trixie-slim AS runtime
 
 # ca-certificates is required for outbound TLS connections to the GitHub API.
 # wget is used by the HEALTHCHECK instruction below.


### PR DESCRIPTION
Introduces a production Dockerfile for the rr-server binary and two GitHub Actions integrations:
a docker-build CI job with a startup smoke test, and a release workflow that publishes versioned
images to GitHub Container Registry on semver tag pushes.

## What Changed

- **`Dockerfile`**: Three-stage multi-stage build. The `deps` stage copies only workspace
  manifests and compiles external crates against stub sources, caching that layer independently
  from workspace-crate compilation. The `builder` stage copies real sources and recompiles only
  workspace crates. The `runtime` stage produces a minimal `debian:bookworm-slim` image with
  `ca-certificates`, a non-root `rr` system user (uid 10001), and the `rr-server` binary.
  Build-time system packages (`cmake`, `clang`, `nasm`, `pkg-config`) are required by
  `aws-lc-sys`, which is a transitive dependency via rustls/azure/reqwest.

- **`.dockerignore`**: Excludes `target/`, `.git/`, `.github/`, `docs/`, `crates/testing/`,
  and developer tooling directories to keep the build context minimal.

- **`.github/workflows/ci.yml`**: Added a `docker-build` job that builds the image with
  Docker Buildx (GHA layer cache enabled) and runs a smoke test: starts the container without
  credentials and asserts it exits non-zero with `GITHUB_WEBHOOK_SECRET` in the error output.

- **`.github/workflows/release.yml`**: New workflow triggered by semver git tag pushes
  (`v*.*.*` and `v*.*.*-*`). Logs in to GHCR, extracts OCI tags and labels via
  `docker/metadata-action` (`{{version}}`, `{{major}}.{{minor}}`, `{{major}}`, `sha-<abbrev>`,
  and `latest` for stable releases), then builds and pushes to
  `ghcr.io/pvandervelde/release-regent`.

## Why

The server binary has been functional for some time but had no packaging or distribution
mechanism. Container images are the practical deployment unit for running the webhook server
locally for end-to-end testing and eventually in production. A release workflow is needed to
publish versioned images without manual steps.

## How

The Dockerfile uses the stub-source layer-caching technique to avoid redownloading and
recompiling all external crates on every source change. The deps stage intentionally lets
`cargo build` fail (via `|| true`) after caching external artifacts, then the builder stage
touches all `.rs` files to force Cargo to detect the real sources as newer than the stubs
before running the final build.

Versioning until the project is self-hosted: manually push an annotated semver tag on master
(`git tag -a v0.1.0 -m "Release v0.1.0" && git push origin v0.1.0`). Once Release Regent
processes its own repository, the release PR workflow will manage this automatically.

## Testing Evidence

- **Test Coverage:** No unit tests added; the docker-build CI job acts as the build validation.
  The smoke test asserts correct binary startup behaviour (fail-fast on missing credentials).
- **Test Results:** Workflows validated for YAML syntax locally. Smoke test logic verified
  against the server's existing `GITHUB_WEBHOOK_SECRET` environment check.
- **Manual Testing:** Not yet run in CI (requires merge); Dockerfile builds verified structurally
  against the workspace manifest layout.

## Reviewer Guidance

- Review the `deps` stage stub-source technique: the `|| true` on `cargo build` is intentional
  and required for the caching approach to work correctly.
- Confirm the system package list (`cmake`, `clang`, `nasm`, `pkg-config`) is complete for
  `aws-lc-sys` compilation in the `rust:1-slim` base image.
- The smoke test uses `grep -q "GITHUB_WEBHOOK_SECRET"` against combined stderr/stdout — verify
  that the server binary writes this error to stderr (captured by `2>&1`).
- The release workflow uses `permissions: packages: write` at the job level; confirm this is
  sufficient for GHCR pushes in this repository's permissions model.
- No runtime behaviour changed; this is purely packaging and CI/CD infrastructure.
```

  Added `tracing-test` dev-dependency and three regression tests using `#[traced_test]` to verify
  that `correlation_id`, `owner`, `repo`, and `version` appear in structured log output from
  `orchestrate`.

## Why

The `.tech-decisions.yml` mandates `structured_logging_only` — all tracing macros must use
key=value fields, not positional format strings. The `span.enter()` pattern is a documented
Rust pitfall: in tokio's multi-thread runtime, the guard is dropped when the future yields at an
`.await` point, meaning any child spans created after that point are parented to the wrong span
and `correlation_id` would not appear in their output. This made distributed traces unreadable
and correlation IDs unreliable in production logs.

## How

`#[tracing::instrument]` on an `async fn` is the idiomatic fix: the macro wraps the entire
future returned by the function in an `Instrument` combinator, so the span is correctly
re-entered and exited at each `.await` suspension boundary regardless of which tokio thread
picks up execution. The structured field conversion is mechanical — each positional placeholder
`{}` maps directly to a named field using the variable already in scope.

## Testing Evidence

- **Test Coverage:** Added 3 regression tests (`test_orchestrate_logs_contain_correlation_id`,
  `test_orchestrate_logs_contain_owner_and_repo`, `test_orchestrate_logs_contain_version`) using
  `tracing_test::traced_test` to assert that the named fields appear in captured log output.
- **Test Results:** All workspace tests pass; `cargo clippy -p release-regent-core
  -p release-regent-github-client -- -D warnings -D clippy::pedantic -D clippy::unwrap_used
  -D clippy::expect_used` produces zero diagnostics.
- **Manual Testing:** `cargo test --workspace` confirmed clean locally.

## Reviewer Guidance

- The `span.enter()` → `#[tracing::instrument]` change on `orchestrate` is the highest-risk
  item: verify the instrument fields list (`skip(self, changelog, version)`,
  `fields(owner, repo, correlation_id, version = %version)`) correctly captures all diagnostic
  context without logging sensitive data.
- The 19 structured-field conversions in `GitHubClient` are mechanical but should be scanned to
  confirm no field name collides with a tracing reserved keyword and that all previously
  logged values are still present in the new form.
- `ReleaseAutomator::automate` and `CommentCommandProcessor::process` were already correctly
  instrumented (`#[tracing::instrument]` and `.instrument(span)` respectively) — no changes
  needed there.
- No runtime behaviour changed; this is a pure observability fix.