### PR TITLE
feat(release-regent): end-to-end release automation with local testing samples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,7 @@ target/
 
 # Coverage reports
 codecov.json
+
+# Local development credentials — never commit these
+samples/.env
+*.pem

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ codecov.json
 # Local development credentials — never commit these
 samples/.env
 *.pem
+samples/config/test.env

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -773,16 +773,7 @@ version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
 dependencies = [
- "dirs-sys 0.4.1",
-]
-
-[[package]]
-name = "dirs"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
-dependencies = [
- "dirs-sys 0.5.0",
+ "dirs-sys",
 ]
 
 [[package]]
@@ -793,20 +784,8 @@ checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users 0.4.6",
+ "redox_users",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
-dependencies = [
- "libc",
- "option-ext",
- "redox_users 0.5.2",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -866,6 +845,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "etcetera"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de48cc4d1c1d97a20fd819def54b890cadde72ed3ad0c614822a0a433361be96"
+dependencies = [
+ "cfg-if",
  "windows-sys 0.61.2",
 ]
 
@@ -1128,23 +1117,20 @@ dependencies = [
 
 [[package]]
 name = "git-cliff-core"
-version = "2.12.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6d358abf5d7808dcd6346ee7728537d28f0ec3f6460cff7322b932fe1ab9ad0"
+checksum = "22f084fe5556719bddf18730c5cdd0294da71169876d4022970838b165fa9b1f"
 dependencies = [
  "bincode",
  "cacache",
  "chrono",
  "config",
- "dirs 6.0.0",
  "dyn-clone",
+ "etcetera",
  "git-conventional",
  "git2",
  "glob",
  "indexmap",
- "lazy-regex",
- "lazy_static",
- "log",
  "next_version",
  "regex",
  "rust-embed",
@@ -1157,6 +1143,7 @@ dependencies = [
  "thiserror 2.0.18",
  "time",
  "toml 0.9.11+spec-1.1.0",
+ "tracing",
  "url",
  "urlencoding",
 ]
@@ -1771,29 +1758,6 @@ dependencies = [
  "serde",
  "serde_json",
  "simple_asn1",
-]
-
-[[package]]
-name = "lazy-regex"
-version = "3.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5c13b6857ade4c8ee05c3c3dc97d2ab5415d691213825b90d3211c425c1f907"
-dependencies = [
- "lazy-regex-proc_macros",
- "once_cell",
- "regex",
-]
-
-[[package]]
-name = "lazy-regex-proc_macros"
-version = "3.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a95c68db5d41694cea563c86a4ba4dc02141c16ef64814108cb23def4d5438"
-dependencies = [
- "proc-macro2",
- "quote",
- "regex",
- "syn 2.0.114",
 ]
 
 [[package]]
@@ -2611,7 +2575,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2706,17 +2670,6 @@ dependencies = [
  "getrandom 0.2.17",
  "libredox",
  "thiserror 1.0.69",
-]
-
-[[package]]
-name = "redox_users"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
-dependencies = [
- "getrandom 0.2.17",
- "libredox",
- "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2858,7 +2811,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "chrono",
- "dirs 5.0.1",
+ "dirs",
  "jsonschema",
  "once_cell",
  "release-regent-core",
@@ -3078,7 +3031,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3135,7 +3088,7 @@ dependencies = [
  "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3146,9 +3099,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -3638,7 +3591,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4440,7 +4393,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2807,6 +2807,7 @@ name = "release-regent-github-client"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "base64 0.22.1",
  "chrono",
  "github-bot-sdk",
  "jsonwebtoken",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2740,6 +2740,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "chrono",
+ "futures",
  "git-cliff-core",
  "git-conventional",
  "release_regent_testing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ sha2 = "0.10"
 hex = "0.4"
 
 # Additional utilities
+base64 = "0.22"
 dirs = "5.0"
 walkdir = "2.4"
 jsonschema = "0.18"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ repository = "https://github.com/pvandervelde/release_regent"
 [workspace.dependencies]
 # Core async and concurrency
 async-trait = "0.1"
+futures = "0.3"
 tokio = { version = "1.45", features = ["full"] }
 tokio-util = { version = "0.7" }
 tracing = "0.1"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 # =============================================================================
 # Release Regent — multi-stage Docker build
 #
@@ -80,8 +81,15 @@ RUN mkdir -p \
     && printf 'pub fn _stub() {}\n' > crates/core/src/lib.rs \
     && printf 'pub fn _stub() {}\n' > crates/github_client/src/lib.rs \
     && printf 'fn main() {}\n' > crates/server/src/main.rs \
-    && printf 'pub fn _stub() {}\n' > crates/testing/src/lib.rs \
-    && cargo build --release --locked --package release-regent-server || true
+    && printf 'pub fn _stub() {}\n' > crates/testing/src/lib.rs
+
+# Pre-compile external dependencies using the stub sources.
+# --mount=type=cache keeps the cargo registry and incremental artifacts on the
+# host between builds, so external crates are not re-downloaded or recompiled
+# on every docker build invocation.
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/build/target \
+    cargo build --release --locked --package release-regent-server || true
 
 # =============================================================================
 # Stage 2 — final compilation
@@ -95,8 +103,11 @@ FROM deps AS builder
 COPY crates/ crates/
 
 # Touch all .rs files so that Cargo detects them as newer than the stubs.
-RUN find crates -name '*.rs' -exec touch {} + \
-    && cargo build --release --locked --package release-regent-server
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/build/target \
+    find crates -name '*.rs' -exec touch {} + \
+    && cargo build --release --locked --package release-regent-server \
+    && cp target/release/rr-server /build/rr-server-bin
 
 # =============================================================================
 # Stage 3 — minimal runtime image
@@ -124,7 +135,7 @@ RUN useradd \
     --uid 10001 \
     rr
 
-COPY --from=builder /build/target/release/rr-server /usr/local/bin/rr-server
+COPY --from=builder /build/rr-server-bin /usr/local/bin/rr-server
 
 USER rr
 

--- a/crates/cli/src/factory.rs
+++ b/crates/cli/src/factory.rs
@@ -97,23 +97,16 @@ pub async fn create_production_processor() -> CliResult<ProductionProcessor> {
     // Webhook secret is optional — an empty string disables signature validation.
     let webhook_secret = std::env::var("GITHUB_WEBHOOK_SECRET").unwrap_or_default();
 
-    let installation_id: u64 = std::env::var("GITHUB_INSTALLATION_ID")
-        .map_err(|_| {
-            CliError::missing_dependency("GITHUB_INSTALLATION_ID", "environment variable not set")
-        })?
-        .parse::<u64>()
-        .map_err(|e| {
-            CliError::invalid_argument("GITHUB_INSTALLATION_ID", format!("Must be a number: {e}"))
-        })?;
-
     let auth_config = release_regent_github_client::AuthConfig {
         app_id,
         private_key,
         webhook_secret,
     };
 
-    let github_client =
-        release_regent_github_client::GitHubClient::from_config(auth_config, installation_id)?;
+    // The installation ID is extracted per-event from the webhook payload
+    // (payload["installation"]["id"]), so it does not need to be a static
+    // env var here.  `scoped_to` is called when each event is dispatched.
+    let github_client = release_regent_github_client::GitHubClient::from_config(auth_config)?;
 
     let config_dir = std::env::current_dir().map_err(|e| {
         CliError::command_execution(

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -11,6 +11,7 @@ description = "Core business logic for Release Regent"
 
 [dependencies]
 # Core dependencies
+futures = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }
 serde = { workspace = true }

--- a/crates/core/src/comment_command_processor.rs
+++ b/crates/core/src/comment_command_processor.rs
@@ -180,6 +180,34 @@ impl<'a, G: GitHubOperations + Send + Sync> CommentCommandProcessor<'a, G> {
             return Ok(());
         };
 
+        // Parse the command first: if there is no recognised command in the
+        // body there is nothing to do regardless of who posted it.  This
+        // prevents spurious rejection replies to ordinary PR comments and
+        // breaks the feedback loop caused by Release Regent responding to
+        // its own posted comments.
+        let command = parse_comment_command(&comment_body);
+        debug!(
+            event_id = %event.event_id,
+            ?command,
+            commenter_login,
+            "Parsed comment command"
+        );
+        if command == CommentCommand::Unknown {
+            return Ok(());
+        }
+
+        // Ignore comments from bot accounts — including our own — to prevent
+        // feedback loops where a posted reply triggers another webhook that
+        // we then process again.
+        if commenter_login.ends_with("[bot]") {
+            debug!(
+                event_id = %event.event_id,
+                commenter_login,
+                "Ignoring command from bot account"
+            );
+            return Ok(());
+        }
+
         // Only collaborators with write access or above may issue commands.
         let permission = self
             .github
@@ -201,14 +229,10 @@ impl<'a, G: GitHubOperations + Send + Sync> CommentCommandProcessor<'a, G> {
                 .await;
         }
 
-        let command = parse_comment_command(&comment_body);
-        debug!(
-            event_id = %event.event_id,
-            ?command,
-            "Parsed comment command"
-        );
 
         match command {
+            // Unknown is handled above with an early return; this arm is
+            // unreachable but kept to satisfy exhaustiveness.
             CommentCommand::Unknown => Ok(()),
             CommentCommand::ReleaseBump(kind) => {
                 self.handle_release_bump(owner, repo, issue_number, &kind, &event.correlation_id)

--- a/crates/core/src/comment_command_processor.rs
+++ b/crates/core/src/comment_command_processor.rs
@@ -229,7 +229,6 @@ impl<'a, G: GitHubOperations + Send + Sync> CommentCommandProcessor<'a, G> {
                 .await;
         }
 
-
         match command {
             // Unknown is handled above with an early return; this arm is
             // unreachable but kept to satisfy exhaustiveness.

--- a/crates/core/src/comment_command_processor_tests.rs
+++ b/crates/core/src/comment_command_processor_tests.rs
@@ -473,6 +473,18 @@ impl GitHubOperations for TestGitHub {
         Ok(0)
     }
 
+    async fn upsert_file(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _path: &str,
+        _commit_message: &str,
+        _content: &str,
+        _branch: &str,
+    ) -> CoreResult<()> {
+        Ok(())
+    }
+
     fn scoped_to(&self, _installation_id: u64) -> Self {
         Self {
             state: Arc::clone(&self.state),

--- a/crates/core/src/comment_command_processor_tests.rs
+++ b/crates/core/src/comment_command_processor_tests.rs
@@ -468,6 +468,12 @@ impl GitHubOperations for TestGitHub {
             .cloned()
             .unwrap_or_default())
     }
+
+    fn scoped_to(&self, _installation_id: u64) -> Self {
+        Self {
+            state: Arc::clone(&self.state),
+        }
+    }
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -619,6 +625,7 @@ fn test_event(pr_number: u64, comment_body: &str, pr_state: &str) -> ProcessingE
         }),
         received_at: Utc::now(),
         source: EventSourceKind::Webhook,
+        installation_id: 0,
     }
 }
 

--- a/crates/core/src/comment_command_processor_tests.rs
+++ b/crates/core/src/comment_command_processor_tests.rs
@@ -469,11 +469,7 @@ impl GitHubOperations for TestGitHub {
             .unwrap_or_default())
     }
 
-    async fn get_installation_id_for_repo(
-        &self,
-        _owner: &str,
-        _repo: &str,
-    ) -> CoreResult<u64> {
+    async fn get_installation_id_for_repo(&self, _owner: &str, _repo: &str) -> CoreResult<u64> {
         Ok(0)
     }
 
@@ -609,6 +605,15 @@ fn make_semver_tag(name: &str) -> GitTag {
 }
 
 fn test_event(pr_number: u64, comment_body: &str, pr_state: &str) -> ProcessingEvent {
+    test_event_with_login(pr_number, comment_body, pr_state, "test-user")
+}
+
+fn test_event_with_login(
+    pr_number: u64,
+    comment_body: &str,
+    pr_state: &str,
+    commenter_login: &str,
+) -> ProcessingEvent {
     use crate::traits::event_source::{EventSourceKind, EventType, RepositoryInfo};
     ProcessingEvent {
         event_id: "evt-001".to_string(),
@@ -627,7 +632,7 @@ fn test_event(pr_number: u64, comment_body: &str, pr_state: &str) -> ProcessingE
             "comment": {
                 "body": comment_body,
                 "user": {
-                    "login": "test-user"
+                    "login": commenter_login
                 }
             }
         }),
@@ -801,8 +806,38 @@ async fn test_process_unrecognised_comment_body_is_noop() {
     let result = processor.process(&event).await;
 
     assert!(result.is_ok());
+    // No GitHub API calls should be made for unrecognised comment bodies —
+    // not even a permission check — so the issue_comments list stays empty.
     assert!(github.issue_comments().await.is_empty());
     assert!(github.created_prs().await.is_empty());
+}
+
+#[tokio::test]
+async fn test_process_bot_comment_with_command_is_noop() {
+    // Simulates the feedback loop: a bot (e.g. our own app posting a reply)
+    // includes text that looks like a command.  We must never act on it.
+    let github = TestGitHub::new().with_pr(make_open_pr(42, "abc123")).await;
+    let processor = CommentCommandProcessor::new(default_config(true), &github);
+
+    let event = test_event_with_login(42, "!release minor", "open", "gg-release-regent[bot]");
+    let result = processor.process(&event).await;
+
+    assert!(result.is_ok());
+    assert!(github.issue_comments().await.is_empty());
+}
+
+#[tokio::test]
+async fn test_process_other_bot_comment_with_command_is_noop() {
+    // A third-party bot that happens to include command-like text should also
+    // be ignored.
+    let github = TestGitHub::new().with_pr(make_open_pr(42, "abc123")).await;
+    let processor = CommentCommandProcessor::new(default_config(true), &github);
+
+    let event = test_event_with_login(42, "!set-version 1.0.0", "open", "some-other-app[bot]");
+    let result = processor.process(&event).await;
+
+    assert!(result.is_ok());
+    assert!(github.issue_comments().await.is_empty());
 }
 
 #[tokio::test]

--- a/crates/core/src/comment_command_processor_tests.rs
+++ b/crates/core/src/comment_command_processor_tests.rs
@@ -469,6 +469,14 @@ impl GitHubOperations for TestGitHub {
             .unwrap_or_default())
     }
 
+    async fn get_installation_id_for_repo(
+        &self,
+        _owner: &str,
+        _repo: &str,
+    ) -> CoreResult<u64> {
+        Ok(0)
+    }
+
     fn scoped_to(&self, _installation_id: u64) -> Self {
         Self {
             state: Arc::clone(&self.state),

--- a/crates/core/src/comment_command_processor_tests.rs
+++ b/crates/core/src/comment_command_processor_tests.rs
@@ -377,6 +377,16 @@ impl GitHubOperations for TestGitHub {
         Ok(())
     }
 
+    async fn force_update_branch(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _branch_name: &str,
+        _sha: &str,
+    ) -> CoreResult<()> {
+        Ok(())
+    }
+
     async fn create_issue_comment(
         &self,
         _owner: &str,

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -13,27 +13,78 @@ use tracing::{debug, info};
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BranchConfig {
     /// Main branch name
+    #[serde(default = "default_main_branch")]
     pub main: String,
+}
+
+fn default_main_branch() -> String {
+    "main".to_string()
+}
+
+impl Default for BranchConfig {
+    fn default() -> Self {
+        Self {
+            main: default_main_branch(),
+        }
+    }
 }
 
 /// Core Release Regent settings
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CoreConfig {
     /// Version prefix (e.g., "v" for "v1.0.0")
+    #[serde(default = "default_version_prefix")]
     pub version_prefix: String,
     /// Branch configuration
+    #[serde(default)]
     pub branches: BranchConfig,
+}
+
+fn default_version_prefix() -> String {
+    "v".to_string()
+}
+
+impl Default for CoreConfig {
+    fn default() -> Self {
+        Self {
+            version_prefix: default_version_prefix(),
+            branches: BranchConfig::default(),
+        }
+    }
 }
 
 /// Error handling configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ErrorHandlingConfig {
     /// Maximum number of retries
+    #[serde(default = "default_max_retries")]
     pub max_retries: u32,
     /// Backoff multiplier for retries
+    #[serde(default = "default_backoff_multiplier")]
     pub backoff_multiplier: f64,
     /// Initial delay in milliseconds
+    #[serde(default = "default_initial_delay_ms")]
     pub initial_delay_ms: u64,
+}
+
+fn default_max_retries() -> u32 {
+    5
+}
+fn default_backoff_multiplier() -> f64 {
+    2.0
+}
+fn default_initial_delay_ms() -> u64 {
+    1000
+}
+
+impl Default for ErrorHandlingConfig {
+    fn default() -> Self {
+        Self {
+            max_retries: default_max_retries(),
+            backoff_multiplier: default_backoff_multiplier(),
+            initial_delay_ms: default_initial_delay_ms(),
+        }
+    }
 }
 
 /// External versioning configuration
@@ -58,8 +109,10 @@ pub struct GitHubIssueConfig {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct NotificationConfig {
     /// Whether notifications are enabled
+    #[serde(default = "default_notifications_enabled")]
     pub enabled: bool,
     /// Notification strategy
+    #[serde(default = "default_notification_strategy")]
     pub strategy: NotificationStrategy,
     /// GitHub issue notification settings
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -72,31 +125,79 @@ pub struct NotificationConfig {
     pub slack: Option<SlackConfig>,
 }
 
+fn default_notifications_enabled() -> bool {
+    true
+}
+fn default_notification_strategy() -> NotificationStrategy {
+    NotificationStrategy::GitHubIssue
+}
+
+impl Default for NotificationConfig {
+    fn default() -> Self {
+        Self {
+            enabled: default_notifications_enabled(),
+            strategy: default_notification_strategy(),
+            github_issue: Some(GitHubIssueConfig {
+                labels: vec!["release-regent".to_string(), "bug".to_string()],
+                assignees: vec![],
+            }),
+            webhook: None,
+            slack: None,
+        }
+    }
+}
+
 /// Release PR configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ReleasePrConfig {
     /// PR title template
+    #[serde(default = "default_pr_title_template")]
     pub title_template: String,
     /// PR body template
+    #[serde(default = "default_pr_body_template")]
     pub body_template: String,
     /// Whether to create PRs as drafts
+    #[serde(default)]
     pub draft: bool,
+}
+
+fn default_pr_title_template() -> String {
+    "chore(release): ${version}".to_string()
+}
+fn default_pr_body_template() -> String {
+    "## Changelog\n\n${changelog}".to_string()
+}
+
+impl Default for ReleasePrConfig {
+    fn default() -> Self {
+        Self {
+            title_template: default_pr_title_template(),
+            body_template: default_pr_body_template(),
+            draft: false,
+        }
+    }
 }
 
 /// Main Release Regent configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ReleaseRegentConfig {
     /// Core settings
+    #[serde(default)]
     pub core: CoreConfig,
     /// Release PR settings
+    #[serde(default)]
     pub release_pr: ReleasePrConfig,
     /// GitHub release settings
+    #[serde(default)]
     pub releases: ReleasesConfig,
     /// Error handling configuration
+    #[serde(default)]
     pub error_handling: ErrorHandlingConfig,
     /// Notification settings
+    #[serde(default)]
     pub notifications: NotificationConfig,
     /// Versioning strategy
+    #[serde(default)]
     pub versioning: VersioningConfig,
 }
 
@@ -104,11 +205,28 @@ pub struct ReleaseRegentConfig {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ReleasesConfig {
     /// Whether to create releases as drafts
+    #[serde(default)]
     pub draft: bool,
     /// Whether to mark as prerelease
+    #[serde(default)]
     pub prerelease: bool,
     /// Whether to generate release notes automatically
+    #[serde(default = "default_generate_notes")]
     pub generate_notes: bool,
+}
+
+fn default_generate_notes() -> bool {
+    true
+}
+
+impl Default for ReleasesConfig {
+    fn default() -> Self {
+        Self {
+            draft: false,
+            prerelease: false,
+            generate_notes: default_generate_notes(),
+        }
+    }
 }
 
 /// Slack notification configuration
@@ -125,12 +243,31 @@ pub struct SlackConfig {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct VersioningConfig {
     /// Versioning strategy
+    #[serde(default = "default_versioning_strategy")]
     pub strategy: VersioningStrategy,
     /// External versioning settings
     #[serde(skip_serializing_if = "Option::is_none")]
     pub external: Option<ExternalVersioningConfig>,
     /// Whether to allow PR comment overrides
+    #[serde(default = "default_allow_override")]
     pub allow_override: bool,
+}
+
+fn default_versioning_strategy() -> VersioningStrategy {
+    VersioningStrategy::Conventional
+}
+fn default_allow_override() -> bool {
+    true
+}
+
+impl Default for VersioningConfig {
+    fn default() -> Self {
+        Self {
+            strategy: default_versioning_strategy(),
+            external: None,
+            allow_override: default_allow_override(),
+        }
+    }
 }
 
 /// Webhook notification configuration
@@ -170,42 +307,12 @@ pub enum VersioningStrategy {
 impl Default for ReleaseRegentConfig {
     fn default() -> Self {
         Self {
-            core: CoreConfig {
-                version_prefix: "v".to_string(),
-                branches: BranchConfig {
-                    main: "main".to_string(),
-                },
-            },
-            release_pr: ReleasePrConfig {
-                title_template: "chore(release): ${version}".to_string(),
-                body_template: "## Changelog\n\n${changelog}".to_string(),
-                draft: false,
-            },
-            releases: ReleasesConfig {
-                draft: false,
-                prerelease: false,
-                generate_notes: true,
-            },
-            error_handling: ErrorHandlingConfig {
-                max_retries: 5,
-                backoff_multiplier: 2.0,
-                initial_delay_ms: 1000,
-            },
-            notifications: NotificationConfig {
-                enabled: true,
-                strategy: NotificationStrategy::GitHubIssue,
-                github_issue: Some(GitHubIssueConfig {
-                    labels: vec!["release-regent".to_string(), "bug".to_string()],
-                    assignees: vec![],
-                }),
-                webhook: None,
-                slack: None,
-            },
-            versioning: VersioningConfig {
-                strategy: VersioningStrategy::Conventional,
-                external: None,
-                allow_override: true,
-            },
+            core: CoreConfig::default(),
+            release_pr: ReleasePrConfig::default(),
+            releases: ReleasesConfig::default(),
+            error_handling: ErrorHandlingConfig::default(),
+            notifications: NotificationConfig::default(),
+            versioning: VersioningConfig::default(),
         }
     }
 }

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -285,6 +285,7 @@ pub struct WebhookConfig {
 #[serde(rename_all = "snake_case")]
 pub enum NotificationStrategy {
     /// Create GitHub issues for errors
+    #[serde(rename = "github_issue")]
     GitHubIssue,
     /// Send webhook notifications
     Webhook,

--- a/crates/core/src/default_version_calculator.rs
+++ b/crates/core/src/default_version_calculator.rs
@@ -445,4 +445,9 @@ impl VersionCalculatorTrait for DefaultVersionCalculator {
         next.build = build;
         Ok(next)
     }
+
+    fn scoped_to(&self, _installation_id: u64) -> std::sync::Arc<dyn VersionCalculatorTrait + Send + Sync> {
+        // Local-git calculator is not GitHub-scoped; return a fresh instance.
+        std::sync::Arc::new(DefaultVersionCalculator::new())
+    }
 }

--- a/crates/core/src/default_version_calculator.rs
+++ b/crates/core/src/default_version_calculator.rs
@@ -410,6 +410,9 @@ impl VersionCalculatorTrait for DefaultVersionCalculator {
     }
 
     /// Apply a version bump to an existing version.
+    ///
+    /// When `major == 0` (pre-1.0 development), a `Major` bump is treated as a
+    /// `Minor` bump so the project stays on `0.x` until it deliberately ships 1.0.0.
     fn apply_version_bump(
         &self,
         current_version: SemanticVersion,
@@ -418,6 +421,13 @@ impl VersionCalculatorTrait for DefaultVersionCalculator {
         build: Option<String>,
     ) -> CoreResult<SemanticVersion> {
         let mut next = match bump_type {
+            TraitVersionBump::Major if current_version.major == 0 => SemanticVersion {
+                major: 0,
+                minor: current_version.minor + 1,
+                patch: 0,
+                prerelease: None,
+                build: None,
+            },
             TraitVersionBump::Major => SemanticVersion {
                 major: current_version.major + 1,
                 minor: 0,

--- a/crates/core/src/default_version_calculator.rs
+++ b/crates/core/src/default_version_calculator.rs
@@ -456,7 +456,10 @@ impl VersionCalculatorTrait for DefaultVersionCalculator {
         Ok(next)
     }
 
-    fn scoped_to(&self, _installation_id: u64) -> std::sync::Arc<dyn VersionCalculatorTrait + Send + Sync> {
+    fn scoped_to(
+        &self,
+        _installation_id: u64,
+    ) -> std::sync::Arc<dyn VersionCalculatorTrait + Send + Sync> {
         // Local-git calculator is not GitHub-scoped; return a fresh instance.
         std::sync::Arc::new(DefaultVersionCalculator::new())
     }

--- a/crates/core/src/default_version_calculator_tests.rs
+++ b/crates/core/src/default_version_calculator_tests.rs
@@ -300,6 +300,25 @@ fn apply_version_bump_increments_major_and_resets_minor_patch() {
 }
 
 #[test]
+fn apply_version_bump_major_on_pre_one_zero_bumps_minor_not_major() {
+    // When major == 0, a breaking change must bump minor, not major.
+    let calc = DefaultVersionCalculator::new();
+    let base = SemanticVersion {
+        major: 0,
+        minor: 1,
+        patch: 0,
+        prerelease: None,
+        build: None,
+    };
+    let result = calc.apply_version_bump(base, TraitVersionBump::Major, None, None);
+    assert!(result.is_ok());
+    let next = result.unwrap();
+    assert_eq!(next.major, 0, "major must stay 0 in pre-1.0 mode");
+    assert_eq!(next.minor, 2, "0.1.0 + breaking change -> 0.2.0, not 1.0.0");
+    assert_eq!(next.patch, 0);
+}
+
+#[test]
 fn apply_version_bump_with_none_leaves_version_unchanged() {
     let calc = DefaultVersionCalculator::new();
     let base = SemanticVersion {

--- a/crates/core/src/github_version_calculator.rs
+++ b/crates/core/src/github_version_calculator.rs
@@ -16,9 +16,7 @@ use crate::{
             VersionCalculator as VersionCalculatorTrait, VersionContext, VersioningStrategy,
         },
     },
-    versioning::{
-        SemanticVersion, VersionCalculator as ConventionalCalculator,
-    },
+    versioning::{SemanticVersion, VersionCalculator as ConventionalCalculator},
     CoreError, CoreResult,
 };
 use async_trait::async_trait;
@@ -134,6 +132,11 @@ impl<G: GitHubOperations> GitHubVersionCalculator<G> {
     }
 
     /// Apply a version bump to a semantic version, returning the bumped version.
+    ///
+    /// When `major == 0` (pre-1.0 development), a `Major` bump is treated as a
+    /// `Minor` bump. Semver 2.0 allows breaking changes within major version 0 to
+    /// only advance the minor component so that projects stay on `0.x` until they
+    /// deliberately ship their first stable `1.0.0` release.
     fn bump_version(
         current: SemanticVersion,
         bump: &TraitVersionBump,
@@ -141,6 +144,13 @@ impl<G: GitHubOperations> GitHubVersionCalculator<G> {
         build: Option<String>,
     ) -> CoreResult<SemanticVersion> {
         let mut next = match bump {
+            TraitVersionBump::Major if current.major == 0 => SemanticVersion {
+                major: 0,
+                minor: current.minor + 1,
+                patch: 0,
+                prerelease: None,
+                build: None,
+            },
             TraitVersionBump::Major => SemanticVersion {
                 major: current.major + 1,
                 minor: 0,

--- a/crates/core/src/github_version_calculator.rs
+++ b/crates/core/src/github_version_calculator.rs
@@ -1,0 +1,399 @@
+//! GitHub API-backed version calculator.
+//!
+//! Implements [`VersionCalculatorTrait`] using the GitHub API to fetch commit
+//! history instead of spawning a local `git` subprocess.  This is the correct
+//! implementation for server deployments where no local git clone exists.
+//!
+//! [`VersionCalculatorTrait`]: crate::traits::version_calculator::VersionCalculator
+
+use crate::{
+    traits::{
+        git_operations::GetCommitsOptions,
+        github_operations::GitHubOperations,
+        version_calculator::{
+            CalculationOptions, ChangelogEntry, CommitAnalysis, ValidationRules,
+            VersionBump as TraitVersionBump, VersionCalculationResult,
+            VersionCalculator as VersionCalculatorTrait, VersionContext, VersioningStrategy,
+        },
+    },
+    versioning::{
+        SemanticVersion, VersionCalculator as ConventionalCalculator,
+    },
+    CoreError, CoreResult,
+};
+use async_trait::async_trait;
+use chrono::Utc;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tracing::debug;
+
+/// Version calculator that fetches commits via the GitHub API.
+///
+/// Holds an unscoped GitHub API client (`G`).  On each `calculate_version`
+/// call the client is scoped to `context.installation_id` before any API
+/// requests are made, so the calculator can safely be constructed once at
+/// server startup and reused across many webhook events.
+///
+/// # When to use
+///
+/// Use `GitHubVersionCalculator` whenever the server runs without a local
+/// git clone.  For the CLI, which always runs inside a git working tree,
+/// [`DefaultVersionCalculator`] remains the appropriate choice.
+///
+/// [`DefaultVersionCalculator`]: crate::DefaultVersionCalculator
+#[derive(Debug, Clone)]
+pub struct GitHubVersionCalculator<G: GitHubOperations> {
+    github_operations: G,
+}
+
+impl<G: GitHubOperations> GitHubVersionCalculator<G> {
+    /// Create a new calculator backed by the given (unscoped) GitHub API client.
+    ///
+    /// The client will be scoped per calculation using `context.installation_id`.
+    #[must_use]
+    pub fn new(github_operations: G) -> Self {
+        Self { github_operations }
+    }
+
+    /// Derive the highest `TraitVersionBump` from a slice of analyses.
+    fn highest_bump(analyses: &[CommitAnalysis]) -> TraitVersionBump {
+        let mut result = TraitVersionBump::None;
+        for analysis in analyses {
+            match analysis.version_bump {
+                TraitVersionBump::Major => return TraitVersionBump::Major,
+                TraitVersionBump::Minor if result != TraitVersionBump::Minor => {
+                    result = TraitVersionBump::Minor;
+                }
+                TraitVersionBump::Patch if result == TraitVersionBump::None => {
+                    result = TraitVersionBump::Patch;
+                }
+                _ => {}
+            }
+        }
+        result
+    }
+
+    /// Convert a parsed [`crate::versioning::ConventionalCommit`] to a [`CommitAnalysis`].
+    fn to_commit_analysis(commit: crate::versioning::ConventionalCommit) -> CommitAnalysis {
+        let version_bump = if commit.breaking_change {
+            TraitVersionBump::Major
+        } else if commit.commit_type == "feat" {
+            TraitVersionBump::Minor
+        } else if commit.commit_type == "fix" {
+            TraitVersionBump::Patch
+        } else {
+            TraitVersionBump::None
+        };
+
+        CommitAnalysis {
+            author: String::new(),
+            commit_type: Some(commit.commit_type),
+            date: Utc::now(),
+            is_breaking: commit.breaking_change,
+            message: commit.message,
+            metadata: HashMap::new(),
+            scope: commit.scope,
+            sha: commit.sha,
+            version_bump,
+        }
+    }
+
+    /// Build a [`VersionCalculationResult`] from analyses and the computed version.
+    fn build_result(
+        context: &VersionContext,
+        strategy: VersioningStrategy,
+        analyses: Vec<CommitAnalysis>,
+        next_version: SemanticVersion,
+        bump: TraitVersionBump,
+    ) -> VersionCalculationResult {
+        let changelog_entries: Vec<ChangelogEntry> = analyses
+            .iter()
+            .filter(|a| a.version_bump != TraitVersionBump::None || a.is_breaking)
+            .map(|a| ChangelogEntry {
+                commit_sha: a.sha.clone(),
+                description: a.message.clone(),
+                entry_type: a.commit_type.clone().unwrap_or_else(|| "chore".to_string()),
+                is_breaking: a.is_breaking,
+                issues: Vec::new(),
+                pr_number: None,
+                scope: a.scope.clone(),
+            })
+            .collect();
+
+        VersionCalculationResult {
+            analyzed_commits: analyses,
+            build_metadata: None,
+            changelog_entries,
+            current_version: context.current_version.clone(),
+            is_prerelease: next_version.is_prerelease(),
+            metadata: HashMap::new(),
+            next_version,
+            strategy,
+            version_bump: bump,
+        }
+    }
+
+    /// Apply a version bump to a semantic version, returning the bumped version.
+    fn bump_version(
+        current: SemanticVersion,
+        bump: &TraitVersionBump,
+        prerelease: Option<String>,
+        build: Option<String>,
+    ) -> CoreResult<SemanticVersion> {
+        let mut next = match bump {
+            TraitVersionBump::Major => SemanticVersion {
+                major: current.major + 1,
+                minor: 0,
+                patch: 0,
+                prerelease: None,
+                build: None,
+            },
+            TraitVersionBump::Minor => SemanticVersion {
+                major: current.major,
+                minor: current.minor + 1,
+                patch: 0,
+                prerelease: None,
+                build: None,
+            },
+            TraitVersionBump::Patch => SemanticVersion {
+                major: current.major,
+                minor: current.minor,
+                patch: current.patch + 1,
+                prerelease: None,
+                build: None,
+            },
+            TraitVersionBump::None => current,
+        };
+        next.prerelease = prerelease;
+        next.build = build;
+        Ok(next)
+    }
+
+    /// Map from core `versioning::VersionBump` to the trait-layer `VersionBump`.
+    #[allow(dead_code)]
+    fn local_to_trait_bump(bump: &crate::versioning::VersionBump) -> TraitVersionBump {
+        match bump {
+            crate::versioning::VersionBump::Major => TraitVersionBump::Major,
+            crate::versioning::VersionBump::Minor => TraitVersionBump::Minor,
+            crate::versioning::VersionBump::Patch => TraitVersionBump::Patch,
+            crate::versioning::VersionBump::None => TraitVersionBump::None,
+        }
+    }
+}
+
+#[async_trait]
+impl<G: GitHubOperations + 'static> VersionCalculatorTrait for GitHubVersionCalculator<G> {
+    /// Calculate the next version by fetching commits from the GitHub API and
+    /// applying conventional-commit rules.
+    ///
+    /// The underlying GitHub client must already be scoped to the correct
+    /// installation (i.e. call `scoped_to(installation_id)` first).
+    async fn calculate_version(
+        &self,
+        context: VersionContext,
+        strategy: VersioningStrategy,
+        _options: CalculationOptions,
+    ) -> CoreResult<VersionCalculationResult> {
+        debug!(
+            owner = %context.owner,
+            repo = %context.repo,
+            base_ref = ?context.base_ref,
+            head_ref = %context.head_ref,
+            "Calculating version via GitHub API",
+        );
+
+        let raw_commits: Vec<(String, String)> = if let Some(ref base) = context.base_ref {
+            let commits = self
+                .github_operations
+                .get_commits_between(
+                    &context.owner,
+                    &context.repo,
+                    base,
+                    &context.head_ref,
+                    GetCommitsOptions::default(),
+                )
+                .await?;
+            debug!(
+                commit_count = commits.len(),
+                "Fetched commits between refs via GitHub API"
+            );
+            commits.into_iter().map(|c| (c.sha, c.subject)).collect()
+        } else {
+            // No base ref — first release, no prior tag to compare against.
+            debug!("No base_ref; skipping commit analysis for first release");
+            Vec::new()
+        };
+
+        let conventional = ConventionalCalculator::parse_conventional_commits(&raw_commits);
+        let analyses: Vec<CommitAnalysis> = conventional
+            .into_iter()
+            .map(Self::to_commit_analysis)
+            .collect();
+
+        let bump = Self::highest_bump(&analyses);
+
+        let current = context.current_version.clone().unwrap_or(SemanticVersion {
+            major: 0,
+            minor: 1,
+            patch: 0,
+            prerelease: None,
+            build: None,
+        });
+
+        let next_version = Self::bump_version(current, &bump, None, None)?;
+
+        Ok(Self::build_result(
+            &context,
+            strategy,
+            analyses,
+            next_version,
+            bump,
+        ))
+    }
+
+    /// Analyse individual commits identified by their SHAs using the GitHub API.
+    async fn analyze_commits(
+        &self,
+        context: VersionContext,
+        _strategy: VersioningStrategy,
+        commit_shas: Vec<String>,
+    ) -> CoreResult<Vec<CommitAnalysis>> {
+        let mut analyses = Vec::with_capacity(commit_shas.len());
+
+        for sha in &commit_shas {
+            let commit = self
+                .github_operations
+                .get_commit(&context.owner, &context.repo, sha)
+                .await
+                .map_err(|e| CoreError::versioning(format!("Failed to fetch commit {sha}: {e}")))?;
+
+            let raw = vec![(commit.sha.clone(), commit.subject.clone())];
+            let parsed = ConventionalCalculator::parse_conventional_commits(&raw);
+            for c in parsed {
+                analyses.push(Self::to_commit_analysis(c));
+            }
+        }
+
+        Ok(analyses)
+    }
+
+    /// Validate a proposed version.  Always returns `true` for this implementation.
+    async fn validate_version(
+        &self,
+        _context: VersionContext,
+        _proposed_version: SemanticVersion,
+        _rules: ValidationRules,
+    ) -> CoreResult<bool> {
+        Ok(true)
+    }
+
+    /// Return the highest version bump implied by the provided analyses.
+    async fn get_version_bump(
+        &self,
+        _context: VersionContext,
+        _strategy: VersioningStrategy,
+        commit_analyses: Vec<CommitAnalysis>,
+    ) -> CoreResult<TraitVersionBump> {
+        Ok(Self::highest_bump(&commit_analyses))
+    }
+
+    /// Generate changelog entries from commit analyses.
+    async fn generate_changelog_entries(
+        &self,
+        _context: VersionContext,
+        _strategy: VersioningStrategy,
+        commit_analyses: Vec<CommitAnalysis>,
+        _version: SemanticVersion,
+    ) -> CoreResult<Vec<ChangelogEntry>> {
+        let entries = commit_analyses
+            .into_iter()
+            .filter(|a| a.version_bump != TraitVersionBump::None || a.is_breaking)
+            .map(|a| ChangelogEntry {
+                commit_sha: a.sha.clone(),
+                description: a.message.clone(),
+                entry_type: a.commit_type.clone().unwrap_or_else(|| "chore".to_string()),
+                is_breaking: a.is_breaking,
+                issues: Vec::new(),
+                pr_number: None,
+                scope: a.scope.clone(),
+            })
+            .collect();
+        Ok(entries)
+    }
+
+    /// Perform a dry-run calculation — delegates to `calculate_version`.
+    async fn preview_calculation(
+        &self,
+        context: VersionContext,
+        strategy: VersioningStrategy,
+        options: CalculationOptions,
+    ) -> CoreResult<VersionCalculationResult> {
+        self.calculate_version(context, strategy, options).await
+    }
+
+    /// Return the set of versioning strategies this calculator supports.
+    fn supported_strategies(&self) -> HashMap<String, String> {
+        let mut map = HashMap::new();
+        map.insert(
+            "conventional_commits".to_string(),
+            "Semantic versioning derived from conventional commits".to_string(),
+        );
+        map
+    }
+
+    /// Return the default versioning strategy.
+    fn default_strategy(&self) -> VersioningStrategy {
+        VersioningStrategy::ConventionalCommits {
+            custom_types: HashMap::new(),
+            include_prerelease: false,
+        }
+    }
+
+    /// Parse a single commit message into a [`CommitAnalysis`].
+    fn parse_conventional_commit(
+        &self,
+        commit_message: &str,
+    ) -> CoreResult<Option<CommitAnalysis>> {
+        let known_types = [
+            "feat", "fix", "chore", "docs", "style", "refactor", "perf", "test", "build", "ci",
+            "revert",
+        ];
+        let first_line = commit_message.lines().next().unwrap_or("");
+        let is_conventional = known_types.iter().any(|t| {
+            first_line.starts_with(&format!("{t}("))
+                || first_line.starts_with(&format!("{t}!"))
+                || first_line.starts_with(&format!("{t}: "))
+        });
+
+        if !is_conventional {
+            return Ok(None);
+        }
+
+        let raw = vec![("unknown".to_string(), commit_message.to_string())];
+        let parsed = ConventionalCalculator::parse_conventional_commits(&raw);
+        Ok(parsed.into_iter().next().map(Self::to_commit_analysis))
+    }
+
+    /// Apply a version bump to an existing version.
+    fn apply_version_bump(
+        &self,
+        current_version: SemanticVersion,
+        bump_type: TraitVersionBump,
+        prerelease: Option<String>,
+        build: Option<String>,
+    ) -> CoreResult<SemanticVersion> {
+        Self::bump_version(current_version, &bump_type, prerelease, build)
+    }
+
+    /// Return a copy of this calculator with the GitHub client scoped to the
+    /// given installation ID.
+    ///
+    /// This is the correct way to supply authentication context to
+    /// `GitHubVersionCalculator` — scope it before calling `calculate_version`
+    /// rather than embedding the installation ID in `VersionContext`.
+    fn scoped_to(&self, installation_id: u64) -> Arc<dyn VersionCalculatorTrait + Send + Sync> {
+        Arc::new(Self {
+            github_operations: self.github_operations.scoped_to(installation_id),
+        })
+    }
+}

--- a/crates/core/src/github_version_calculator.rs
+++ b/crates/core/src/github_version_calculator.rs
@@ -72,7 +72,16 @@ impl<G: GitHubOperations> GitHubVersionCalculator<G> {
     }
 
     /// Convert a parsed [`crate::versioning::ConventionalCommit`] to a [`CommitAnalysis`].
-    fn to_commit_analysis(commit: crate::versioning::ConventionalCommit) -> CommitAnalysis {
+    ///
+    /// The `date` and `author` parameters are threaded in from the originating
+    /// [`crate::traits::git_operations::GitCommit`] because [`ConventionalCommit`]
+    /// only carries the SHA and message text — the full commit metadata is
+    /// discarded by the parser.
+    fn to_commit_analysis(
+        commit: crate::versioning::ConventionalCommit,
+        date: chrono::DateTime<Utc>,
+        author: String,
+    ) -> CommitAnalysis {
         let version_bump = if commit.breaking_change {
             TraitVersionBump::Major
         } else if commit.commit_type == "feat" {
@@ -84,9 +93,9 @@ impl<G: GitHubOperations> GitHubVersionCalculator<G> {
         };
 
         CommitAnalysis {
-            author: String::new(),
+            author,
             commit_type: Some(commit.commit_type),
-            date: Utc::now(),
+            date,
             is_breaking: commit.breaking_change,
             message: commit.message,
             metadata: HashMap::new(),
@@ -180,6 +189,13 @@ impl<G: GitHubOperations> GitHubVersionCalculator<G> {
     }
 
     /// Map from core `versioning::VersionBump` to the trait-layer `VersionBump`.
+    ///
+    /// This conversion helper is not yet called by any production code path — the
+    /// trait's `VersionBump` is currently derived directly from
+    /// `ConventionalCommit.breaking_change` / `commit_type` in
+    /// [`to_commit_analysis`].  It is retained here because future refactors may
+    /// need to convert an already-computed `versioning::VersionBump` (e.g., when
+    /// integrating with `DefaultVersionCalculator` output) into the trait type.
     #[allow(dead_code)]
     fn local_to_trait_bump(bump: &crate::versioning::VersionBump) -> TraitVersionBump {
         match bump {
@@ -212,7 +228,10 @@ impl<G: GitHubOperations + 'static> VersionCalculatorTrait for GitHubVersionCalc
             "Calculating version via GitHub API",
         );
 
-        let raw_commits: Vec<(String, String)> = if let Some(ref base) = context.base_ref {
+        let raw_commits: Vec<(String, String)>;
+        let mut sha_to_meta: HashMap<String, (chrono::DateTime<Utc>, String)> = HashMap::new();
+
+        if let Some(ref base) = context.base_ref {
             let commits = self
                 .github_operations
                 .get_commits_between(
@@ -227,17 +246,28 @@ impl<G: GitHubOperations + 'static> VersionCalculatorTrait for GitHubVersionCalc
                 commit_count = commits.len(),
                 "Fetched commits between refs via GitHub API"
             );
-            commits.into_iter().map(|c| (c.sha, c.subject)).collect()
+            // Build a lookup table keyed by SHA so that to_commit_analysis can
+            // populate the date and author fields from the original GitCommit
+            // rather than falling back to Utc::now() / empty string.
+            for c in &commits {
+                sha_to_meta.insert(c.sha.clone(), (c.author_date, c.author.name.clone()));
+            }
+            raw_commits = commits.into_iter().map(|c| (c.sha, c.subject)).collect();
         } else {
             // No base ref — first release, no prior tag to compare against.
             debug!("No base_ref; skipping commit analysis for first release");
-            Vec::new()
+            raw_commits = Vec::new();
         };
 
         let conventional = ConventionalCalculator::parse_conventional_commits(&raw_commits);
         let analyses: Vec<CommitAnalysis> = conventional
             .into_iter()
-            .map(Self::to_commit_analysis)
+            .map(|c| {
+                let (date, author) = sha_to_meta
+                    .remove(&c.sha)
+                    .unwrap_or_else(|| (Utc::now(), String::new()));
+                Self::to_commit_analysis(c, date, author)
+            })
             .collect();
 
         let bump = Self::highest_bump(&analyses);
@@ -277,10 +307,12 @@ impl<G: GitHubOperations + 'static> VersionCalculatorTrait for GitHubVersionCalc
                 .await
                 .map_err(|e| CoreError::versioning(format!("Failed to fetch commit {sha}: {e}")))?;
 
+            let date = commit.author_date;
+            let author = commit.author.name.clone();
             let raw = vec![(commit.sha.clone(), commit.subject.clone())];
             let parsed = ConventionalCalculator::parse_conventional_commits(&raw);
             for c in parsed {
-                analyses.push(Self::to_commit_analysis(c));
+                analyses.push(Self::to_commit_analysis(c, date, author.clone()));
             }
         }
 
@@ -381,7 +413,10 @@ impl<G: GitHubOperations + 'static> VersionCalculatorTrait for GitHubVersionCalc
 
         let raw = vec![("unknown".to_string(), commit_message.to_string())];
         let parsed = ConventionalCalculator::parse_conventional_commits(&raw);
-        Ok(parsed.into_iter().next().map(Self::to_commit_analysis))
+        Ok(parsed
+            .into_iter()
+            .next()
+            .map(|c| Self::to_commit_analysis(c, Utc::now(), String::new())))
     }
 
     /// Apply a version bump to an existing version.

--- a/crates/core/src/github_version_calculator.rs
+++ b/crates/core/src/github_version_calculator.rs
@@ -25,6 +25,10 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use tracing::debug;
 
+#[cfg(test)]
+#[path = "github_version_calculator_tests.rs"]
+mod tests;
+
 /// Version calculator that fetches commits via the GitHub API.
 ///
 /// Holds an unscoped GitHub API client (`G`).  On each `calculate_version`
@@ -292,21 +296,32 @@ impl<G: GitHubOperations + 'static> VersionCalculatorTrait for GitHubVersionCalc
     }
 
     /// Analyse individual commits identified by their SHAs using the GitHub API.
+    ///
+    /// All commits are fetched concurrently to avoid an O(N × RTT) sequential
+    /// chain of API round-trips. GitHub provides no batch commit endpoint, so
+    /// N requests are still sent, but they are issued in parallel and the total
+    /// latency is O(RTT) rather than O(N × RTT).
     async fn analyze_commits(
         &self,
         context: VersionContext,
         _strategy: VersioningStrategy,
         commit_shas: Vec<String>,
     ) -> CoreResult<Vec<CommitAnalysis>> {
-        let mut analyses = Vec::with_capacity(commit_shas.len());
+        use futures::future::try_join_all;
 
-        for sha in &commit_shas {
-            let commit = self
-                .github_operations
-                .get_commit(&context.owner, &context.repo, sha)
+        let owner = context.owner.as_str();
+        let repo = context.repo.as_str();
+
+        let commits = try_join_all(commit_shas.iter().map(|sha| async move {
+            self.github_operations
+                .get_commit(owner, repo, sha)
                 .await
-                .map_err(|e| CoreError::versioning(format!("Failed to fetch commit {sha}: {e}")))?;
+                .map_err(|e| CoreError::versioning(format!("Failed to fetch commit {sha}: {e}")))
+        }))
+        .await?;
 
+        let mut analyses = Vec::with_capacity(commits.len());
+        for commit in commits {
             let date = commit.author_date;
             let author = commit.author.name.clone();
             let raw = vec![(commit.sha.clone(), commit.subject.clone())];

--- a/crates/core/src/github_version_calculator_tests.rs
+++ b/crates/core/src/github_version_calculator_tests.rs
@@ -1,0 +1,523 @@
+//! Tests for [`GitHubVersionCalculator`].
+//!
+//! These tests exercise `analyze_commits` directly using an inline test double
+//! for [`GitHubOperations`] so that the concurrent fan-out behaviour can be
+//! verified without a live GitHub API.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use chrono::Utc;
+use tokio::sync::Mutex;
+
+use crate::{
+    github_version_calculator::GitHubVersionCalculator,
+    traits::{
+        git_operations::{
+            GetCommitsOptions, GitCommit, GitRepository, GitTag, GitUser, ListTagsOptions,
+        },
+        github_operations::{
+            CreatePullRequestParams, CreateReleaseParams, GitHubOperations, GitUser as GHGitUser,
+            Label, PullRequest, Release, Repository, Tag, UpdateReleaseParams,
+        },
+        version_calculator::{VersionCalculator, VersionContext, VersioningStrategy},
+    },
+    CoreError, CoreResult,
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test double
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// A minimal `GitHubOperations` stub that serves a pre-loaded commit map and
+/// records how many times `get_commit` has been called.
+#[derive(Clone)]
+struct StubGitHub {
+    /// Commits keyed by SHA; a missing key produces `CoreError::not_found`.
+    commits: HashMap<String, GitCommit>,
+    /// Counter incremented on every `get_commit` call.
+    get_commit_call_count: Arc<Mutex<usize>>,
+}
+
+impl StubGitHub {
+    fn new(commits: Vec<GitCommit>) -> Self {
+        let map = commits.into_iter().map(|c| (c.sha.clone(), c)).collect();
+        Self {
+            commits: map,
+            get_commit_call_count: Arc::new(Mutex::new(0)),
+        }
+    }
+
+    async fn get_commit_call_count(&self) -> usize {
+        *self.get_commit_call_count.lock().await
+    }
+}
+
+fn make_commit(sha: &str, message: &str) -> GitCommit {
+    GitCommit {
+        sha: sha.to_string(),
+        author: GitUser {
+            name: "Dev".to_string(),
+            email: "dev@example.com".to_string(),
+            username: None,
+        },
+        committer: GitUser {
+            name: "Dev".to_string(),
+            email: "dev@example.com".to_string(),
+            username: None,
+        },
+        author_date: Utc::now(),
+        commit_date: Utc::now(),
+        message: message.to_string(),
+        subject: message.to_string(),
+        body: None,
+        parents: vec![],
+        files: vec![],
+    }
+}
+
+#[async_trait]
+impl crate::traits::git_operations::GitOperations for StubGitHub {
+    async fn get_commits_between(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _base: &str,
+        _head: &str,
+        _options: GetCommitsOptions,
+    ) -> CoreResult<Vec<GitCommit>> {
+        Ok(vec![])
+    }
+
+    async fn get_commit(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        commit_sha: &str,
+    ) -> CoreResult<GitCommit> {
+        *self.get_commit_call_count.lock().await += 1;
+        self.commits
+            .get(commit_sha)
+            .cloned()
+            .ok_or_else(|| CoreError::not_found(format!("commit {commit_sha}")))
+    }
+
+    async fn list_tags(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _options: ListTagsOptions,
+    ) -> CoreResult<Vec<GitTag>> {
+        Ok(vec![])
+    }
+
+    async fn get_tag(&self, _owner: &str, _repo: &str, _tag_name: &str) -> CoreResult<GitTag> {
+        Err(CoreError::not_found("tag"))
+    }
+
+    async fn tag_exists(&self, _owner: &str, _repo: &str, _tag_name: &str) -> CoreResult<bool> {
+        Ok(false)
+    }
+
+    async fn get_head_commit(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _branch: Option<&str>,
+    ) -> CoreResult<GitCommit> {
+        Err(CoreError::not_found("head commit"))
+    }
+
+    async fn get_repository_info(&self, owner: &str, repo: &str) -> CoreResult<GitRepository> {
+        Ok(GitRepository {
+            name: repo.to_string(),
+            owner: owner.to_string(),
+            full_name: format!("{owner}/{repo}"),
+            default_branch: "main".to_string(),
+            clone_url: format!("https://github.com/{owner}/{repo}"),
+            ssh_url: format!("git@github.com:{owner}/{repo}.git"),
+            private: false,
+            description: None,
+        })
+    }
+}
+
+fn stub_repo() -> Repository {
+    Repository {
+        id: 1,
+        name: "repo".to_string(),
+        full_name: "owner/repo".to_string(),
+        owner: "owner".to_string(),
+        description: None,
+        private: false,
+        default_branch: "main".to_string(),
+        clone_url: "https://github.com/owner/repo.git".to_string(),
+        ssh_url: "git@github.com:owner/repo.git".to_string(),
+        homepage: None,
+    }
+}
+
+fn stub_git_user() -> GHGitUser {
+    GHGitUser {
+        name: "bot".to_string(),
+        email: "bot@example.com".to_string(),
+        login: Some("bot".to_string()),
+    }
+}
+
+#[async_trait]
+impl GitHubOperations for StubGitHub {
+    async fn create_pull_request(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _params: CreatePullRequestParams,
+    ) -> CoreResult<PullRequest> {
+        Err(CoreError::not_found("not implemented"))
+    }
+
+    async fn create_release(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _params: CreateReleaseParams,
+    ) -> CoreResult<Release> {
+        Err(CoreError::not_found("not implemented"))
+    }
+
+    async fn create_tag(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        tag_name: &str,
+        commit_sha: &str,
+        message: Option<String>,
+        tagger: Option<GHGitUser>,
+    ) -> CoreResult<Tag> {
+        Ok(Tag {
+            name: tag_name.to_string(),
+            commit_sha: commit_sha.to_string(),
+            message,
+            tagger,
+            created_at: None,
+        })
+    }
+
+    async fn get_latest_release(&self, _owner: &str, _repo: &str) -> CoreResult<Option<Release>> {
+        Ok(None)
+    }
+
+    async fn get_pull_request(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _number: u64,
+    ) -> CoreResult<PullRequest> {
+        Err(CoreError::not_found("PR"))
+    }
+
+    async fn get_release_by_tag(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _tag: &str,
+    ) -> CoreResult<Release> {
+        Err(CoreError::not_found("release"))
+    }
+
+    async fn list_releases(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _per_page: Option<u8>,
+        _page: Option<u32>,
+    ) -> CoreResult<Vec<Release>> {
+        Ok(vec![])
+    }
+
+    async fn list_pull_requests(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _state: Option<&str>,
+        _head: Option<&str>,
+        _base: Option<&str>,
+        _per_page: Option<u8>,
+        _page: Option<u32>,
+    ) -> CoreResult<Vec<PullRequest>> {
+        Ok(vec![])
+    }
+
+    async fn search_pull_requests(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _query: &str,
+    ) -> CoreResult<Vec<PullRequest>> {
+        Ok(vec![])
+    }
+
+    async fn update_pull_request(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _number: u64,
+        _title: Option<String>,
+        _body: Option<String>,
+        _state: Option<String>,
+    ) -> CoreResult<PullRequest> {
+        Err(CoreError::not_found("PR"))
+    }
+
+    async fn update_release(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _release_id: u64,
+        _params: UpdateReleaseParams,
+    ) -> CoreResult<Release> {
+        Err(CoreError::not_found("release"))
+    }
+
+    async fn create_branch(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _branch_name: &str,
+        _sha: &str,
+    ) -> CoreResult<()> {
+        Ok(())
+    }
+
+    async fn delete_branch(&self, _owner: &str, _repo: &str, _branch_name: &str) -> CoreResult<()> {
+        Ok(())
+    }
+
+    async fn force_update_branch(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _branch_name: &str,
+        _sha: &str,
+    ) -> CoreResult<()> {
+        Ok(())
+    }
+
+    async fn create_issue_comment(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _issue_number: u64,
+        _body: &str,
+    ) -> CoreResult<()> {
+        Ok(())
+    }
+
+    async fn get_collaborator_permission(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _username: &str,
+    ) -> CoreResult<crate::traits::github_operations::CollaboratorPermission> {
+        Ok(crate::traits::github_operations::CollaboratorPermission::Write)
+    }
+
+    async fn add_labels(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _issue_number: u64,
+        _labels: &[&str],
+    ) -> CoreResult<()> {
+        Ok(())
+    }
+
+    async fn remove_label(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _issue_number: u64,
+        _label_name: &str,
+    ) -> CoreResult<()> {
+        Ok(())
+    }
+
+    async fn list_pr_labels(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _issue_number: u64,
+    ) -> CoreResult<Vec<Label>> {
+        Ok(vec![])
+    }
+
+    async fn get_installation_id_for_repo(&self, _owner: &str, _repo: &str) -> CoreResult<u64> {
+        Ok(0)
+    }
+
+    async fn upsert_file(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _path: &str,
+        _commit_message: &str,
+        _content: &str,
+        _branch: &str,
+    ) -> CoreResult<()> {
+        Ok(())
+    }
+
+    fn scoped_to(&self, _installation_id: u64) -> Self {
+        self.clone()
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+fn make_context() -> VersionContext {
+    VersionContext {
+        base_ref: None,
+        current_version: None,
+        head_ref: "main".to_string(),
+        owner: "owner".to_string(),
+        repo: "repo".to_string(),
+        target_branch: "main".to_string(),
+    }
+}
+
+fn conventional_strategy() -> VersioningStrategy {
+    VersioningStrategy::ConventionalCommits {
+        custom_types: HashMap::new(),
+        include_prerelease: false,
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// analyze_commits tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// An empty SHA list produces an empty analysis result without calling the API.
+#[tokio::test]
+async fn test_analyze_commits_with_empty_list_returns_empty() {
+    let stub = StubGitHub::new(vec![]);
+    let calc = GitHubVersionCalculator::new(stub.clone());
+
+    let result = calc
+        .analyze_commits(make_context(), conventional_strategy(), vec![])
+        .await
+        .unwrap();
+
+    assert!(result.is_empty());
+    assert_eq!(stub.get_commit_call_count().await, 0);
+}
+
+/// A single SHA is fetched and its conventional-commit message is analysed.
+#[tokio::test]
+async fn test_analyze_commits_single_sha_returns_one_analysis() {
+    let sha = "abc1234".to_string();
+    let stub = StubGitHub::new(vec![make_commit(&sha, "feat: add login endpoint")]);
+    let calc = GitHubVersionCalculator::new(stub.clone());
+
+    let result = calc
+        .analyze_commits(make_context(), conventional_strategy(), vec![sha.clone()])
+        .await
+        .unwrap();
+
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0].sha, sha);
+    assert_eq!(result[0].commit_type, Some("feat".to_string()));
+    assert!(!result[0].is_breaking);
+    assert_eq!(stub.get_commit_call_count().await, 1);
+}
+
+/// Multiple SHAs are all fetched and each produces a separate analysis entry.
+#[tokio::test]
+async fn test_analyze_commits_multiple_shas_returns_all_analyses() {
+    let commits = vec![
+        make_commit("sha1", "feat: add feature"),
+        make_commit("sha2", "fix: patch bug"),
+        make_commit("sha3", "chore: update deps"),
+    ];
+    let shas: Vec<String> = commits.iter().map(|c| c.sha.clone()).collect();
+    let stub = StubGitHub::new(commits);
+    let calc = GitHubVersionCalculator::new(stub.clone());
+
+    let result = calc
+        .analyze_commits(make_context(), conventional_strategy(), shas)
+        .await
+        .unwrap();
+
+    assert_eq!(result.len(), 3);
+    assert_eq!(stub.get_commit_call_count().await, 3);
+
+    let types: Vec<Option<String>> = result.iter().map(|a| a.commit_type.clone()).collect();
+    assert!(types.contains(&Some("feat".to_string())));
+    assert!(types.contains(&Some("fix".to_string())));
+    assert!(types.contains(&Some("chore".to_string())));
+}
+
+/// A breaking-change commit is flagged with `is_breaking = true` and
+/// `version_bump = Major`.
+#[tokio::test]
+async fn test_analyze_commits_breaking_change_is_flagged() {
+    let sha = "break1".to_string();
+    let stub = StubGitHub::new(vec![make_commit(&sha, "feat!: remove legacy API")]);
+    let calc = GitHubVersionCalculator::new(stub);
+
+    let result = calc
+        .analyze_commits(make_context(), conventional_strategy(), vec![sha])
+        .await
+        .unwrap();
+
+    assert_eq!(result.len(), 1);
+    assert!(result[0].is_breaking);
+
+    use crate::traits::version_calculator::VersionBump;
+    assert_eq!(result[0].version_bump, VersionBump::Major);
+}
+
+/// When one SHA is not found the whole call returns an error rather than
+/// silently dropping the missing commit.
+#[tokio::test]
+async fn test_analyze_commits_missing_sha_returns_error() {
+    let stub = StubGitHub::new(vec![make_commit("exists", "fix: known commit")]);
+    let calc = GitHubVersionCalculator::new(stub);
+
+    let err = calc
+        .analyze_commits(
+            make_context(),
+            conventional_strategy(),
+            vec!["exists".to_string(), "missing-sha".to_string()],
+        )
+        .await
+        .unwrap_err();
+
+    let msg = err.to_string();
+    assert!(
+        msg.contains("missing-sha"),
+        "error should identify the missing SHA; got: {msg}"
+    );
+}
+
+/// `get_commit` is called exactly once per SHA — not more, not less.
+#[tokio::test]
+async fn test_analyze_commits_calls_api_once_per_sha() {
+    let n = 10_usize;
+    let commits: Vec<GitCommit> = (0..n)
+        .map(|i| make_commit(&format!("sha{i:03}"), &format!("fix: patch {i}")))
+        .collect();
+    let shas: Vec<String> = commits.iter().map(|c| c.sha.clone()).collect();
+    let stub = StubGitHub::new(commits);
+    let calc = GitHubVersionCalculator::new(stub.clone());
+
+    let result = calc
+        .analyze_commits(make_context(), conventional_strategy(), shas)
+        .await
+        .unwrap();
+
+    assert_eq!(result.len(), n);
+    assert_eq!(stub.get_commit_call_count().await, n);
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -311,11 +311,14 @@ where
             changelog_header: "## Changelog".to_string(),
         };
 
-        match ReleaseAutomator::new(config, &self.github_operations.scoped_to(
-            self.resolve_installation_id(owner, repo).await?,
-        ))
-            .automate(owner, repo, event, correlation_id)
-            .await
+        match ReleaseAutomator::new(
+            config,
+            &self
+                .github_operations
+                .scoped_to(self.resolve_installation_id(owner, repo).await?),
+        )
+        .automate(owner, repo, event, correlation_id)
+        .await
         {
             Ok(result) => {
                 tracing::info!(result = ?result, "Release automation completed");
@@ -349,11 +352,14 @@ where
             allow_override: repo_config.versioning.allow_override,
         };
 
-        CommentCommandProcessor::new(config, &self.github_operations.scoped_to(
-            self.resolve_installation_id(owner, repo).await?,
-        ))
-            .process(event)
-            .await
+        CommentCommandProcessor::new(
+            config,
+            &self
+                .github_operations
+                .scoped_to(self.resolve_installation_id(owner, repo).await?),
+        )
+        .process(event)
+        .await
     }
 }
 
@@ -642,11 +648,7 @@ where
     ///
     /// Calls the GitHub App API to look up the installation ID for the given
     /// repository.
-    async fn resolve_installation_id(
-        &self,
-        owner: &str,
-        repo: &str,
-    ) -> CoreResult<u64> {
+    async fn resolve_installation_id(&self, owner: &str, repo: &str) -> CoreResult<u64> {
         self.github_operations
             .get_installation_id_for_repo(owner, repo)
             .await
@@ -724,9 +726,7 @@ where
             })?
             .to_string();
 
-        let installation_id = self
-            .resolve_installation_id(owner, repo)
-            .await?;
+        let installation_id = self.resolve_installation_id(owner, repo).await?;
 
         let MergeCalcResult {
             calc_result,
@@ -775,6 +775,7 @@ where
             self.process_release_pr_merged(
                 owner,
                 repo,
+                installation_id,
                 correlation_id,
                 &orchestrator,
                 &calc_result.next_version,
@@ -787,6 +788,7 @@ where
             self.process_feature_pr_merged(
                 owner,
                 repo,
+                installation_id,
                 merged_pr_number,
                 correlation_id,
                 &orchestrator,
@@ -819,8 +821,7 @@ where
 
         let scoped_github = self.github_operations.scoped_to(installation_id);
         let current_version =
-            versioning::resolve_current_version(&scoped_github, owner, repo, false)
-                .await?;
+            versioning::resolve_current_version(&scoped_github, owner, repo, false).await?;
 
         let ctx = VersionContext {
             base_ref: current_version.as_ref().map(|v| format!("v{v}")),
@@ -848,7 +849,9 @@ where
         // Scope the calculator to the resolved installation before calling it,
         // keeping authentication concerns out of VersionContext.
         let scoped_calc = self.version_calculator.scoped_to(installation_id);
-        let calc_result = scoped_calc.calculate_version(ctx, strategy, options).await?;
+        let calc_result = scoped_calc
+            .calculate_version(ctx, strategy, options)
+            .await?;
 
         let changelog = format_changelog_for_release(&calc_result.changelog_entries);
 
@@ -864,11 +867,12 @@ where
     ///
     /// Orchestrates the next release cycle and clears stale bump-override labels
     /// from open feature PRs that were scoped to the completed release.
-    #[allow(clippy::too_many_arguments)] // owner/repo/correlation/orchestrator/version/changelog/branch/sha is the minimal surface
+    #[allow(clippy::too_many_arguments)] // owner/repo/installation_id/correlation/orchestrator/version/changelog/branch/sha is the minimal surface
     async fn process_release_pr_merged(
         &self,
         owner: &str,
         repo: &str,
+        installation_id: u64,
         correlation_id: &str,
         orchestrator: &release_orchestrator::ReleaseOrchestrator<'_, G>,
         version: &versioning::SemanticVersion,
@@ -899,8 +903,13 @@ where
 
         // After a release is published, clear stale rr:override-* labels from
         // any open feature PRs. Overrides were scoped to this release cycle.
-        self.clear_stale_override_labels_after_release(owner, repo, correlation_id)
-            .await;
+        self.clear_stale_override_labels_after_release(
+            owner,
+            repo,
+            installation_id,
+            correlation_id,
+        )
+        .await;
 
         Ok(orch_result)
     }
@@ -910,21 +919,22 @@ where
         &self,
         owner: &str,
         repo: &str,
+        installation_id: u64,
         correlation_id: &str,
     ) {
         use comment_command_processor::ALL_OVERRIDE_LABELS;
 
+        let scoped_github = self.github_operations.scoped_to(installation_id);
+
         for &label_name in ALL_OVERRIDE_LABELS {
             let query = format!("is:open label:{label_name}");
-            match self
-                .github_operations
+            match scoped_github
                 .search_pull_requests(owner, repo, &query)
                 .await
             {
                 Ok(stale_prs) => {
                     for stale_pr in stale_prs {
-                        if let Err(e) = self
-                            .github_operations
+                        if let Err(e) = scoped_github
                             .remove_label(owner, repo, stale_pr.number, label_name)
                             .await
                         {
@@ -946,8 +956,7 @@ where
                              a minimum bump for the next release, please re-post your \
                              `!release` command."
                         );
-                        if let Err(e) = self
-                            .github_operations
+                        if let Err(e) = scoped_github
                             .create_issue_comment(owner, repo, stale_pr.number, &cleanup_body)
                             .await
                         {
@@ -977,11 +986,12 @@ where
     /// Applies any bump-floor override from the merged PR's labels, orchestrates
     /// the release PR, posts an audit comment if the floor was applied, and
     /// removes the consumed override labels.
-    #[allow(clippy::too_many_arguments)] // owner/repo/pr_num/correlation/orchestrator/current/calc/changelog/branch/sha is minimal
+    #[allow(clippy::too_many_arguments)] // owner/repo/installation_id/pr_num/correlation/orchestrator/current/calc/changelog/branch/sha is minimal
     async fn process_feature_pr_merged(
         &self,
         owner: &str,
         repo: &str,
+        installation_id: u64,
         merged_pr_number: u64,
         correlation_id: &str,
         orchestrator: &release_orchestrator::ReleaseOrchestrator<'_, G>,
@@ -996,10 +1006,12 @@ where
         };
         use versioning::BumpKind;
 
+        let scoped_github = self.github_operations.scoped_to(installation_id);
+
         // Read any rr:override-* label from the merged PR and apply it as a
         // minimum-bump floor before calling the orchestrator.
         let labels = if merged_pr_number > 0 {
-            self.github_operations
+            scoped_github
                 .list_pr_labels(owner, repo, merged_pr_number)
                 .await?
         } else {
@@ -1061,6 +1073,7 @@ where
                 self.post_bump_floor_audit_comment(
                     owner,
                     repo,
+                    installation_id,
                     merged_pr_number,
                     correlation_id,
                     &orch_result,
@@ -1077,8 +1090,7 @@ where
         // unconditionally to clean up any label applied by `!release` commands.
         if floor_kind.is_some() {
             for &label in ALL_OVERRIDE_LABELS {
-                if let Err(e) = self
-                    .github_operations
+                if let Err(e) = scoped_github
                     .remove_label(owner, repo, merged_pr_number, label)
                     .await
                 {
@@ -1097,11 +1109,12 @@ where
     }
 
     /// Post an audit comment on the release PR explaining a bump-floor override.
-    #[allow(clippy::too_many_arguments)] // audit context requires all 8 data points; no good grouping
+    #[allow(clippy::too_many_arguments)] // audit context requires all 9 data points; no good grouping
     async fn post_bump_floor_audit_comment(
         &self,
         owner: &str,
         repo: &str,
+        installation_id: u64,
         merged_pr_number: u64,
         correlation_id: &str,
         orch_result: &release_orchestrator::OrchestratorResult,
@@ -1131,8 +1144,8 @@ where
              `{calc_version}` but was raised to `{eff_version}` to satisfy the requested \
              minimum {kind_str} bump.",
         );
-        if let Err(e) = self
-            .github_operations
+        let scoped_github = self.github_operations.scoped_to(installation_id);
+        if let Err(e) = scoped_github
             .create_issue_comment(owner, repo, release_pr, &audit_body)
             .await
         {

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -309,7 +309,7 @@ where
             changelog_header: "## Changelog".to_string(),
         };
 
-        match ReleaseAutomator::new(config, &self.github_operations)
+        match ReleaseAutomator::new(config, &self.github_operations.scoped_to(event.installation_id))
             .automate(owner, repo, event, correlation_id)
             .await
         {
@@ -345,7 +345,7 @@ where
             allow_override: repo_config.versioning.allow_override,
         };
 
-        CommentCommandProcessor::new(config, &self.github_operations)
+        CommentCommandProcessor::new(config, &self.github_operations.scoped_to(event.installation_id))
             .process(event)
             .await
     }
@@ -743,8 +743,9 @@ where
             .and_then(serde_json::Value::as_u64)
             .unwrap_or(0);
 
+        let scoped_github = self.github_operations.scoped_to(event.installation_id);
         let orchestrator =
-            release_orchestrator::ReleaseOrchestrator::new(orch_config, &self.github_operations);
+            release_orchestrator::ReleaseOrchestrator::new(orch_config, &scoped_github);
 
         if is_release_pr {
             self.process_release_pr_merged(

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -208,6 +208,7 @@ pub mod comment_command_processor;
 pub mod config;
 pub(crate) mod default_version_calculator;
 pub mod errors;
+pub(crate) mod github_version_calculator;
 pub mod release_automator;
 pub mod release_orchestrator;
 pub mod traits;
@@ -215,6 +216,7 @@ pub mod versioning;
 
 pub use default_version_calculator::DefaultVersionCalculator;
 pub use errors::{CoreError, CoreResult};
+pub use github_version_calculator::GitHubVersionCalculator;
 pub use traits::{ConfigurationProvider, GitHubOperations, GitOperations, VersionCalculator};
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -843,10 +845,10 @@ where
             ..Default::default()
         };
 
-        let calc_result = self
-            .version_calculator
-            .calculate_version(ctx, strategy, options)
-            .await?;
+        // Scope the calculator to the resolved installation before calling it,
+        // keeping authentication concerns out of VersionContext.
+        let scoped_calc = self.version_calculator.scoped_to(installation_id);
+        let calc_result = scoped_calc.calculate_version(ctx, strategy, options).await?;
 
         let changelog = format_changelog_for_release(&calc_result.changelog_entries);
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -309,7 +309,9 @@ where
             changelog_header: "## Changelog".to_string(),
         };
 
-        match ReleaseAutomator::new(config, &self.github_operations.scoped_to(event.installation_id))
+        match ReleaseAutomator::new(config, &self.github_operations.scoped_to(
+            self.resolve_installation_id(owner, repo).await?,
+        ))
             .automate(owner, repo, event, correlation_id)
             .await
         {
@@ -345,7 +347,9 @@ where
             allow_override: repo_config.versioning.allow_override,
         };
 
-        CommentCommandProcessor::new(config, &self.github_operations.scoped_to(event.installation_id))
+        CommentCommandProcessor::new(config, &self.github_operations.scoped_to(
+            self.resolve_installation_id(owner, repo).await?,
+        ))
             .process(event)
             .await
     }
@@ -632,6 +636,20 @@ where
         &self.version_calculator
     }
 
+    /// Resolve a reliable installation ID for `owner/repo`.
+    ///
+    /// Calls the GitHub App API to look up the installation ID for the given
+    /// repository.
+    async fn resolve_installation_id(
+        &self,
+        owner: &str,
+        repo: &str,
+    ) -> CoreResult<u64> {
+        self.github_operations
+            .get_installation_id_for_repo(owner, repo)
+            .await
+    }
+
     /// Handle a merged pull request event by orchestrating the creation or
     /// update of a release PR.
     ///
@@ -704,13 +722,17 @@ where
             })?
             .to_string();
 
+        let installation_id = self
+            .resolve_installation_id(owner, repo)
+            .await?;
+
         let MergeCalcResult {
             calc_result,
             changelog,
             current_version,
             repo_config,
         } = self
-            .calculate_version_for_merge(owner, repo, &base_sha, &base_branch)
+            .calculate_version_for_merge(owner, repo, &base_sha, &base_branch, installation_id)
             .await?;
 
         // Build orchestrator config honouring the repository PR title template.
@@ -743,7 +765,7 @@ where
             .and_then(serde_json::Value::as_u64)
             .unwrap_or(0);
 
-        let scoped_github = self.github_operations.scoped_to(event.installation_id);
+        let scoped_github = self.github_operations.scoped_to(installation_id);
         let orchestrator =
             release_orchestrator::ReleaseOrchestrator::new(orch_config, &scoped_github);
 
@@ -783,6 +805,7 @@ where
         repo: &str,
         base_sha: &str,
         base_branch: &str,
+        installation_id: u64,
     ) -> CoreResult<MergeCalcResult> {
         use traits::configuration_provider::LoadOptions;
         use traits::version_calculator::{CalculationOptions, VersionContext, VersioningStrategy};
@@ -792,8 +815,9 @@ where
             .get_merged_config(owner, repo, LoadOptions::default())
             .await?;
 
+        let scoped_github = self.github_operations.scoped_to(installation_id);
         let current_version =
-            versioning::resolve_current_version(&self.github_operations, owner, repo, false)
+            versioning::resolve_current_version(&scoped_github, owner, repo, false)
                 .await?;
 
         let ctx = VersionContext {

--- a/crates/core/src/lib_tests.rs
+++ b/crates/core/src/lib_tests.rs
@@ -937,11 +937,7 @@ impl GitHubOperations for TestGitHubForLib {
             .unwrap_or_default())
     }
 
-    async fn get_installation_id_for_repo(
-        &self,
-        _owner: &str,
-        _repo: &str,
-    ) -> CoreResult<u64> {
+    async fn get_installation_id_for_repo(&self, _owner: &str, _repo: &str) -> CoreResult<u64> {
         Ok(0)
     }
 
@@ -1168,6 +1164,13 @@ impl VersionCalculator for TestVersionCalcForLib {
         _build: Option<String>,
     ) -> CoreResult<SemanticVersion> {
         Ok(current_version)
+    }
+
+    fn scoped_to(&self, _installation_id: u64) -> Arc<dyn VersionCalculator + Send + Sync> {
+        Arc::new(TestVersionCalcForLib {
+            next_version: self.next_version.clone(),
+            changelog_entries: self.changelog_entries.clone(),
+        })
     }
 }
 

--- a/crates/core/src/lib_tests.rs
+++ b/crates/core/src/lib_tests.rs
@@ -861,6 +861,16 @@ impl GitHubOperations for TestGitHubForLib {
         Ok(())
     }
 
+    async fn force_update_branch(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _branch_name: &str,
+        _sha: &str,
+    ) -> CoreResult<()> {
+        Ok(())
+    }
+
     async fn create_issue_comment(
         &self,
         _owner: &str,

--- a/crates/core/src/lib_tests.rs
+++ b/crates/core/src/lib_tests.rs
@@ -937,6 +937,14 @@ impl GitHubOperations for TestGitHubForLib {
             .unwrap_or_default())
     }
 
+    async fn get_installation_id_for_repo(
+        &self,
+        _owner: &str,
+        _repo: &str,
+    ) -> CoreResult<u64> {
+        Ok(0)
+    }
+
     fn scoped_to(&self, _installation_id: u64) -> Self {
         Self {
             tags: self.tags.clone(),

--- a/crates/core/src/lib_tests.rs
+++ b/crates/core/src/lib_tests.rs
@@ -161,6 +161,7 @@ fn make_test_event(id: &str, event_type: EventType) -> ProcessingEvent {
         payload: serde_json::json!({}),
         received_at: Utc::now(),
         source: EventSourceKind::Webhook,
+        installation_id: 0,
     }
 }
 
@@ -935,6 +936,23 @@ impl GitHubOperations for TestGitHubForLib {
             .cloned()
             .unwrap_or_default())
     }
+
+    fn scoped_to(&self, _installation_id: u64) -> Self {
+        Self {
+            tags: self.tags.clone(),
+            existing_prs: self.existing_prs.clone(),
+            search_results: self.search_results.clone(),
+            pr_labels: self.pr_labels.clone(),
+            created_prs: Arc::clone(&self.created_prs),
+            create_branch_calls: Arc::clone(&self.create_branch_calls),
+            removed_labels: Arc::clone(&self.removed_labels),
+            issue_comments: Arc::clone(&self.issue_comments),
+            fail_search_for_label: self.fail_search_for_label.clone(),
+            fail_remove_label_for_pr: self.fail_remove_label_for_pr,
+            fail_comment_for_pr: self.fail_comment_for_pr,
+            fail_list_labels_for_pr: self.fail_list_labels_for_pr,
+        }
+    }
 }
 
 // ── TestConfigForLib ────────────────────────────────────────────────────────
@@ -1173,6 +1191,7 @@ async fn test_handle_merged_pr_creates_release_pr_when_none_exists() {
         }),
         received_at: Utc::now(),
         source: EventSourceKind::Webhook,
+        installation_id: 0,
     };
 
     let result = processor.handle_merged_pull_request(&event).await.unwrap();
@@ -1220,6 +1239,7 @@ async fn test_handle_merged_pr_returns_invalid_input_when_sha_missing() {
         payload: serde_json::json!({ "pull_request": { "base": { "ref": "main" } } }),
         received_at: Utc::now(),
         source: EventSourceKind::Webhook,
+        installation_id: 0,
     };
 
     let err = processor
@@ -1259,6 +1279,7 @@ async fn test_handle_merged_pr_uses_default_branch_when_base_ref_absent() {
         }),
         received_at: Utc::now(),
         source: EventSourceKind::Webhook,
+        installation_id: 0,
     };
 
     let result = processor.handle_merged_pull_request(&event).await.unwrap();
@@ -1318,6 +1339,7 @@ async fn test_handle_merged_pr_includes_changelog_entries_in_pr_body() {
         }),
         received_at: Utc::now(),
         source: EventSourceKind::Webhook,
+        installation_id: 0,
     };
 
     processor.handle_merged_pull_request(&event).await.unwrap();
@@ -1399,6 +1421,7 @@ async fn test_handle_merged_feature_pr_with_override_major_label_applies_floor()
         }),
         received_at: Utc::now(),
         source: EventSourceKind::Webhook,
+        installation_id: 0,
     };
 
     let result = processor.handle_merged_pull_request(&event).await.unwrap();
@@ -1489,6 +1512,7 @@ async fn test_handle_merged_feature_pr_without_override_label_uses_calculated_ve
         }),
         received_at: Utc::now(),
         source: EventSourceKind::Webhook,
+        installation_id: 0,
     };
 
     let result = processor.handle_merged_pull_request(&event).await.unwrap();
@@ -1550,6 +1574,7 @@ async fn test_handle_merged_release_pr_clears_stale_override_labels_from_open_pr
         }),
         received_at: Utc::now(),
         source: EventSourceKind::Webhook,
+        installation_id: 0,
     };
 
     processor.handle_merged_pull_request(&event).await.unwrap();
@@ -1648,6 +1673,7 @@ async fn test_handle_merged_feature_pr_with_override_minor_label_applies_floor()
         }),
         received_at: Utc::now(),
         source: EventSourceKind::Webhook,
+        installation_id: 0,
     };
 
     let result = processor.handle_merged_pull_request(&event).await.unwrap();
@@ -1724,6 +1750,7 @@ async fn test_handle_merged_feature_pr_with_patch_floor_no_effect_when_calculate
         }),
         received_at: Utc::now(),
         source: EventSourceKind::Webhook,
+        installation_id: 0,
     };
 
     let result = processor.handle_merged_pull_request(&event).await.unwrap();
@@ -1796,6 +1823,7 @@ async fn test_handle_merged_release_pr_search_failure_for_one_label_continues() 
         }),
         received_at: Utc::now(),
         source: EventSourceKind::Webhook,
+        installation_id: 0,
     };
 
     // Event must succeed despite the partial search failure.
@@ -1853,6 +1881,7 @@ async fn test_handle_merged_release_pr_remove_label_failure_still_posts_cleanup_
         }),
         received_at: Utc::now(),
         source: EventSourceKind::Webhook,
+        installation_id: 0,
     };
 
     // Event must succeed despite remove_label failures.
@@ -1903,6 +1932,7 @@ async fn test_handle_merged_release_pr_cleanup_comment_failure_event_still_succe
         }),
         received_at: Utc::now(),
         source: EventSourceKind::Webhook,
+        installation_id: 0,
     };
 
     // Event must succeed despite comment posting failure.
@@ -1976,6 +2006,7 @@ async fn test_handle_merged_feature_pr_audit_comment_failure_returns_ok() {
         }),
         received_at: Utc::now(),
         source: EventSourceKind::Webhook,
+        installation_id: 0,
     };
 
     // The overall result must be Ok even though the audit comment failed.

--- a/crates/core/src/lib_tests.rs
+++ b/crates/core/src/lib_tests.rs
@@ -941,6 +941,18 @@ impl GitHubOperations for TestGitHubForLib {
         Ok(0)
     }
 
+    async fn upsert_file(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _path: &str,
+        _commit_message: &str,
+        _content: &str,
+        _branch: &str,
+    ) -> CoreResult<()> {
+        Ok(())
+    }
+
     fn scoped_to(&self, _installation_id: u64) -> Self {
         Self {
             tags: self.tags.clone(),

--- a/crates/core/src/release_automator_tests.rs
+++ b/crates/core/src/release_automator_tests.rs
@@ -427,6 +427,18 @@ impl GitHubOperations for TestGitHub {
         Ok(0)
     }
 
+    async fn upsert_file(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _path: &str,
+        _commit_message: &str,
+        _content: &str,
+        _branch: &str,
+    ) -> CoreResult<()> {
+        Ok(())
+    }
+
     fn scoped_to(&self, _installation_id: u64) -> Self {
         Self {
             state: Arc::clone(&self.state),

--- a/crates/core/src/release_automator_tests.rs
+++ b/crates/core/src/release_automator_tests.rs
@@ -293,6 +293,16 @@ impl GitHubOperations for TestGitHub {
         Ok(())
     }
 
+    async fn force_update_branch(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _branch_name: &str,
+        _sha: &str,
+    ) -> CoreResult<()> {
+        Ok(())
+    }
+
     async fn get_collaborator_permission(
         &self,
         _owner: &str,

--- a/crates/core/src/release_automator_tests.rs
+++ b/crates/core/src/release_automator_tests.rs
@@ -422,6 +422,12 @@ impl GitHubOperations for TestGitHub {
     ) -> CoreResult<Release> {
         Err(CoreError::not_supported("update_release", "stub"))
     }
+
+    fn scoped_to(&self, _installation_id: u64) -> Self {
+        Self {
+            state: Arc::clone(&self.state),
+        }
+    }
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -496,6 +502,7 @@ fn make_release_pr_event(branch: &str, merge_sha: &str, body: &str) -> Processin
         payload,
         received_at: Utc::now(),
         source: EventSourceKind::Webhook,
+        installation_id: 0,
     }
 }
 
@@ -577,6 +584,7 @@ fn make_release_pr_event_with_title(
         payload,
         received_at: Utc::now(),
         source: EventSourceKind::Webhook,
+        installation_id: 0,
     }
 }
 
@@ -981,6 +989,7 @@ async fn test_automate_missing_head_ref_returns_invalid_input() {
         payload: serde_json::json!({ "pull_request": { "number": 1 } }),
         received_at: Utc::now(),
         source: EventSourceKind::Webhook,
+        installation_id: 0,
     };
 
     let err = automator
@@ -1015,6 +1024,7 @@ async fn test_automate_missing_merge_sha_returns_invalid_input() {
         }),
         received_at: Utc::now(),
         source: EventSourceKind::Webhook,
+        installation_id: 0,
     };
 
     let err = automator
@@ -1109,6 +1119,7 @@ async fn test_automate_fallback_sha_used_when_merge_commit_sha_absent() {
         }),
         received_at: Utc::now(),
         source: EventSourceKind::Webhook,
+        installation_id: 0,
     };
 
     automator

--- a/crates/core/src/release_automator_tests.rs
+++ b/crates/core/src/release_automator_tests.rs
@@ -423,6 +423,10 @@ impl GitHubOperations for TestGitHub {
         Err(CoreError::not_supported("update_release", "stub"))
     }
 
+    async fn get_installation_id_for_repo(&self, _owner: &str, _repo: &str) -> CoreResult<u64> {
+        Ok(0)
+    }
+
     fn scoped_to(&self, _installation_id: u64) -> Self {
         Self {
             state: Arc::clone(&self.state),

--- a/crates/core/src/release_orchestrator.rs
+++ b/crates/core/src/release_orchestrator.rs
@@ -215,7 +215,7 @@ impl<'a, G: GitHubOperations> ReleaseOrchestrator<'a, G> {
                             "Existing PR has same version; merging changelogs"
                         );
                         let pr = self
-                            .update_release_pr(owner, repo, &existing_pr, version, changelog)
+                            .update_release_pr(owner, repo, &existing_pr, version, changelog, base_sha)
                             .await?;
                         Ok(OrchestratorResult::Updated { pr })
                     }
@@ -315,11 +315,16 @@ impl<'a, G: GitHubOperations> ReleaseOrchestrator<'a, G> {
             Ok(()) => branch_name,
             Err(CoreError::Conflict { .. }) => {
                 // The branch already exists — most likely from a previous run that
-                // created the branch but failed before opening the PR. Reuse it.
+                // created the branch but failed before opening the PR. Reuse it,
+                // but force-reset it to the current base SHA so the PR diff stays
+                // clean (exactly one commit ahead of the base branch).
                 info!(
                     branch = %branch_name,
                     "Release branch already exists; reusing it"
                 );
+                self.github
+                    .force_update_branch(owner, repo, &branch_name, base_sha)
+                    .await?;
                 branch_name
             }
             Err(other) => return Err(other),
@@ -376,6 +381,7 @@ impl<'a, G: GitHubOperations> ReleaseOrchestrator<'a, G> {
         existing_pr: &PullRequest,
         version: &SemanticVersion,
         new_changelog: &str,
+        base_sha: &str,
     ) -> CoreResult<PullRequest> {
         // Always re-fetch to get the latest body (ETag prep).
         let fresh_pr = self
@@ -406,6 +412,12 @@ impl<'a, G: GitHubOperations> ReleaseOrchestrator<'a, G> {
                 Some(new_body),
                 None,
             )
+            .await?;
+
+        // Force-reset the release branch to the latest base SHA so the PR always
+        // shows exactly one commit (the CHANGELOG.md update) on top of main.
+        self.github
+            .force_update_branch(owner, repo, &fresh_pr.head.ref_name, base_sha)
             .await?;
 
         // Keep CHANGELOG.md on the release branch in sync with the PR body.

--- a/crates/core/src/release_orchestrator.rs
+++ b/crates/core/src/release_orchestrator.rs
@@ -329,8 +329,10 @@ impl<'a, G: GitHubOperations> ReleaseOrchestrator<'a, G> {
         let body = self.render_body(changelog);
 
         // Commit CHANGELOG.md to the release branch so the PR has a real diff.
-        let changelog_commit_message =
-            format!("chore(release): update CHANGELOG for {}", version.to_string_with_prefix(true));
+        let changelog_commit_message = format!(
+            "chore(release): update CHANGELOG for {}",
+            version.to_string_with_prefix(true)
+        );
         self.github
             .upsert_file(
                 owner,
@@ -508,11 +510,18 @@ impl<'a, G: GitHubOperations> ReleaseOrchestrator<'a, G> {
     // ── Template / body helpers ────────────────────────────────────────────
 
     /// Render the PR title from the configured template.
+    ///
+    /// Supports both `${variable}` (config-file style) and `{variable}` (internal style)
+    /// for `version` (e.g. `"0.2.0"`) and `version_tag` (e.g. `"v0.2.0"`).
     fn render_title(&self, version: &SemanticVersion) -> String {
+        let version_str = version.to_string();
+        let version_tag_str = version.to_string_with_prefix(true);
         self.config
             .title_template
-            .replace("{version}", &version.to_string())
-            .replace("{version_tag}", &version.to_string_with_prefix(true))
+            .replace("${version_tag}", &version_tag_str)
+            .replace("${version}", &version_str)
+            .replace("{version_tag}", &version_tag_str)
+            .replace("{version}", &version_str)
     }
 
     /// Wrap the changelog body in the standard PR body format.

--- a/crates/core/src/release_orchestrator.rs
+++ b/crates/core/src/release_orchestrator.rs
@@ -331,6 +331,20 @@ impl<'a, G: GitHubOperations> ReleaseOrchestrator<'a, G> {
         let title = self.render_title(version);
         let body = self.render_body(changelog);
 
+        // Commit CHANGELOG.md to the release branch so the PR has a real diff.
+        let changelog_commit_message =
+            format!("chore(release): update CHANGELOG for {}", version.to_string_with_prefix(true));
+        self.github
+            .upsert_file(
+                owner,
+                repo,
+                "CHANGELOG.md",
+                &changelog_commit_message,
+                changelog,
+                &actual_branch,
+            )
+            .await?;
+
         let pr = self
             .github
             .create_pull_request(
@@ -392,6 +406,22 @@ impl<'a, G: GitHubOperations> ReleaseOrchestrator<'a, G> {
                 title_update,
                 Some(new_body),
                 None,
+            )
+            .await?;
+
+        // Keep CHANGELOG.md on the release branch in sync with the PR body.
+        let changelog_commit_message = format!(
+            "chore(release): update CHANGELOG for {}",
+            version.to_string_with_prefix(true)
+        );
+        self.github
+            .upsert_file(
+                owner,
+                repo,
+                "CHANGELOG.md",
+                &changelog_commit_message,
+                &merged_changelog,
+                &fresh_pr.head.ref_name,
             )
             .await?;
 

--- a/crates/core/src/release_orchestrator.rs
+++ b/crates/core/src/release_orchestrator.rs
@@ -19,8 +19,9 @@
 //! | Yes            | Higher than new         | No-op (never downgrade)   |
 //!
 //! 3. **Idempotency**: Every sub-operation is safe to retry without side effects.
-//!    If a branch already exists the timestamped fallback is used instead of
-//!    failing.
+//!    If the canonical release branch already exists (e.g. from a previous run that
+//!    created the branch but failed before opening the PR), the orchestrator reuses
+//!    it rather than failing.
 //!
 //! ## `ETag` / concurrency note
 //!
@@ -50,7 +51,6 @@ use crate::{
     versioning::SemanticVersion,
     CoreError, CoreResult,
 };
-use std::time::{SystemTime, UNIX_EPOCH};
 use tracing::{debug, info, warn};
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -314,16 +314,13 @@ impl<'a, G: GitHubOperations> ReleaseOrchestrator<'a, G> {
         {
             Ok(()) => branch_name,
             Err(CoreError::Conflict { .. }) => {
-                let fallback = self.make_fallback_branch_name(version);
-                warn!(
-                    original = %branch_name,
-                    fallback = %fallback,
-                    "Branch conflict; retrying with timestamped fallback"
+                // The branch already exists — most likely from a previous run that
+                // created the branch but failed before opening the PR. Reuse it.
+                info!(
+                    branch = %branch_name,
+                    "Release branch already exists; reusing it"
                 );
-                self.github
-                    .create_branch(owner, repo, &fallback, base_sha)
-                    .await?;
-                fallback
+                branch_name
             }
             Err(other) => return Err(other),
         };
@@ -503,20 +500,6 @@ impl<'a, G: GitHubOperations> ReleaseOrchestrator<'a, G> {
     pub(crate) fn make_branch_name(&self, version: &SemanticVersion) -> String {
         format!(
             "{}/{}",
-            self.config.branch_prefix,
-            version.to_string_with_prefix(true)
-        )
-    }
-
-    /// Construct a timestamped fallback branch name used when the canonical
-    /// branch already exists, e.g. `"release/v1.2.3-1711234567"`.
-    pub(crate) fn make_fallback_branch_name(&self, version: &SemanticVersion) -> String {
-        let ts = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .map(|d| d.as_secs())
-            .unwrap_or(0);
-        format!(
-            "{}/{}-{ts}",
             self.config.branch_prefix,
             version.to_string_with_prefix(true)
         )

--- a/crates/core/src/release_orchestrator.rs
+++ b/crates/core/src/release_orchestrator.rs
@@ -215,7 +215,14 @@ impl<'a, G: GitHubOperations> ReleaseOrchestrator<'a, G> {
                             "Existing PR has same version; merging changelogs"
                         );
                         let pr = self
-                            .update_release_pr(owner, repo, &existing_pr, version, changelog, base_sha)
+                            .update_release_pr(
+                                owner,
+                                repo,
+                                &existing_pr,
+                                version,
+                                changelog,
+                                base_sha,
+                            )
                             .await?;
                         Ok(OrchestratorResult::Updated { pr })
                     }

--- a/crates/core/src/release_orchestrator_tests.rs
+++ b/crates/core/src/release_orchestrator_tests.rs
@@ -399,6 +399,12 @@ impl GitHubOperations for TestGitHub {
     ) -> CoreResult<Vec<crate::traits::github_operations::Label>> {
         Ok(vec![])
     }
+
+    fn scoped_to(&self, _installation_id: u64) -> Self {
+        Self {
+            state: Arc::clone(&self.state),
+        }
+    }
 }
 // ─────────────────────────────────────────────────────────────────────────────
 

--- a/crates/core/src/release_orchestrator_tests.rs
+++ b/crates/core/src/release_orchestrator_tests.rs
@@ -41,6 +41,8 @@ struct TestState {
     updated_prs: Vec<(u64, Option<String>, Option<String>, Option<String>)>,
     /// Recorded `delete_branch` calls: branch name.
     deleted_branches: Vec<String>,
+    /// Recorded `force_update_branch` calls: (branch_name, sha).
+    force_updated_branches: Vec<(String, String)>,
     /// Recorded `upsert_file` calls: (path, branch).
     upserted_files: Vec<(String, String)>,
     /// Sequential PR number to return from `create_pull_request`.
@@ -100,6 +102,10 @@ impl TestGitHub {
 
     async fn deleted_branches(&self) -> Vec<String> {
         self.state.lock().await.deleted_branches.clone()
+    }
+
+    async fn force_updated_branches(&self) -> Vec<(String, String)> {
+        self.state.lock().await.force_updated_branches.clone()
     }
 
     async fn upserted_files(&self) -> Vec<(String, String)> {
@@ -358,6 +364,21 @@ impl GitHubOperations for TestGitHub {
         Ok(())
     }
 
+    async fn force_update_branch(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        branch_name: &str,
+        sha: &str,
+    ) -> CoreResult<()> {
+        self.state
+            .lock()
+            .await
+            .force_updated_branches
+            .push((branch_name.to_string(), sha.to_string()));
+        Ok(())
+    }
+
     async fn create_issue_comment(
         &self,
         _owner: &str,
@@ -613,6 +634,12 @@ async fn test_orchestrate_existing_equal_version_pr_updates_changelog() {
     );
     assert_eq!(upserted[0].0, "CHANGELOG.md");
     assert_eq!(upserted[0].1, "release/v1.0.0");
+
+    // The release branch should be force-reset to the latest base SHA before the commit.
+    let force_updated = github.force_updated_branches().await;
+    assert_eq!(force_updated.len(), 1, "branch should be force-reset once");
+    assert_eq!(force_updated[0].0, "release/v1.0.0");
+    assert_eq!(force_updated[0].1, "sha002");
 }
 
 /// Existing PR has a lower version → rename (Renamed).
@@ -768,6 +795,16 @@ async fn test_orchestrate_branch_already_exists_reuses_it() {
     );
     assert_eq!(upserted[0].0, "CHANGELOG.md");
     assert_eq!(upserted[0].1, "release/v1.0.0");
+
+    // The existing branch should be force-reset to the current base SHA before the commit.
+    let force_updated = github.force_updated_branches().await;
+    assert_eq!(
+        force_updated.len(),
+        1,
+        "existing branch should be force-reset to base SHA"
+    );
+    assert_eq!(force_updated[0].0, "release/v1.0.0");
+    assert_eq!(force_updated[0].1, "sha005");
 }
 
 /// `search_pull_requests` returns an error → propagated to caller.

--- a/crates/core/src/release_orchestrator_tests.rs
+++ b/crates/core/src/release_orchestrator_tests.rs
@@ -41,6 +41,8 @@ struct TestState {
     updated_prs: Vec<(u64, Option<String>, Option<String>, Option<String>)>,
     /// Recorded `delete_branch` calls: branch name.
     deleted_branches: Vec<String>,
+    /// Recorded `upsert_file` calls: (path, branch).
+    upserted_files: Vec<(String, String)>,
     /// Sequential PR number to return from `create_pull_request`.
     next_pr_number: u64,
     /// Whether `search_pull_requests` should return an error.
@@ -98,6 +100,10 @@ impl TestGitHub {
 
     async fn deleted_branches(&self) -> Vec<String> {
         self.state.lock().await.deleted_branches.clone()
+    }
+
+    async fn upserted_files(&self) -> Vec<(String, String)> {
+        self.state.lock().await.upserted_files.clone()
     }
 }
 
@@ -408,6 +414,23 @@ impl GitHubOperations for TestGitHub {
         Ok(0)
     }
 
+    async fn upsert_file(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        path: &str,
+        _commit_message: &str,
+        _content: &str,
+        branch: &str,
+    ) -> CoreResult<()> {
+        self.state
+            .lock()
+            .await
+            .upserted_files
+            .push((path.to_string(), branch.to_string()));
+        Ok(())
+    }
+
     fn scoped_to(&self, _installation_id: u64) -> Self {
         Self {
             state: Arc::clone(&self.state),
@@ -531,6 +554,11 @@ async fn test_orchestrate_no_existing_pr_creates_branch_and_pr() {
         .as_deref()
         .unwrap_or("")
         .contains("## Changelog"));
+
+    let upserted = github.upserted_files().await;
+    assert_eq!(upserted.len(), 1, "CHANGELOG.md should be committed to the release branch");
+    assert_eq!(upserted[0].0, "CHANGELOG.md");
+    assert_eq!(upserted[0].1, "release/v1.2.3");
 }
 
 /// Existing PR has the same version → changelog is merged (Updated).
@@ -575,6 +603,12 @@ async fn test_orchestrate_existing_equal_version_pr_updates_changelog() {
     let body = updates[0].2.as_deref().unwrap_or("");
     assert!(body.contains("old fix"), "should keep existing entry");
     assert!(body.contains("new feature"), "should add new entry");
+
+    // CHANGELOG.md should be committed to the existing branch.
+    let upserted = github.upserted_files().await;
+    assert_eq!(upserted.len(), 1, "CHANGELOG.md should be updated on the existing branch");
+    assert_eq!(upserted[0].0, "CHANGELOG.md");
+    assert_eq!(upserted[0].1, "release/v1.0.0");
 }
 
 /// Existing PR has a lower version → rename (Renamed).
@@ -628,6 +662,12 @@ async fn test_orchestrate_existing_lower_version_pr_renames() {
         deleted.contains(&"release/v1.0.0".to_string()),
         "old branch not deleted; {deleted:?}"
     );
+
+    // CHANGELOG.md should be committed to the new release branch.
+    let upserted = github.upserted_files().await;
+    assert_eq!(upserted.len(), 1, "CHANGELOG.md should be committed to the new release branch");
+    assert_eq!(upserted[0].0, "CHANGELOG.md");
+    assert_eq!(upserted[0].1, "release/v1.1.0");
 }
 
 /// Existing PR has a *higher* version → NoOp (never downgrade).
@@ -664,6 +704,7 @@ async fn test_orchestrate_existing_higher_version_pr_is_no_op() {
     assert!(github.created_prs().await.is_empty());
     assert!(github.updated_prs().await.is_empty());
     assert!(github.deleted_branches().await.is_empty());
+    assert!(github.upserted_files().await.is_empty(), "NoOp should not commit any files");
 }
 
 /// Branch name conflict on first attempt → retries with timestamped fallback.
@@ -705,6 +746,12 @@ async fn test_orchestrate_branch_conflict_uses_timestamped_fallback() {
         "expected timestamped branch, got {:?}",
         branches[0].0
     );
+
+    // CHANGELOG.md should be committed to the fallback branch.
+    let upserted = github.upserted_files().await;
+    assert_eq!(upserted.len(), 1, "CHANGELOG.md should be committed to the fallback branch");
+    assert_eq!(upserted[0].0, "CHANGELOG.md");
+    assert!(upserted[0].1.starts_with("release/v1.0.0-"), "expected fallback branch, got {:?}", upserted[0].1);
 }
 
 /// `search_pull_requests` returns an error → propagated to caller.
@@ -768,6 +815,12 @@ async fn test_orchestrate_changelog_merge_deduplicates_commits() {
         count, 1,
         "duplicate SHA should be deduplicated; body:\n{body}"
     );
+
+    // CHANGELOG.md should be committed to the existing branch.
+    let upserted = github.upserted_files().await;
+    assert_eq!(upserted.len(), 1, "CHANGELOG.md should be updated on the existing branch");
+    assert_eq!(upserted[0].0, "CHANGELOG.md");
+    assert_eq!(upserted[0].1, "release/v1.0.0");
 }
 
 /// Branch name helper: `make_branch_name` formats as `"release/v{major}.{minor}.{patch}"`.

--- a/crates/core/src/release_orchestrator_tests.rs
+++ b/crates/core/src/release_orchestrator_tests.rs
@@ -888,6 +888,70 @@ async fn test_custom_branch_prefix_is_used() {
     }
 }
 
+/// Config-file style `${version}` placeholder in title template is substituted correctly.
+#[tokio::test]
+async fn test_title_template_dollar_brace_syntax_is_substituted() {
+    let config = OrchestratorConfig {
+        title_template: "chore(release): ${version}".to_string(),
+        ..OrchestratorConfig::default()
+    };
+    let github = TestGitHub::new();
+    let orchestrator = ReleaseOrchestrator::new(config, &github);
+
+    let result = orchestrator
+        .orchestrate(
+            "testorg",
+            "testrepo",
+            &ver(1, 2, 3),
+            "- feat: something [ab12cd34ef5678901234abcdef12345678901234]",
+            "main",
+            "sha009",
+            "corr-009",
+        )
+        .await
+        .expect("orchestrate should succeed");
+
+    if let OrchestratorResult::Created { .. } = result {
+        let prs = github.created_prs().await;
+        assert_eq!(prs.len(), 1);
+        assert_eq!(prs[0].title, "chore(release): 1.2.3");
+    } else {
+        panic!("expected Created, got {result:?}");
+    }
+}
+
+/// Config-file style `${version_tag}` placeholder in title template is substituted correctly.
+#[tokio::test]
+async fn test_title_template_dollar_brace_version_tag_syntax_is_substituted() {
+    let config = OrchestratorConfig {
+        title_template: "chore(release): ${version_tag}".to_string(),
+        ..OrchestratorConfig::default()
+    };
+    let github = TestGitHub::new();
+    let orchestrator = ReleaseOrchestrator::new(config, &github);
+
+    let result = orchestrator
+        .orchestrate(
+            "testorg",
+            "testrepo",
+            &ver(1, 2, 3),
+            "- feat: something [ab12cd34ef5678901234abcdef12345678901234]",
+            "main",
+            "sha010",
+            "corr-010",
+        )
+        .await
+        .expect("orchestrate should succeed");
+
+    if let OrchestratorResult::Created { .. } = result {
+        let prs = github.created_prs().await;
+        assert_eq!(prs.len(), 1);
+        assert_eq!(prs[0].title, "chore(release): v1.2.3");
+    } else {
+        panic!("expected Created, got {result:?}");
+    }
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Unit tests for internal helpers
 // ─────────────────────────────────────────────────────────────────────────────

--- a/crates/core/src/release_orchestrator_tests.rs
+++ b/crates/core/src/release_orchestrator_tests.rs
@@ -406,11 +406,7 @@ impl GitHubOperations for TestGitHub {
         Ok(vec![])
     }
 
-    async fn get_installation_id_for_repo(
-        &self,
-        _owner: &str,
-        _repo: &str,
-    ) -> CoreResult<u64> {
+    async fn get_installation_id_for_repo(&self, _owner: &str, _repo: &str) -> CoreResult<u64> {
         Ok(0)
     }
 
@@ -556,7 +552,11 @@ async fn test_orchestrate_no_existing_pr_creates_branch_and_pr() {
         .contains("## Changelog"));
 
     let upserted = github.upserted_files().await;
-    assert_eq!(upserted.len(), 1, "CHANGELOG.md should be committed to the release branch");
+    assert_eq!(
+        upserted.len(),
+        1,
+        "CHANGELOG.md should be committed to the release branch"
+    );
     assert_eq!(upserted[0].0, "CHANGELOG.md");
     assert_eq!(upserted[0].1, "release/v1.2.3");
 }
@@ -606,7 +606,11 @@ async fn test_orchestrate_existing_equal_version_pr_updates_changelog() {
 
     // CHANGELOG.md should be committed to the existing branch.
     let upserted = github.upserted_files().await;
-    assert_eq!(upserted.len(), 1, "CHANGELOG.md should be updated on the existing branch");
+    assert_eq!(
+        upserted.len(),
+        1,
+        "CHANGELOG.md should be updated on the existing branch"
+    );
     assert_eq!(upserted[0].0, "CHANGELOG.md");
     assert_eq!(upserted[0].1, "release/v1.0.0");
 }
@@ -665,7 +669,11 @@ async fn test_orchestrate_existing_lower_version_pr_renames() {
 
     // CHANGELOG.md should be committed to the new release branch.
     let upserted = github.upserted_files().await;
-    assert_eq!(upserted.len(), 1, "CHANGELOG.md should be committed to the new release branch");
+    assert_eq!(
+        upserted.len(),
+        1,
+        "CHANGELOG.md should be committed to the new release branch"
+    );
     assert_eq!(upserted[0].0, "CHANGELOG.md");
     assert_eq!(upserted[0].1, "release/v1.1.0");
 }
@@ -704,12 +712,15 @@ async fn test_orchestrate_existing_higher_version_pr_is_no_op() {
     assert!(github.created_prs().await.is_empty());
     assert!(github.updated_prs().await.is_empty());
     assert!(github.deleted_branches().await.is_empty());
-    assert!(github.upserted_files().await.is_empty(), "NoOp should not commit any files");
+    assert!(
+        github.upserted_files().await.is_empty(),
+        "NoOp should not commit any files"
+    );
 }
 
-/// Branch name conflict on first attempt → retries with timestamped fallback.
+/// Branch already exists (conflict from create_branch) → orchestrator reuses it.
 #[tokio::test]
-async fn test_orchestrate_branch_conflict_uses_timestamped_fallback() {
+async fn test_orchestrate_branch_already_exists_reuses_it() {
     let github = TestGitHub::new().with_next_create_branch_conflict().await;
 
     let orchestrator = ReleaseOrchestrator::new(default_config(), &github);
@@ -725,33 +736,38 @@ async fn test_orchestrate_branch_conflict_uses_timestamped_fallback() {
             "corr-005",
         )
         .await
-        .expect("orchestrate should succeed despite first branch conflict");
+        .expect("orchestrate should succeed when branch already exists");
 
-    // The result should still be Created.
+    // The result should still be Created, using the canonical branch name.
     if let OrchestratorResult::Created { branch_name, .. } = &result {
-        // The fallback branch should start with "release/v1.0.0-" (plus timestamp).
-        assert!(
-            branch_name.starts_with("release/v1.0.0-"),
-            "fallback branch name unexpected: {branch_name}"
+        assert_eq!(
+            branch_name, "release/v1.0.0",
+            "should reuse canonical branch, got {branch_name}"
         );
     } else {
         panic!("expected Created, got {result:?}");
     }
 
-    // Two branch creation attempts should have been recorded.
-    let branches = github.created_branches().await;
-    assert_eq!(branches.len(), 1, "only the successful attempt is tracked");
+    // No new branch was successfully created (the conflict was on the only attempt).
     assert!(
-        branches[0].0.starts_with("release/v1.0.0-"),
-        "expected timestamped branch, got {:?}",
-        branches[0].0
+        github.created_branches().await.is_empty(),
+        "no successful branch creation expected when reusing existing"
     );
 
-    // CHANGELOG.md should be committed to the fallback branch.
+    // A PR should have been opened on the canonical branch.
+    let prs = github.created_prs().await;
+    assert_eq!(prs.len(), 1);
+    assert_eq!(prs[0].head, "release/v1.0.0");
+
+    // CHANGELOG.md should be committed to the canonical branch.
     let upserted = github.upserted_files().await;
-    assert_eq!(upserted.len(), 1, "CHANGELOG.md should be committed to the fallback branch");
+    assert_eq!(
+        upserted.len(),
+        1,
+        "CHANGELOG.md should be committed to the existing branch"
+    );
     assert_eq!(upserted[0].0, "CHANGELOG.md");
-    assert!(upserted[0].1.starts_with("release/v1.0.0-"), "expected fallback branch, got {:?}", upserted[0].1);
+    assert_eq!(upserted[0].1, "release/v1.0.0");
 }
 
 /// `search_pull_requests` returns an error → propagated to caller.
@@ -818,7 +834,11 @@ async fn test_orchestrate_changelog_merge_deduplicates_commits() {
 
     // CHANGELOG.md should be committed to the existing branch.
     let upserted = github.upserted_files().await;
-    assert_eq!(upserted.len(), 1, "CHANGELOG.md should be updated on the existing branch");
+    assert_eq!(
+        upserted.len(),
+        1,
+        "CHANGELOG.md should be updated on the existing branch"
+    );
     assert_eq!(upserted[0].0, "CHANGELOG.md");
     assert_eq!(upserted[0].1, "release/v1.0.0");
 }
@@ -835,23 +855,6 @@ fn test_make_branch_name_format() {
     assert_eq!(
         orchestrator.make_branch_name(&ver(0, 1, 0)),
         "release/v0.1.0"
-    );
-}
-
-/// Fallback branch name starts with the canonical name and has a numeric suffix.
-#[test]
-fn test_make_fallback_branch_name_contains_timestamp() {
-    let github = TestGitHub::new();
-    let orchestrator = ReleaseOrchestrator::new(default_config(), &github);
-    let fallback = orchestrator.make_fallback_branch_name(&ver(1, 0, 0));
-    assert!(
-        fallback.starts_with("release/v1.0.0-"),
-        "fallback should start with canonical prefix: {fallback}"
-    );
-    let suffix = fallback.trim_start_matches("release/v1.0.0-");
-    assert!(
-        suffix.chars().all(|c| c.is_ascii_digit()),
-        "suffix should be numeric timestamp: {suffix}"
     );
 }
 

--- a/crates/core/src/release_orchestrator_tests.rs
+++ b/crates/core/src/release_orchestrator_tests.rs
@@ -400,6 +400,14 @@ impl GitHubOperations for TestGitHub {
         Ok(vec![])
     }
 
+    async fn get_installation_id_for_repo(
+        &self,
+        _owner: &str,
+        _repo: &str,
+    ) -> CoreResult<u64> {
+        Ok(0)
+    }
+
     fn scoped_to(&self, _installation_id: u64) -> Self {
         Self {
             state: Arc::clone(&self.state),

--- a/crates/core/src/traits/event_source.rs
+++ b/crates/core/src/traits/event_source.rs
@@ -253,6 +253,20 @@ pub struct ProcessingEvent {
 
     /// Delivery mechanism that produced this event.
     pub source: EventSourceKind,
+
+    /// GitHub App installation ID extracted from the webhook payload field
+    /// `installation.id`.
+    ///
+    /// Every webhook sent by a GitHub App includes the installation ID of the
+    /// specific account or organisation where the app is installed. Using this
+    /// value — rather than a static environment variable — means the server can
+    /// serve webhooks from any installation of the same GitHub App without
+    /// reconfiguration.
+    ///
+    /// Set to `0` for events that do not originate from a GitHub App webhook
+    /// (e.g. events injected by tests or produced by queue-based sources that
+    /// do not carry installation context).
+    pub installation_id: u64,
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/crates/core/src/traits/event_source_tests.rs
+++ b/crates/core/src/traits/event_source_tests.rs
@@ -16,6 +16,7 @@ fn make_processing_event(source: EventSourceKind) -> ProcessingEvent {
         payload: serde_json::json!({ "action": "closed", "merged": true }),
         received_at: Utc.with_ymd_and_hms(2026, 3, 8, 12, 0, 0).unwrap(),
         source,
+        installation_id: 0,
     }
 }
 

--- a/crates/core/src/traits/github_operations.rs
+++ b/crates/core/src/traits/github_operations.rs
@@ -477,6 +477,19 @@ pub trait GitHubOperations: GitOperations + Send + Sync {
         release_id: u64,
         params: UpdateReleaseParams,
     ) -> CoreResult<Release>;
+
+    /// Return a clone of this client scoped to the given GitHub App installation.
+    ///
+    /// All subsequent API calls on the returned client will use an installation
+    /// access token obtained for `installation_id` rather than the token used
+    /// by `self`.  This allows a single top-level client to serve webhooks from
+    /// any installation of the GitHub App without re-initialisation.
+    ///
+    /// Implementations must not make any network calls in this method — the
+    /// installation token is obtained lazily on the first API call.
+    fn scoped_to(&self, installation_id: u64) -> Self
+    where
+        Self: Sized;
 }
 
 // Note: Git commit information is now provided by GitOperations trait

--- a/crates/core/src/traits/github_operations.rs
+++ b/crates/core/src/traits/github_operations.rs
@@ -356,6 +356,12 @@ pub trait GitHubOperations: GitOperations + Send + Sync {
     /// - `per_page`: Number of PRs per page, max 100 (optional)
     /// - `page`: Page number, 1-based (optional)
     ///
+    /// # Note on pagination
+    ///
+    /// Implementations may ignore `per_page` and `page` and instead return a
+    /// complete, fully-paginated result set in a single call.  Callers should
+    /// not rely on these parameters to page through results themselves.
+    ///
     /// # Returns
     /// List of pull requests matching the filters
     ///
@@ -434,8 +440,14 @@ pub trait GitHubOperations: GitOperations + Send + Sync {
     /// Supports a subset of GitHub search qualifiers:
     /// - `is:open` / `is:closed` / `is:merged` — filter by state
     /// - `head:BRANCH` or `head:PREFIX*` — filter by head branch (glob prefix with `*`)
-    /// - `base:BRANCH` — filter by exact base branch name
-    /// - `label:NAME` — filter by label name (exact match)
+    ///
+    /// # Note on supported qualifiers
+    ///
+    /// The `label:NAME` qualifier documented here is **not yet implemented** in
+    /// the current `GitHubClient` implementation.  Passing `label:NAME` in the
+    /// query will silently return results without filtering by label.  Track the
+    /// implementation gap and add label-based client-side filtering before
+    /// relying on this qualifier in production callers.
     ///
     /// # Parameters
     /// - `owner`: Repository owner name
@@ -516,11 +528,7 @@ pub trait GitHubOperations: GitOperations + Send + Sync {
     ///
     /// Returns [`CoreError::GitHub`] if the API call fails or if the App is not
     /// installed on the repository.
-    async fn get_installation_id_for_repo(
-        &self,
-        owner: &str,
-        repo: &str,
-    ) -> CoreResult<u64>;
+    async fn get_installation_id_for_repo(&self, owner: &str, repo: &str) -> CoreResult<u64>;
 
     /// Create or update a file at the given path on a branch.
     ///

--- a/crates/core/src/traits/github_operations.rs
+++ b/crates/core/src/traits/github_operations.rs
@@ -478,6 +478,24 @@ pub trait GitHubOperations: GitOperations + Send + Sync {
         params: UpdateReleaseParams,
     ) -> CoreResult<Release>;
 
+    /// Look up the GitHub App installation ID for a specific repository.
+    ///
+    /// Calls `GET /repos/{owner}/{repo}/installation` using app-level JWT
+    /// authentication and returns the numeric installation ID.
+    ///
+    /// Use this when no installation ID is available in the incoming event
+    /// (e.g. queue-sourced events that do not carry the `installation` field).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CoreError::GitHub`] if the API call fails or if the App is not
+    /// installed on the repository.
+    async fn get_installation_id_for_repo(
+        &self,
+        owner: &str,
+        repo: &str,
+    ) -> CoreResult<u64>;
+
     /// Return a clone of this client scoped to the given GitHub App installation.
     ///
     /// All subsequent API calls on the returned client will use an installation

--- a/crates/core/src/traits/github_operations.rs
+++ b/crates/core/src/traits/github_operations.rs
@@ -496,6 +496,52 @@ pub trait GitHubOperations: GitOperations + Send + Sync {
         repo: &str,
     ) -> CoreResult<u64>;
 
+    /// Create or update a file at the given path on a branch.
+    ///
+    /// Uses the GitHub Contents API (`PUT /repos/{owner}/{repo}/contents/{path}`)
+    /// to commit the file content directly onto the specified branch. If the
+    /// file already exists, the current blob SHA is fetched automatically so
+    /// the update can succeed without the caller needing to track the previous
+    /// content.
+    ///
+    /// The `content` string is plain UTF-8 text; base64 encoding is handled
+    /// internally.
+    ///
+    /// # Parameters
+    /// - `owner`: Repository owner name
+    /// - `repo`: Repository name
+    /// - `path`: File path relative to the repository root (e.g. `"CHANGELOG.md"`)
+    /// - `commit_message`: Commit message for the change
+    /// - `content`: File content as plain UTF-8 text
+    /// - `branch`: Branch to commit to
+    ///
+    /// # Returns
+    /// `Ok(())` on success.
+    ///
+    /// # Errors
+    /// - `CoreError::GitHub` — the API call failed
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// github.upsert_file(
+    ///     "owner", "repo",
+    ///     "CHANGELOG.md",
+    ///     "chore(release): update CHANGELOG for v1.2.3",
+    ///     "## Changelog\n\n- feat: add thing",
+    ///     "release/v1.2.3",
+    /// ).await?;
+    /// ```
+    async fn upsert_file(
+        &self,
+        owner: &str,
+        repo: &str,
+        path: &str,
+        commit_message: &str,
+        content: &str,
+        branch: &str,
+    ) -> CoreResult<()>;
+
     /// Return a clone of this client scoped to the given GitHub App installation.
     ///
     /// All subsequent API calls on the returned client will use an installation

--- a/crates/core/src/traits/github_operations.rs
+++ b/crates/core/src/traits/github_operations.rs
@@ -214,6 +214,32 @@ pub trait GitHubOperations: GitOperations + Send + Sync {
     /// - `CoreError::GitHub` - API communication failed
     async fn delete_branch(&self, owner: &str, repo: &str, branch_name: &str) -> CoreResult<()>;
 
+    /// Force-reset an existing branch tip to a specific commit SHA.
+    ///
+    /// Equivalent to `git push --force origin <sha>:refs/heads/<branch_name>`.
+    /// Used to keep the release branch exactly one commit ahead of the base branch
+    /// on every changelog update, so the PR always shows a single diff.
+    ///
+    /// # Parameters
+    /// - `owner`: Repository owner name
+    /// - `repo`: Repository name
+    /// - `branch_name`: Name of the branch to reset (without `refs/heads/` prefix)
+    /// - `sha`: The commit SHA to reset the branch tip to
+    ///
+    /// # Returns
+    /// `Ok(())` on success
+    ///
+    /// # Errors
+    /// - `CoreError::NotFound` - Branch does not exist
+    /// - `CoreError::GitHub` - API communication failed
+    async fn force_update_branch(
+        &self,
+        owner: &str,
+        repo: &str,
+        branch_name: &str,
+        sha: &str,
+    ) -> CoreResult<()>;
+
     /// Get the permission level a specific user has on a repository
     ///
     /// Used to authorise PR comment commands: only collaborators with `Write`,

--- a/crates/core/src/traits/version_calculator.rs
+++ b/crates/core/src/traits/version_calculator.rs
@@ -7,6 +7,7 @@ use crate::{versioning::SemanticVersion, CoreResult};
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::sync::Arc;
 
 /// Version calculation context
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -414,6 +415,125 @@ pub trait VersionCalculator: Send + Sync {
         prerelease: Option<String>,
         build: Option<String>,
     ) -> CoreResult<SemanticVersion>;
+
+    /// Scope this calculator to the given GitHub App installation ID.
+    ///
+    /// GitHub-backed calculators use this to construct a scoped API client that
+    /// authenticates with the correct installation token.  Calculators that do
+    /// not interact with the GitHub API (e.g. the CLI's local-git calculator)
+    /// should return a fresh instance of the same calculator — the installation
+    /// ID is irrelevant to them.
+    ///
+    /// The processor calls this method once at the start of each event, passing
+    /// the resolved installation ID, and then calls `calculate_version` on the
+    /// returned scoped calculator.  This keeps authentication concerns out of
+    /// [`VersionContext`].
+    fn scoped_to(&self, installation_id: u64) -> Arc<dyn VersionCalculator + Send + Sync>;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Blanket impl — allows Arc<dyn VersionCalculator + Send + Sync> to be used
+// wherever V: VersionCalculator is required (e.g. as the V type parameter in
+// ReleaseRegentProcessor).
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[async_trait]
+impl VersionCalculator for Arc<dyn VersionCalculator + Send + Sync> {
+    async fn calculate_version(
+        &self,
+        context: VersionContext,
+        strategy: VersioningStrategy,
+        options: CalculationOptions,
+    ) -> CoreResult<VersionCalculationResult> {
+        (**self).calculate_version(context, strategy, options).await
+    }
+
+    async fn analyze_commits(
+        &self,
+        context: VersionContext,
+        strategy: VersioningStrategy,
+        commit_shas: Vec<String>,
+    ) -> CoreResult<Vec<CommitAnalysis>> {
+        (**self)
+            .analyze_commits(context, strategy, commit_shas)
+            .await
+    }
+
+    async fn validate_version(
+        &self,
+        context: VersionContext,
+        proposed_version: SemanticVersion,
+        rules: ValidationRules,
+    ) -> CoreResult<bool> {
+        (**self)
+            .validate_version(context, proposed_version, rules)
+            .await
+    }
+
+    async fn get_version_bump(
+        &self,
+        context: VersionContext,
+        strategy: VersioningStrategy,
+        commit_analyses: Vec<CommitAnalysis>,
+    ) -> CoreResult<VersionBump> {
+        (**self)
+            .get_version_bump(context, strategy, commit_analyses)
+            .await
+    }
+
+    async fn generate_changelog_entries(
+        &self,
+        context: VersionContext,
+        strategy: VersioningStrategy,
+        commit_analyses: Vec<CommitAnalysis>,
+        version: SemanticVersion,
+    ) -> CoreResult<Vec<ChangelogEntry>> {
+        (**self)
+            .generate_changelog_entries(context, strategy, commit_analyses, version)
+            .await
+    }
+
+    async fn preview_calculation(
+        &self,
+        context: VersionContext,
+        strategy: VersioningStrategy,
+        options: CalculationOptions,
+    ) -> CoreResult<VersionCalculationResult> {
+        (**self)
+            .preview_calculation(context, strategy, options)
+            .await
+    }
+
+    fn supported_strategies(&self) -> HashMap<String, String> {
+        (**self).supported_strategies()
+    }
+
+    fn default_strategy(&self) -> VersioningStrategy {
+        (**self).default_strategy()
+    }
+
+    #[allow(clippy::result_large_err)]
+    fn parse_conventional_commit(
+        &self,
+        commit_message: &str,
+    ) -> CoreResult<Option<CommitAnalysis>> {
+        (**self).parse_conventional_commit(commit_message)
+    }
+
+    #[allow(clippy::result_large_err)]
+    fn apply_version_bump(
+        &self,
+        current_version: SemanticVersion,
+        bump_type: VersionBump,
+        prerelease: Option<String>,
+        build: Option<String>,
+    ) -> CoreResult<SemanticVersion> {
+        (**self).apply_version_bump(current_version, bump_type, prerelease, build)
+    }
+
+    fn scoped_to(&self, installation_id: u64) -> Arc<dyn VersionCalculator + Send + Sync> {
+        (**self).scoped_to(installation_id)
+    }
 }
 
 // TODO: implement - placeholder for compilation
@@ -536,5 +656,9 @@ impl VersionCalculator for MockVersionCalculator {
             "MockVersionCalculator",
             "not yet implemented",
         ))
+    }
+
+    fn scoped_to(&self, _installation_id: u64) -> Arc<dyn VersionCalculator + Send + Sync> {
+        Arc::new(MockVersionCalculator)
     }
 }

--- a/crates/core/src/versioning.rs
+++ b/crates/core/src/versioning.rs
@@ -418,8 +418,20 @@ impl VersionCalculator {
     }
 
     /// Apply version bump to base version
+    ///
+    /// When `major == 0` (pre-1.0 development), a `Major` bump is treated as a
+    /// `Minor` bump. Semver 2.0 allows breaking changes within major version 0 to
+    /// only advance the minor component so that projects stay on `0.x` until they
+    /// deliberately ship their first stable `1.0.0` release.
     fn apply_version_bump(base: &SemanticVersion, bump: &VersionBump) -> SemanticVersion {
         match bump {
+            VersionBump::Major if base.major == 0 => SemanticVersion {
+                major: 0,
+                minor: base.minor + 1,
+                patch: 0,
+                prerelease: None,
+                build: None,
+            },
             VersionBump::Major => SemanticVersion {
                 major: base.major + 1,
                 minor: 0,

--- a/crates/core/src/versioning_tests.rs
+++ b/crates/core/src/versioning_tests.rs
@@ -123,6 +123,50 @@ fn test_version_bump_application() {
 }
 
 #[test]
+fn test_version_bump_major_on_pre_one_zero_bumps_minor() {
+    // When major == 0 a breaking-change bump should increment minor, not major,
+    // so the project stays in pre-1.0 development (semver §4 / §11).
+    let pre_release_base = SemanticVersion {
+        major: 0,
+        minor: 2,
+        patch: 0,
+        prerelease: None,
+        build: None,
+    };
+
+    let result = VersionCalculator::apply_version_bump(&pre_release_base, &VersionBump::Major);
+    assert_eq!(result.major, 0, "major must stay 0 in pre-1.0 mode");
+    assert_eq!(result.minor, 3, "minor must be incremented for breaking change on 0.x");
+    assert_eq!(result.patch, 0);
+
+    // From 0.1.0 (the default initial version when no tags exist)
+    let initial = SemanticVersion { major: 0, minor: 1, patch: 0, prerelease: None, build: None };
+    let from_initial = VersionCalculator::apply_version_bump(&initial, &VersionBump::Major);
+    assert_eq!(from_initial.major, 0);
+    assert_eq!(from_initial.minor, 2, "0.1.0 + breaking change -> 0.2.0, not 1.0.0");
+    assert_eq!(from_initial.patch, 0);
+}
+
+#[test]
+fn test_initial_version_with_breaking_change_stays_pre_one_zero() {
+    // No prior tag → starts from 0.1.0; a breaking-change commit must yield 0.2.0.
+    let calculator = VersionCalculator::new(None);
+    let commits = vec![ConventionalCommit {
+        commit_type: "feat".to_string(),
+        scope: None,
+        description: "rename endpoint".to_string(),
+        breaking_change: true,
+        message: "feat!: rename endpoint".to_string(),
+        sha: "deadbeef".to_string(),
+    }];
+
+    let version = calculator.calculate_next_version(&commits).unwrap();
+    assert_eq!(version.major, 0, "should stay on 0.x for initial breaking change");
+    assert_eq!(version.minor, 2, "0.1.0 + breaking change -> 0.2.0");
+    assert_eq!(version.patch, 0);
+}
+
+#[test]
 fn test_version_bump_determination() {
     // Test breaking change
     let breaking_commits = vec![ConventionalCommit {

--- a/crates/core/src/versioning_tests.rs
+++ b/crates/core/src/versioning_tests.rs
@@ -136,14 +136,26 @@ fn test_version_bump_major_on_pre_one_zero_bumps_minor() {
 
     let result = VersionCalculator::apply_version_bump(&pre_release_base, &VersionBump::Major);
     assert_eq!(result.major, 0, "major must stay 0 in pre-1.0 mode");
-    assert_eq!(result.minor, 3, "minor must be incremented for breaking change on 0.x");
+    assert_eq!(
+        result.minor, 3,
+        "minor must be incremented for breaking change on 0.x"
+    );
     assert_eq!(result.patch, 0);
 
     // From 0.1.0 (the default initial version when no tags exist)
-    let initial = SemanticVersion { major: 0, minor: 1, patch: 0, prerelease: None, build: None };
+    let initial = SemanticVersion {
+        major: 0,
+        minor: 1,
+        patch: 0,
+        prerelease: None,
+        build: None,
+    };
     let from_initial = VersionCalculator::apply_version_bump(&initial, &VersionBump::Major);
     assert_eq!(from_initial.major, 0);
-    assert_eq!(from_initial.minor, 2, "0.1.0 + breaking change -> 0.2.0, not 1.0.0");
+    assert_eq!(
+        from_initial.minor, 2,
+        "0.1.0 + breaking change -> 0.2.0, not 1.0.0"
+    );
     assert_eq!(from_initial.patch, 0);
 }
 
@@ -161,7 +173,10 @@ fn test_initial_version_with_breaking_change_stays_pre_one_zero() {
     }];
 
     let version = calculator.calculate_next_version(&commits).unwrap();
-    assert_eq!(version.major, 0, "should stay on 0.x for initial breaking change");
+    assert_eq!(
+        version.major, 0,
+        "should stay on 0.x for initial breaking change"
+    );
     assert_eq!(version.minor, 2, "0.1.0 + breaking change -> 0.2.0");
     assert_eq!(version.patch, 0);
 }

--- a/crates/github_client/Cargo.toml
+++ b/crates/github_client/Cargo.toml
@@ -19,6 +19,7 @@ tokio = { workspace = true }
 tracing = { workspace = true }
 
 # GitHub integration - using github-bot-sdk
+base64 = { workspace = true }
 github-bot-sdk = { workspace = true }
 jsonwebtoken = { workspace = true }
 reqwest = { workspace = true }

--- a/crates/github_client/src/lib.rs
+++ b/crates/github_client/src/lib.rs
@@ -211,6 +211,26 @@ impl GitOperations for GitHubClient {
             .await
             .map_err(|e| CoreError::network(format!("GitHub HTTP client error: {e}")))?;
 
+        // The GitHub compare endpoint returns at most 250 commits. When the
+        // range spans more than 250 commits the response is silently truncated.
+        // Emit a warning so operators can identify that version-bump and
+        // changelog results may be incomplete.
+        if comparison.ahead_by > comparison.commits.len() {
+            warn!(
+                owner,
+                repo,
+                base,
+                head,
+                ahead_by = comparison.ahead_by,
+                returned = comparison.commits.len(),
+                "GitHub compare API returned only {} of {} commits (250-commit limit). \
+                 Version bump and changelog calculations may be incomplete. \
+                 Consider paginating via /commits if full history is required.",
+                comparison.commits.len(),
+                comparison.ahead_by,
+            );
+        }
+
         Ok(comparison
             .commits
             .into_iter()
@@ -962,7 +982,7 @@ impl GitHubOperations for GitHubClient {
             "/repos/{owner}/{repo}/contents/{}",
             urlencoding_encode(path)
         );
-        let get_url_with_ref = format!("{get_path}?ref={branch}");
+        let get_url_with_ref = format!("{get_path}?ref={}", urlencoding_encode_query_value(branch));
 
         let existing_sha: Option<String> = match installation.get(&get_url_with_ref).await {
             Ok(resp) => {
@@ -1054,6 +1074,13 @@ impl GitHubOperations for GitHubClient {
 #[derive(serde::Deserialize)]
 struct CompareApiResponse {
     commits: Vec<CompareCommitEnvelope>,
+    /// Number of commits that `head` is ahead of `base`.
+    ///
+    /// When this value is greater than `commits.len()` (which is capped at 250
+    /// by the GitHub API), the commit list is truncated and callers will operate
+    /// on an incomplete set.
+    #[serde(default)]
+    ahead_by: usize,
 }
 
 #[derive(serde::Deserialize)]
@@ -1161,6 +1188,26 @@ fn urlencoding_encode(path: &str) -> String {
         })
         .collect::<Vec<_>>()
         .join("/")
+}
+
+/// Percent-encode a query-string value for use in a GitHub API URL.
+///
+/// Encodes all bytes that are not RFC 3986 unreserved characters, including
+/// `/` (unlike [`urlencoding_encode`] which preserves slashes as path
+/// separators).  This is required for values placed in query parameters such
+/// as `?ref=<branch>` where a branch name like `release/v1.2.3` would
+/// otherwise be misinterpreted as a URL path component.
+fn urlencoding_encode_query_value(value: &str) -> String {
+    value
+        .bytes()
+        .flat_map(|b| {
+            if b.is_ascii_alphanumeric() || matches!(b, b'-' | b'_' | b'.' | b'~') {
+                vec![b as char]
+            } else {
+                format!("%{b:02X}").chars().collect::<Vec<char>>()
+            }
+        })
+        .collect()
 }
 
 /// Parse the `Link` response header and return the page number from the

--- a/crates/github_client/src/lib.rs
+++ b/crates/github_client/src/lib.rs
@@ -745,8 +745,17 @@ impl GitHubOperations for GitHubClient {
             .create_branch(owner, repo, branch_name, sha)
             .await
             .map_err(|e| {
-                // HTTP 422 from GitHub means "Reference already exists"
-                if let github_bot_sdk::error::ApiError::HttpError { status: 422, .. } = &e {
+                // The SDK may surface the GitHub 422 "Reference already exists" response
+                // as either ApiError::HttpError { status: 422 } or as ApiError::InvalidRequest
+                // with the raw GitHub JSON body in the message field. Handle both.
+                let is_already_exists = match &e {
+                    github_bot_sdk::error::ApiError::HttpError { status: 422, .. } => true,
+                    github_bot_sdk::error::ApiError::InvalidRequest { message } => {
+                        message.contains("Reference already exists")
+                    }
+                    _ => false,
+                };
+                if is_already_exists {
                     CoreError::conflict(format!("branch '{branch_name}' already exists"))
                 } else {
                     map_sdk_error(e)
@@ -929,7 +938,10 @@ impl GitHubOperations for GitHubClient {
 
         // GET the existing file to retrieve its blob SHA (required for updates).
         // A 404 means the file doesn't exist yet, which is fine for creation.
-        let get_path = format!("/repos/{owner}/{repo}/contents/{}", urlencoding_encode(path));
+        let get_path = format!(
+            "/repos/{owner}/{repo}/contents/{}",
+            urlencoding_encode(path)
+        );
         let get_url_with_ref = format!("{get_path}?ref={branch}");
 
         let existing_sha: Option<String> = match installation.get(&get_url_with_ref).await {

--- a/crates/github_client/src/lib.rs
+++ b/crates/github_client/src/lib.rs
@@ -559,39 +559,55 @@ impl GitHubOperations for GitHubClient {
             "Listing pull requests"
         );
 
+        // Use the raw HTTP endpoint instead of the SDK helper.
+        // The SDK's `PullRequest.head.repo` / `.base.repo` fields are required
+        // (non-Option), but GitHub returns `null` when a fork's repository has
+        // been deleted, causing "error decoding response body" at runtime.
         let state_str = state.unwrap_or("open");
         let installation = self.installation().await?;
         let mut all_prs: Vec<PullRequest> = Vec::new();
         let mut page: Option<u32> = None;
 
         loop {
-            let response = installation
-                .list_pull_requests(owner, repo, Some(state_str), page)
+            let path = match page {
+                Some(p) => {
+                    format!("/repos/{owner}/{repo}/pulls?state={state_str}&per_page=100&page={p}")
+                }
+                None => format!("/repos/{owner}/{repo}/pulls?state={state_str}&per_page=100"),
+            };
+
+            let response = installation.get(&path).await.map_err(map_sdk_error)?;
+
+            let next_page = response
+                .headers()
+                .get("Link")
+                .and_then(|h| h.to_str().ok())
+                .and_then(parse_next_page_from_link_header);
+
+            let items: Vec<ListPrItem> = response
+                .json()
                 .await
-                .map_err(map_sdk_error)?;
+                .map_err(|e| CoreError::network(format!("GitHub HTTP client error: {e}")))?;
 
-            let has_next = response.has_next();
-            let next_page_num = response.next_page_number();
-
-            for sdk_pr in response.items {
+            for pr_item in items {
                 // Client-side head-branch prefix filter.
                 if let Some(prefix) = head {
-                    if !sdk_pr.head.branch_ref.starts_with(prefix) {
+                    if !pr_item.head.branch_ref.starts_with(prefix) {
                         continue;
                     }
                 }
                 // Client-side base-branch exact-match filter.
                 if let Some(base_branch) = base {
-                    if sdk_pr.base.branch_ref != base_branch {
+                    if pr_item.base.branch_ref != base_branch {
                         continue;
                     }
                 }
-                all_prs.push(convert_sdk_pr_to_release_regent_pr(sdk_pr)?);
+                all_prs.push(list_pr_item_to_release_regent_pr(pr_item));
             }
 
-            match (has_next, next_page_num) {
-                (true, Some(next)) => page = Some(next),
-                _ => break,
+            match next_page {
+                Some(next) => page = Some(next),
+                None => break,
             }
         }
 
@@ -630,32 +646,46 @@ impl GitHubOperations for GitHubClient {
             .split_whitespace()
             .find_map(|token| token.strip_prefix("head:").map(|p| p.trim_end_matches('*')));
 
+        // Use the raw HTTP endpoint instead of the SDK helper.
+        // See the comment in list_pull_requests for why the SDK is bypassed.
         let installation = self.installation().await?;
         let mut all_prs: Vec<PullRequest> = Vec::new();
         let mut page: Option<u32> = None;
 
         loop {
-            let response = installation
-                .list_pull_requests(owner, repo, Some(state), page)
+            let path = match page {
+                Some(p) => {
+                    format!("/repos/{owner}/{repo}/pulls?state={state}&per_page=100&page={p}")
+                }
+                None => format!("/repos/{owner}/{repo}/pulls?state={state}&per_page=100"),
+            };
+
+            let response = installation.get(&path).await.map_err(map_sdk_error)?;
+
+            let next_page = response
+                .headers()
+                .get("Link")
+                .and_then(|h| h.to_str().ok())
+                .and_then(parse_next_page_from_link_header);
+
+            let items: Vec<ListPrItem> = response
+                .json()
                 .await
-                .map_err(map_sdk_error)?;
+                .map_err(|e| CoreError::network(format!("GitHub HTTP client error: {e}")))?;
 
-            let has_next = response.has_next();
-            let next_page_num = response.next_page_number();
-
-            for sdk_pr in response.items {
+            for pr_item in items {
                 // Filter by head branch prefix when specified.
                 if let Some(prefix) = head_prefix {
-                    if !sdk_pr.head.branch_ref.starts_with(prefix) {
+                    if !pr_item.head.branch_ref.starts_with(prefix) {
                         continue;
                     }
                 }
-                all_prs.push(convert_sdk_pr_to_release_regent_pr(sdk_pr)?);
+                all_prs.push(list_pr_item_to_release_regent_pr(pr_item));
             }
 
-            match (has_next, next_page_num) {
-                (true, Some(next)) => page = Some(next),
-                _ => break,
+            match next_page {
+                Some(next) => page = Some(next),
+                None => break,
             }
         }
 
@@ -962,6 +992,133 @@ struct CompareGitHubUser {
 #[derive(serde::Deserialize)]
 struct CompareCommitParent {
     sha: String,
+}
+
+// ── List-PRs API local types ────────────────────────────────────────────────
+//
+// The SDK's `PullRequest` type has `head.repo: PullRequestRepo` (required).
+// GitHub's REST API returns `null` for `head.repo` / `base.repo` when the
+// head repository has been deleted (common with merged or closed forks).
+// Using the SDK type therefore causes "error decoding response body" for any
+// response that contains such a PR.
+//
+// These private types mirror what GitHub actually returns.
+
+#[derive(serde::Deserialize)]
+struct ListPrItem {
+    number: u64,
+    title: String,
+    body: Option<String>,
+    state: String,
+    draft: bool,
+    user: ListPrUser,
+    head: ListPrBranch,
+    base: ListPrBranch,
+    created_at: chrono::DateTime<chrono::Utc>,
+    updated_at: chrono::DateTime<chrono::Utc>,
+    #[serde(default)]
+    merged_at: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+#[derive(serde::Deserialize)]
+struct ListPrBranch {
+    #[serde(rename = "ref")]
+    branch_ref: String,
+    sha: String,
+    /// `null` when the fork repository has been deleted.
+    repo: Option<ListPrBranchRepo>,
+}
+
+#[derive(serde::Deserialize)]
+struct ListPrBranchRepo {
+    id: u64,
+    name: String,
+    full_name: String,
+}
+
+#[derive(serde::Deserialize)]
+struct ListPrUser {
+    login: String,
+}
+
+/// Parse the `Link` response header and return the page number from the
+/// `rel="next"` URL, if present.
+fn parse_next_page_from_link_header(header_value: &str) -> Option<u32> {
+    for part in header_value.split(',') {
+        let part = part.trim();
+        if part.contains(r#"rel="next""#) {
+            if let (Some(start), Some(end)) = (part.find('<'), part.find('>')) {
+                let url = &part[start + 1..end];
+                for param in url.split('?').nth(1).unwrap_or("").split('&') {
+                    if let Some(val) = param.strip_prefix("page=") {
+                        return val.parse().ok();
+                    }
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Convert a raw GitHub list-PRs-API item into the core `PullRequest` type.
+fn list_pr_item_to_release_regent_pr(pr: ListPrItem) -> PullRequest {
+    let head_repo = pr.head.repo.as_ref();
+    let base_repo = pr.base.repo.as_ref();
+
+    let head_owner = head_repo
+        .and_then(|r| r.full_name.split('/').next().map(str::to_string))
+        .unwrap_or_default();
+    let base_owner = base_repo
+        .and_then(|r| r.full_name.split('/').next().map(str::to_string))
+        .unwrap_or_default();
+
+    PullRequest {
+        number: pr.number,
+        title: pr.title,
+        body: pr.body,
+        state: pr.state,
+        draft: pr.draft,
+        created_at: pr.created_at,
+        updated_at: pr.updated_at,
+        merged_at: pr.merged_at,
+        user: GitHubUser {
+            name: pr.user.login.clone(),
+            email: format!("{}@users.noreply.github.com", pr.user.login),
+            login: Some(pr.user.login),
+        },
+        head: PullRequestBranch {
+            ref_name: pr.head.branch_ref,
+            sha: pr.head.sha,
+            repo: Repository {
+                id: head_repo.map(|r| r.id).unwrap_or(0),
+                name: head_repo.map(|r| r.name.clone()).unwrap_or_default(),
+                full_name: head_repo.map(|r| r.full_name.clone()).unwrap_or_default(),
+                owner: head_owner,
+                description: None,
+                private: false,
+                default_branch: String::new(),
+                clone_url: String::new(),
+                ssh_url: String::new(),
+                homepage: None,
+            },
+        },
+        base: PullRequestBranch {
+            ref_name: pr.base.branch_ref,
+            sha: pr.base.sha,
+            repo: Repository {
+                id: base_repo.map(|r| r.id).unwrap_or(0),
+                name: base_repo.map(|r| r.name.clone()).unwrap_or_default(),
+                full_name: base_repo.map(|r| r.full_name.clone()).unwrap_or_default(),
+                owner: base_owner,
+                description: None,
+                private: false,
+                default_branch: String::new(),
+                clone_url: String::new(),
+                ssh_url: String::new(),
+                homepage: None,
+            },
+        },
+    }
 }
 
 /// Convert a raw GitHub compare-API commit envelope into the core `GitCommit` type.

--- a/crates/github_client/src/lib.rs
+++ b/crates/github_client/src/lib.rs
@@ -874,6 +874,30 @@ impl GitHubOperations for GitHubClient {
         Ok(labels)
     }
 
+    #[instrument(skip(self))]
+    async fn get_installation_id_for_repo(
+        &self,
+        owner: &str,
+        repo: &str,
+    ) -> CoreResult<u64> {
+        info!(owner, repo, "Looking up installation ID for repository");
+        let path = format!("/repos/{owner}/{repo}/installation");
+        let response = self
+            .sdk_client
+            .get_as_app(&path)
+            .await
+            .map_err(map_sdk_error)?;
+        let body: serde_json::Value = response.json().await.map_err(CoreError::github)?;
+        body["id"]
+            .as_u64()
+            .ok_or_else(|| CoreError::GitHub {
+                source: Box::new(std::io::Error::other(
+                    "installation lookup response missing 'id' field",
+                )),
+                context: None,
+            })
+    }
+
     fn scoped_to(&self, installation_id: u64) -> Self {
         Self {
             sdk_client: self.sdk_client.clone(),

--- a/crates/github_client/src/lib.rs
+++ b/crates/github_client/src/lib.rs
@@ -4,6 +4,7 @@
 //! using the github-bot-sdk library for GitHub API interactions.
 
 use async_trait::async_trait;
+use base64::Engine as _;
 use github_bot_sdk::{
     auth::{
         cache::InMemoryTokenCache, tokens::GitHubAppAuth, AuthenticationProvider, InstallationId,
@@ -912,6 +913,72 @@ impl GitHubOperations for GitHubClient {
         Ok(labels)
     }
 
+    #[instrument(skip(self, content, commit_message))]
+    async fn upsert_file(
+        &self,
+        owner: &str,
+        repo: &str,
+        path: &str,
+        commit_message: &str,
+        content: &str,
+        branch: &str,
+    ) -> CoreResult<()> {
+        info!(owner, repo, path, branch, "Upserting file on branch");
+
+        let installation = self.installation().await?;
+
+        // GET the existing file to retrieve its blob SHA (required for updates).
+        // A 404 means the file doesn't exist yet, which is fine for creation.
+        let get_path = format!("/repos/{owner}/{repo}/contents/{}", urlencoding_encode(path));
+        let get_url_with_ref = format!("{get_path}?ref={branch}");
+
+        let existing_sha: Option<String> = match installation.get(&get_url_with_ref).await {
+            Ok(resp) => {
+                let status = resp.status().as_u16();
+                if status == 200 {
+                    let json: serde_json::Value = resp.json().await.map_err(CoreError::github)?;
+                    json["sha"].as_str().map(str::to_owned)
+                } else if status == 404 {
+                    None
+                } else {
+                    let body = resp.text().await.unwrap_or_default();
+                    return Err(CoreError::github(std::io::Error::other(format!(
+                        "GET /contents failed with status {status}: {body}"
+                    ))));
+                }
+            }
+            Err(ApiError::NotFound) => None,
+            Err(e) => return Err(map_sdk_error(e)),
+        };
+
+        // Build the PUT request body.
+        let encoded = base64::engine::general_purpose::STANDARD.encode(content.as_bytes());
+        let mut body = serde_json::json!({
+            "message": commit_message,
+            "content": encoded,
+            "branch": branch,
+        });
+        if let Some(sha) = existing_sha {
+            body["sha"] = serde_json::Value::String(sha);
+        }
+
+        let response = installation
+            .put(&get_path, &body)
+            .await
+            .map_err(map_sdk_error)?;
+
+        let status = response.status().as_u16();
+        if !(200..=201).contains(&status) {
+            let resp_body = response.text().await.unwrap_or_default();
+            return Err(CoreError::github(std::io::Error::other(format!(
+                "PUT /contents failed with status {status}: {resp_body}"
+            ))));
+        }
+
+        info!(owner, repo, path, branch, "File upserted successfully");
+        Ok(())
+    }
+
     #[instrument(skip(self))]
     async fn get_installation_id_for_repo(&self, owner: &str, repo: &str) -> CoreResult<u64> {
         info!(owner, repo, "Looking up installation ID for repository");
@@ -1039,6 +1106,29 @@ struct ListPrBranchRepo {
 #[derive(serde::Deserialize)]
 struct ListPrUser {
     login: String,
+}
+
+/// Percent-encode a file path for use in a GitHub Contents API URL.
+///
+/// Only forward slashes are kept unencoded (they are valid path separators
+/// in the GitHub API).  All other characters that are not unreserved in RFC
+/// 3986 are percent-encoded.
+fn urlencoding_encode(path: &str) -> String {
+    path.split('/')
+        .map(|segment| {
+            segment
+                .bytes()
+                .flat_map(|b| {
+                    if b.is_ascii_alphanumeric() || matches!(b, b'-' | b'_' | b'.' | b'~') {
+                        vec![b as char]
+                    } else {
+                        format!("%{b:02X}").chars().collect::<Vec<char>>()
+                    }
+                })
+                .collect::<String>()
+        })
+        .collect::<Vec<_>>()
+        .join("/")
 }
 
 /// Parse the `Link` response header and return the page number from the

--- a/crates/github_client/src/lib.rs
+++ b/crates/github_client/src/lib.rs
@@ -196,16 +196,24 @@ impl GitOperations for GitHubClient {
     ) -> CoreResult<Vec<GitCommit>> {
         info!(owner, repo, base, head, "Getting commits between");
 
+        // Use the raw HTTP endpoint directly instead of the SDK helper.
+        // The SDK's `compare_commits` deserialises the response into `FullCommit`
+        // which has a required `comment_count: u32` field.  GitHub does not
+        // include that field at the commit envelope level (it returns
+        // `comments_url` there instead), so serde rejects the response with
+        // "error decoding response body".
         let installation = self.installation().await?;
-        let comparison = installation
-            .compare_commits(owner, repo, base, head)
+        let path = format!("/repos/{owner}/{repo}/compare/{base}...{head}");
+        let response = installation.get(&path).await.map_err(map_sdk_error)?;
+        let comparison: CompareApiResponse = response
+            .json()
             .await
-            .map_err(map_sdk_error)?;
+            .map_err(|e| CoreError::network(format!("GitHub HTTP client error: {e}")))?;
 
         Ok(comparison
             .commits
             .into_iter()
-            .map(convert_sdk_commit_to_git_commit)
+            .map(compare_envelope_to_git_commit)
             .collect())
     }
 
@@ -875,11 +883,7 @@ impl GitHubOperations for GitHubClient {
     }
 
     #[instrument(skip(self))]
-    async fn get_installation_id_for_repo(
-        &self,
-        owner: &str,
-        repo: &str,
-    ) -> CoreResult<u64> {
+    async fn get_installation_id_for_repo(&self, owner: &str, repo: &str) -> CoreResult<u64> {
         info!(owner, repo, "Looking up installation ID for repository");
         let path = format!("/repos/{owner}/{repo}/installation");
         let response = self
@@ -888,14 +892,12 @@ impl GitHubOperations for GitHubClient {
             .await
             .map_err(map_sdk_error)?;
         let body: serde_json::Value = response.json().await.map_err(CoreError::github)?;
-        body["id"]
-            .as_u64()
-            .ok_or_else(|| CoreError::GitHub {
-                source: Box::new(std::io::Error::other(
-                    "installation lookup response missing 'id' field",
-                )),
-                context: None,
-            })
+        body["id"].as_u64().ok_or_else(|| CoreError::GitHub {
+            source: Box::new(std::io::Error::other(
+                "installation lookup response missing 'id' field",
+            )),
+            context: None,
+        })
     }
 
     fn scoped_to(&self, installation_id: u64) -> Self {
@@ -910,9 +912,94 @@ impl GitHubOperations for GitHubClient {
 // Type conversion utilities
 // ============================================================================
 
-// Note: Placeholder for when SDK has commit support
-// Currently SDK's Tag type only has { sha, url } not full commit details
-#[allow(dead_code)]
+// Local types for GitHub compare API response deserialization.
+//
+// The SDK's `Comparison` / `FullCommit` structs require `comment_count` at the
+// commit-envelope level, but GitHub's REST API does not include that field
+// there (it places it inside the nested `commit` object and returns
+// `comments_url` at the envelope level instead).  Deserialising the real
+// GitHub response with the SDK types therefore fails at runtime.
+//
+// These private types map exactly to what GitHub actually returns.
+
+#[derive(serde::Deserialize)]
+struct CompareApiResponse {
+    commits: Vec<CompareCommitEnvelope>,
+}
+
+#[derive(serde::Deserialize)]
+struct CompareCommitEnvelope {
+    sha: String,
+    commit: CompareCommitDetails,
+    /// GitHub user record for the author (nullable — absent when the commit
+    /// email doesn't match any GitHub account).
+    author: Option<CompareGitHubUser>,
+    /// GitHub user record for the committer (same nullability rules).
+    committer: Option<CompareGitHubUser>,
+    #[serde(default)]
+    parents: Vec<CompareCommitParent>,
+}
+
+#[derive(serde::Deserialize)]
+struct CompareCommitDetails {
+    message: String,
+    author: CompareGitSignature,
+    committer: CompareGitSignature,
+}
+
+#[derive(serde::Deserialize)]
+struct CompareGitSignature {
+    name: String,
+    email: String,
+    date: chrono::DateTime<chrono::Utc>,
+}
+
+#[derive(serde::Deserialize)]
+struct CompareGitHubUser {
+    login: String,
+}
+
+#[derive(serde::Deserialize)]
+struct CompareCommitParent {
+    sha: String,
+}
+
+/// Convert a raw GitHub compare-API commit envelope into the core `GitCommit` type.
+fn compare_envelope_to_git_commit(commit: CompareCommitEnvelope) -> GitCommit {
+    let message = commit.commit.message.clone();
+    let subject = message.lines().next().unwrap_or("").to_string();
+    let body_start: String = message.lines().skip(1).collect::<Vec<&str>>().join("\n");
+    let body = {
+        let trimmed = body_start.trim_start_matches('\n');
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed.to_string())
+        }
+    };
+
+    GitCommit {
+        sha: commit.sha,
+        author: GitOpsUser {
+            name: commit.commit.author.name,
+            email: commit.commit.author.email,
+            username: commit.author.map(|u| u.login),
+        },
+        committer: GitOpsUser {
+            name: commit.commit.committer.name,
+            email: commit.commit.committer.email,
+            username: commit.committer.map(|u| u.login),
+        },
+        author_date: commit.commit.author.date,
+        commit_date: commit.commit.committer.date,
+        message,
+        subject,
+        body,
+        parents: commit.parents.into_iter().map(|p| p.sha).collect(),
+        files: vec![],
+    }
+}
+
 fn convert_sdk_commit_to_git_commit(commit: github_bot_sdk::client::FullCommit) -> GitCommit {
     let message = commit.commit.message.clone();
     let subject = message.lines().next().unwrap_or("").to_string();

--- a/crates/github_client/src/lib.rs
+++ b/crates/github_client/src/lib.rs
@@ -779,6 +779,26 @@ impl GitHubOperations for GitHubClient {
         Ok(())
     }
 
+    #[instrument(skip(self))]
+    async fn force_update_branch(
+        &self,
+        owner: &str,
+        repo: &str,
+        branch_name: &str,
+        sha: &str,
+    ) -> CoreResult<()> {
+        info!(owner, repo, branch_name, sha, "Force-resetting branch tip");
+
+        let installation = self.installation().await?;
+
+        installation
+            .update_git_ref(owner, repo, &format!("heads/{branch_name}"), sha, true)
+            .await
+            .map_err(map_sdk_error)?;
+
+        Ok(())
+    }
+
     #[instrument(skip(self, body))]
     async fn create_issue_comment(
         &self,

--- a/crates/github_client/src/lib.rs
+++ b/crates/github_client/src/lib.rs
@@ -62,6 +62,12 @@ pub struct GitHubClient {
 impl GitHubClient {
     /// Create a new GitHub client with authentication provider.
     ///
+    /// `installation_id` is the GitHub App installation identifier extracted
+    /// from the incoming webhook payload (`installation.id`).  Pass `0` when
+    /// constructing the client at startup before any webhook is received; call
+    /// [`scoped_to`](GitHubClient::scoped_to) to obtain a per-request client
+    /// with the correct installation ID before making any API calls.
+    ///
     /// # Errors
     ///
     /// Returns [`CoreError::GitHub`] if the underlying SDK client cannot be built.
@@ -91,6 +97,10 @@ impl GitHubClient {
 
     /// Create a new GitHub client directly from [`AuthConfig`].
     ///
+    /// The client is constructed without a bound installation ID (ID `0`).
+    /// Call [`scoped_to`](GitHubClient::scoped_to) with the installation ID
+    /// from each incoming webhook before making any API calls.
+    ///
     /// This convenience constructor wires together all required SDK components:
     /// - [`auth::EnvSecretProvider`] for secret retrieval
     /// - [`auth::DefaultJwtSigner`] for RS256 JWT signing
@@ -102,7 +112,7 @@ impl GitHubClient {
     /// Returns an error if the private key in `auth_config` is malformed or
     /// if the underlying SDK client cannot be initialised.
     #[allow(clippy::result_large_err)]
-    pub fn from_config(auth_config: AuthConfig, installation_id: u64) -> CoreResult<Self> {
+    pub fn from_config(auth_config: AuthConfig) -> CoreResult<Self> {
         let secret_provider =
             auth::EnvSecretProvider::new(auth_config).map_err(|e| CoreError::GitHub {
                 source: Box::new(e),
@@ -122,7 +132,9 @@ impl GitHubClient {
             auth_config_sdk,
         );
 
-        Self::new(auth_provider, installation_id)
+        // Installation ID 0 is a placeholder; the real ID is supplied per-request
+        // via `scoped_to()` after extracting it from the webhook payload.
+        Self::new(auth_provider, 0)
     }
 
     /// Get the SDK client for direct access if needed
@@ -860,6 +872,13 @@ impl GitHubOperations for GitHubClient {
             .collect();
 
         Ok(labels)
+    }
+
+    fn scoped_to(&self, installation_id: u64) -> Self {
+        Self {
+            sdk_client: self.sdk_client.clone(),
+            installation_id: InstallationId::new(installation_id),
+        }
     }
 }
 

--- a/crates/github_client/src/pr_management_tests.rs
+++ b/crates/github_client/src/pr_management_tests.rs
@@ -431,3 +431,125 @@ async fn test_search_pull_requests_closed_state() {
     assert_eq!(prs.len(), 1);
     assert_eq!(prs[0].number, 5);
 }
+
+/// `list_pull_requests` succeeds when GitHub returns `null` for `head.repo` or
+/// `base.repo`.  This happens for PRs whose fork repository has been deleted.
+/// The SDK's `PullRequest` type requires these fields (non-Option), so the bypass
+/// path must handle them gracefully rather than panicking or returning an error.
+#[tokio::test]
+async fn test_list_pull_requests_null_repo_handled_gracefully() {
+    let mock_server = MockServer::start().await;
+
+    // A PR with a deleted fork (head.repo = null) mixed with a normal PR.
+    let pr_deleted_fork = serde_json::json!({
+        "id": 10,
+        "node_id": "PR_10",
+        "number": 10,
+        "title": "PR from deleted fork",
+        "body": null,
+        "state": "open",
+        "user": { "login": "forker", "id": 2, "node_id": "U_2", "type": "User" },
+        "head": {
+            "ref": "feature/fork-branch",
+            "sha": "abc123",
+            "repo": null
+        },
+        "base": {
+            "ref": "main",
+            "sha": "def456",
+            "repo": { "id": 100, "name": "repo", "full_name": "owner/repo" }
+        },
+        "draft": false,
+        "merged": false,
+        "mergeable": null,
+        "merge_commit_sha": null,
+        "assignees": [],
+        "requested_reviewers": [],
+        "labels": [],
+        "milestone": null,
+        "created_at": "2024-01-01T00:00:00Z",
+        "updated_at": "2024-01-01T00:00:00Z",
+        "closed_at": null,
+        "merged_at": null,
+        "html_url": "https://github.com/owner/repo/pull/10"
+    });
+
+    Mock::given(method("GET"))
+        .and(path("/repos/owner/repo/pulls"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+            pr_deleted_fork,
+            pr_json(2, "feature/normal", "main", "open"),
+        ])))
+        .mount(&mock_server)
+        .await;
+
+    let client = make_client(&mock_server, "test-token");
+    let prs = client
+        .list_pull_requests("owner", "repo", None, None, None, None, None)
+        .await
+        .expect("null repo should not cause an error");
+
+    assert_eq!(prs.len(), 2, "both PRs should be returned");
+    let deleted_fork_pr = prs.iter().find(|p| p.number == 10).unwrap();
+    assert_eq!(deleted_fork_pr.head.repo.full_name, "");
+    assert_eq!(deleted_fork_pr.head.repo.id, 0);
+}
+
+/// `search_pull_requests` succeeds when GitHub returns `null` for `head.repo`.
+/// Same root cause as `test_list_pull_requests_null_repo_handled_gracefully`.
+#[tokio::test]
+async fn test_search_pull_requests_null_repo_handled_gracefully() {
+    let mock_server = MockServer::start().await;
+
+    let pr_deleted_fork = serde_json::json!({
+        "id": 20,
+        "node_id": "PR_20",
+        "number": 20,
+        "title": "Release PR",
+        "body": null,
+        "state": "open",
+        "user": { "login": "release-bot", "id": 3, "node_id": "U_3", "type": "Bot" },
+        "head": {
+            "ref": "release/v1.0.0",
+            "sha": "aaa111",
+            "repo": null
+        },
+        "base": {
+            "ref": "main",
+            "sha": "bbb222",
+            "repo": { "id": 100, "name": "repo", "full_name": "owner/repo" }
+        },
+        "draft": false,
+        "merged": false,
+        "mergeable": null,
+        "merge_commit_sha": null,
+        "assignees": [],
+        "requested_reviewers": [],
+        "labels": [],
+        "milestone": null,
+        "created_at": "2024-01-01T00:00:00Z",
+        "updated_at": "2024-01-01T00:00:00Z",
+        "closed_at": null,
+        "merged_at": null,
+        "html_url": "https://github.com/owner/repo/pull/20"
+    });
+
+    Mock::given(method("GET"))
+        .and(path("/repos/owner/repo/pulls"))
+        .and(query_param("state", "open"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(serde_json::json!([pr_deleted_fork])),
+        )
+        .mount(&mock_server)
+        .await;
+
+    let client = make_client(&mock_server, "test-token");
+    let prs = client
+        .search_pull_requests("owner", "repo", "is:open head:release/v*")
+        .await
+        .expect("null repo in response should not cause an error");
+
+    assert_eq!(prs.len(), 1);
+    assert_eq!(prs[0].number, 20);
+    assert_eq!(prs[0].head.ref_name, "release/v1.0.0");
+}

--- a/crates/server/src/handler.rs
+++ b/crates/server/src/handler.rs
@@ -271,7 +271,16 @@ pub fn convert_envelope(
         .get("installation")
         .and_then(|i| i.get("id"))
         .and_then(serde_json::Value::as_u64)
-        .unwrap_or(0);
+        .unwrap_or_else(|| {
+            warn!(
+                event_id = %envelope.event_id,
+                event_type = %envelope.event_type,
+                "Webhook payload missing installation.id — \
+                 this may indicate an unsupported event type or a misconfigured webhook. \
+                 API calls will fail with auth errors if this event requires an installation token.",
+            );
+            0
+        });
 
     Ok(ProcessingEvent {
         event_id: envelope.event_id.to_string(),

--- a/crates/server/src/handler.rs
+++ b/crates/server/src/handler.rs
@@ -265,6 +265,14 @@ pub fn convert_envelope(
         release_branch_prefix,
     );
 
+    let installation_id = envelope
+        .payload
+        .raw()
+        .get("installation")
+        .and_then(|i| i.get("id"))
+        .and_then(serde_json::Value::as_u64)
+        .unwrap_or(0);
+
     Ok(ProcessingEvent {
         event_id: envelope.event_id.to_string(),
         correlation_id: envelope.correlation_id().to_string(),
@@ -273,6 +281,7 @@ pub fn convert_envelope(
         payload: envelope.payload.raw().clone(),
         received_at: Utc::now(),
         source: EventSourceKind::Webhook,
+        installation_id,
     })
 }
 

--- a/crates/server/src/handler_tests.rs
+++ b/crates/server/src/handler_tests.rs
@@ -537,6 +537,7 @@ async fn test_handle_event_full_channel_drops_event_without_error() {
         payload: json!({}),
         received_at: Utc::now(),
         source: EventSourceKind::Webhook,
+        installation_id: 0,
     };
     tx.try_send(filler).expect("pre-fill must succeed");
 
@@ -586,6 +587,7 @@ async fn test_next_event_with_event_available_returns_some() {
         payload: json!({}),
         received_at: Utc::now(),
         source: EventSourceKind::Webhook,
+        installation_id: 0,
     };
     tx.try_send(event.clone()).expect("send must succeed");
 
@@ -615,6 +617,7 @@ async fn test_next_event_returns_none_after_channel_is_drained() {
         payload: json!({}),
         received_at: Utc::now(),
         source: EventSourceKind::Webhook,
+        installation_id: 0,
     };
     tx.try_send(event).expect("send must succeed");
     let source = WebhookEventSource::new(rx);

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -11,7 +11,6 @@
 //! | `GITHUB_WEBHOOK_SECRET`  | HMAC-SHA256 secret shared with GitHub (**required**) | —                  |
 //! | `GITHUB_APP_ID`          | Numeric GitHub App ID (**required**)                 | —                  |
 //! | `GITHUB_PRIVATE_KEY`     | PEM-encoded GitHub App private key (**required**)    | —                  |
-//! | `GITHUB_INSTALLATION_ID` | GitHub App installation ID (**required**)            | —                  |
 //! | `CONFIG_DIR`             | Directory to search for `.release-regent.toml`       | current directory  |
 //! | `ALLOWED_REPOS`          | Comma-separated `owner/repo` values, or `*`          | `*`                |
 //! | `EVENT_CHANNEL_CAPACITY` | Bounded channel depth for in-flight events           | `1024`             |
@@ -89,14 +88,19 @@ const MAX_BODY_BYTES: usize = 10 * 1024 * 1024;
 
 /// Parse GitHub App credentials from environment variables.
 ///
-/// Returns `(app_id, private_key, installation_id)` on success.
+/// Returns `(app_id, private_key)` on success.
+///
+/// The GitHub App installation ID is **not** read here.  It is present in every
+/// GitHub App webhook payload as `installation.id` and is extracted from the
+/// incoming event by [`handler::convert_envelope`] so that the server can serve
+/// webhooks from any installation of the same GitHub App without reconfiguration.
 ///
 /// # Errors
 ///
 /// Returns [`errors::Error::Environment`] if any required variable is absent
-/// or if `GITHUB_APP_ID` / `GITHUB_INSTALLATION_ID` cannot be parsed as `u64`.
+/// or if `GITHUB_APP_ID` cannot be parsed as `u64`.
 #[allow(clippy::result_large_err)] // errors::Error is intentionally large
-fn read_github_credentials_from_env() -> Result<(u64, String, u64), errors::Error> {
+fn read_github_credentials_from_env() -> Result<(u64, String), errors::Error> {
     let app_id: u64 = std::env::var("GITHUB_APP_ID")
         .map_err(|e| errors::Error::environment("GITHUB_APP_ID", e.to_string()))?
         .parse::<u64>()
@@ -107,31 +111,28 @@ fn read_github_credentials_from_env() -> Result<(u64, String, u64), errors::Erro
     let private_key = std::env::var("GITHUB_PRIVATE_KEY")
         .map_err(|e| errors::Error::environment("GITHUB_PRIVATE_KEY", e.to_string()))?;
 
-    let installation_id: u64 = std::env::var("GITHUB_INSTALLATION_ID")
-        .map_err(|e| errors::Error::environment("GITHUB_INSTALLATION_ID", e.to_string()))?
-        .parse::<u64>()
-        .map_err(|e| {
-            errors::Error::environment("GITHUB_INSTALLATION_ID", format!("must be a number: {e}"))
-        })?;
-
-    Ok((app_id, private_key, installation_id))
+    Ok((app_id, private_key))
 }
 
 /// Construct the production [`ServerProcessor`] from environment variables.
 ///
-/// Reads `GITHUB_APP_ID`, `GITHUB_PRIVATE_KEY`, and `GITHUB_INSTALLATION_ID`
-/// from the environment, builds a [`release_regent_github_client::GitHubClient`],
-/// initialises a [`release_regent_config_provider::FileConfigurationProvider`]
+/// Reads `GITHUB_APP_ID` and `GITHUB_PRIVATE_KEY` from the environment, builds
+/// a [`release_regent_github_client::GitHubClient`] without a bound installation
+/// ID, initialises a [`release_regent_config_provider::FileConfigurationProvider`]
 /// from the directory specified by `CONFIG_DIR` (falling back to the current
 /// working directory when `CONFIG_DIR` is absent), and wires them together with
 /// [`DefaultVersionCalculator`] into a [`ServerProcessor`].
+///
+/// The installation ID is intentionally omitted here.  It is extracted from each
+/// webhook payload at event-processing time so that one server instance can handle
+/// webhooks from any installation of the same GitHub App.
 ///
 /// # Errors
 ///
 /// Returns an error if any required variable is absent, if the GitHub App
 /// private key is malformed, or if the configuration directory is inaccessible.
 async fn build_server_processor(webhook_secret: String) -> Result<ServerProcessor, errors::Error> {
-    let (app_id, private_key, installation_id) = read_github_credentials_from_env()?;
+    let (app_id, private_key) = read_github_credentials_from_env()?;
 
     let auth_config = release_regent_github_client::AuthConfig {
         app_id,
@@ -140,7 +141,7 @@ async fn build_server_processor(webhook_secret: String) -> Result<ServerProcesso
     };
 
     let github_client =
-        release_regent_github_client::GitHubClient::from_config(auth_config, installation_id)?;
+        release_regent_github_client::GitHubClient::from_config(auth_config)?;
 
     let config_dir = match std::env::var("CONFIG_DIR") {
         Ok(dir) => std::path::PathBuf::from(dir),

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -269,8 +269,8 @@ fn setup_logging() {
 /// # Errors
 ///
 /// Returns an error if:
-/// - Any of `GITHUB_WEBHOOK_SECRET`, `GITHUB_APP_ID`, `GITHUB_PRIVATE_KEY`, or
-///   `GITHUB_INSTALLATION_ID` is absent from the environment.
+/// - Any of `GITHUB_WEBHOOK_SECRET`, `GITHUB_APP_ID`, or `GITHUB_PRIVATE_KEY` is absent from the
+///   environment. (`GITHUB_INSTALLATION_ID` is resolved per-event from the webhook payload.)
 /// - The TCP listener cannot bind to the configured address.
 /// - The Axum server exits with an error.
 #[tokio::main]

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -49,7 +49,7 @@ use github_bot_sdk::{
     events::{EventProcessor, ProcessorConfig},
     webhook::{WebhookReceiver, WebhookRequest, WebhookResponse},
 };
-use release_regent_core::{run_event_loop, DefaultVersionCalculator};
+use release_regent_core::{run_event_loop, GitHubVersionCalculator, VersionCalculator};
 use std::{collections::HashMap, sync::Arc};
 use tokio::net::TcpListener;
 use tokio_util::sync::CancellationToken;
@@ -70,10 +70,13 @@ use handler::WebhookSecretProvider;
 // ─────────────────────────────────────────────────────────────────────────────
 
 /// Concrete production processor type used by the server.
+///
+/// The version calculator is held as a trait object so that the server's type
+/// alias does not leak the concrete `GitHubVersionCalculator` type.
 type ServerProcessor = release_regent_core::ReleaseRegentProcessor<
     release_regent_github_client::GitHubClient,
     release_regent_config_provider::FileConfigurationProvider,
-    DefaultVersionCalculator,
+    Arc<dyn VersionCalculator + Send + Sync>,
 >;
 
 /// Maximum allowed webhook payload size (10 MiB).
@@ -121,7 +124,7 @@ fn read_github_credentials_from_env() -> Result<(u64, String), errors::Error> {
 /// ID, initialises a [`release_regent_config_provider::FileConfigurationProvider`]
 /// from the directory specified by `CONFIG_DIR` (falling back to the current
 /// working directory when `CONFIG_DIR` is absent), and wires them together with
-/// [`DefaultVersionCalculator`] into a [`ServerProcessor`].
+/// [`GitHubVersionCalculator`] into a [`ServerProcessor`].
 ///
 /// The installation ID is intentionally omitted here.  It is extracted from each
 /// webhook payload at event-processing time so that one server instance can handle
@@ -140,8 +143,7 @@ async fn build_server_processor(webhook_secret: String) -> Result<ServerProcesso
         webhook_secret,
     };
 
-    let github_client =
-        release_regent_github_client::GitHubClient::from_config(auth_config)?;
+    let github_client = release_regent_github_client::GitHubClient::from_config(auth_config)?;
 
     let config_dir = match std::env::var("CONFIG_DIR") {
         Ok(dir) => std::path::PathBuf::from(dir),
@@ -156,7 +158,12 @@ async fn build_server_processor(webhook_secret: String) -> Result<ServerProcesso
             .await
             .map_err(|e| errors::Error::config_provider(e.to_string()))?;
 
-    let version_calculator = DefaultVersionCalculator::new();
+    // The GitHubVersionCalculator is constructed with a clone of the (unscoped)
+    // GitHub client and held as a trait object.  The processor calls
+    // `VersionCalculator::scoped_to(installation_id)` on it before each version
+    // calculation so the concrete type never leaks into the processor type alias.
+    let version_calculator: Arc<dyn VersionCalculator + Send + Sync> =
+        Arc::new(GitHubVersionCalculator::new(github_client.clone()));
 
     Ok(release_regent_core::ReleaseRegentProcessor::new(
         github_client,

--- a/crates/server/src/main_tests.rs
+++ b/crates/server/src/main_tests.rs
@@ -22,7 +22,6 @@ static ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(Mutex::default);
 fn clear_github_app_env_vars() {
     std::env::remove_var("GITHUB_APP_ID");
     std::env::remove_var("GITHUB_PRIVATE_KEY");
-    std::env::remove_var("GITHUB_INSTALLATION_ID");
 }
 
 // ──────────────────────────────────────────────────────────────────────────────
@@ -72,31 +71,6 @@ fn test_read_github_credentials_missing_private_key_returns_environment_error() 
     }
 }
 
-#[test]
-fn test_read_github_credentials_missing_installation_id_returns_environment_error() {
-    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-    clear_github_app_env_vars();
-    std::env::set_var("GITHUB_APP_ID", "12345");
-    std::env::set_var("GITHUB_PRIVATE_KEY", "some-key");
-
-    let result = read_github_credentials_from_env();
-
-    std::env::remove_var("GITHUB_APP_ID");
-    std::env::remove_var("GITHUB_PRIVATE_KEY");
-
-    assert!(
-        result.is_err(),
-        "Expected error when GITHUB_INSTALLATION_ID is absent"
-    );
-    let err = result.unwrap_err();
-    match err {
-        errors::Error::Environment { variable, .. } => {
-            assert_eq!(variable, "GITHUB_INSTALLATION_ID");
-        }
-        other => panic!("Expected Environment error for GITHUB_INSTALLATION_ID, got: {other:?}"),
-    }
-}
-
 // ──────────────────────────────────────────────────────────────────────────────
 // read_github_credentials_from_env — malformed value paths
 // ──────────────────────────────────────────────────────────────────────────────
@@ -128,37 +102,6 @@ fn test_read_github_credentials_non_numeric_app_id_returns_environment_error() {
     }
 }
 
-#[test]
-fn test_read_github_credentials_non_numeric_installation_id_returns_environment_error() {
-    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-    clear_github_app_env_vars();
-    std::env::set_var("GITHUB_APP_ID", "12345");
-    std::env::set_var("GITHUB_PRIVATE_KEY", "some-key");
-    std::env::set_var("GITHUB_INSTALLATION_ID", "not-a-number");
-
-    let result = read_github_credentials_from_env();
-
-    std::env::remove_var("GITHUB_APP_ID");
-    std::env::remove_var("GITHUB_PRIVATE_KEY");
-    std::env::remove_var("GITHUB_INSTALLATION_ID");
-
-    assert!(
-        result.is_err(),
-        "Expected error for non-numeric GITHUB_INSTALLATION_ID"
-    );
-    let err = result.unwrap_err();
-    match err {
-        errors::Error::Environment { variable, message } => {
-            assert_eq!(variable, "GITHUB_INSTALLATION_ID");
-            assert!(
-                message.contains("must be a number"),
-                "Expected 'must be a number' in message, got: {message}"
-            );
-        }
-        other => panic!("Expected Environment error, got: {other:?}"),
-    }
-}
-
 // ──────────────────────────────────────────────────────────────────────────────
 // read_github_credentials_from_env — happy path
 // ──────────────────────────────────────────────────────────────────────────────
@@ -169,19 +112,16 @@ fn test_read_github_credentials_all_valid_returns_parsed_values() {
     clear_github_app_env_vars();
     std::env::set_var("GITHUB_APP_ID", "99999");
     std::env::set_var("GITHUB_PRIVATE_KEY", "-----BEGIN RSA PRIVATE KEY-----");
-    std::env::set_var("GITHUB_INSTALLATION_ID", "12345678");
 
     let result = read_github_credentials_from_env();
 
     std::env::remove_var("GITHUB_APP_ID");
     std::env::remove_var("GITHUB_PRIVATE_KEY");
-    std::env::remove_var("GITHUB_INSTALLATION_ID");
 
     assert!(result.is_ok(), "Expected Ok, got: {:?}", result.err());
-    let (app_id, private_key, installation_id) = result.unwrap();
+    let (app_id, private_key) = result.unwrap();
     assert_eq!(app_id, 99_999_u64);
     assert_eq!(private_key, "-----BEGIN RSA PRIVATE KEY-----");
-    assert_eq!(installation_id, 12_345_678_u64);
 }
 
 // ──────────────────────────────────────────────────────────────────────────────
@@ -206,13 +146,11 @@ async fn test_build_server_processor_with_valid_credentials_succeeds() {
     clear_github_app_env_vars();
     std::env::set_var("GITHUB_APP_ID", "99999");
     std::env::set_var("GITHUB_PRIVATE_KEY", TEST_RSA_PRIVATE_KEY);
-    std::env::set_var("GITHUB_INSTALLATION_ID", "12345678");
 
     let result = build_server_processor("test-webhook-secret".to_string()).await;
 
     std::env::remove_var("GITHUB_APP_ID");
     std::env::remove_var("GITHUB_PRIVATE_KEY");
-    std::env::remove_var("GITHUB_INSTALLATION_ID");
 
     assert!(
         result.is_ok(),
@@ -230,13 +168,11 @@ async fn test_build_server_processor_with_invalid_pem_returns_github_error() {
     clear_github_app_env_vars();
     std::env::set_var("GITHUB_APP_ID", "99999");
     std::env::set_var("GITHUB_PRIVATE_KEY", "not-a-pem-key");
-    std::env::set_var("GITHUB_INSTALLATION_ID", "12345678");
 
     let result = build_server_processor("test-webhook-secret".to_string()).await;
 
     std::env::remove_var("GITHUB_APP_ID");
     std::env::remove_var("GITHUB_PRIVATE_KEY");
-    std::env::remove_var("GITHUB_INSTALLATION_ID");
 
     assert!(result.is_err(), "Expected error for invalid PEM key");
     // `GitHubClient::from_config` returns `CoreError::GitHub`, which maps to

--- a/crates/testing/src/mocks/event_source.rs
+++ b/crates/testing/src/mocks/event_source.rs
@@ -26,6 +26,7 @@
 //!     payload: serde_json::json!({}),
 //!     received_at: Utc::now(),
 //!     source: EventSourceKind::Webhook,
+//!     installation_id: 0,
 //! };
 //!
 //! let mock = MockEventSource::new(vec![event]);

--- a/crates/testing/src/mocks/event_source_tests.rs
+++ b/crates/testing/src/mocks/event_source_tests.rs
@@ -28,6 +28,7 @@ fn make_event(id: &str) -> ProcessingEvent {
         payload: serde_json::json!({}),
         received_at: Utc::now(),
         source: EventSourceKind::Webhook,
+        installation_id: 0,
     }
 }
 

--- a/crates/testing/src/mocks/github_operations.rs
+++ b/crates/testing/src/mocks/github_operations.rs
@@ -1197,6 +1197,25 @@ impl GitHubOperations for MockGitHubOperations {
             .await;
         Ok(labels)
     }
+
+    fn scoped_to(&self, _installation_id: u64) -> Self {
+        // Shares Arc-based state (call history, labels, etc.) so tests can
+        // observe calls made through the scoped client.
+        Self {
+            state: Arc::clone(&self.state),
+            next_id: Arc::clone(&self.next_id),
+            next_sha: Arc::clone(&self.next_sha),
+            repositories: self.repositories.clone(),
+            commits: self.commits.clone(),
+            pull_requests: self.pull_requests.clone(),
+            tags: self.tags.clone(),
+            releases: self.releases.clone(),
+            branches: self.branches.clone(),
+            pr_labels: Arc::clone(&self.pr_labels),
+            collaborator_permission: self.collaborator_permission.clone(),
+            method_errors: self.method_errors.clone(),
+        }
+    }
 }
 
 /// `GitOperations` implementation for `MockGitHubOperations`

--- a/crates/testing/src/mocks/github_operations.rs
+++ b/crates/testing/src/mocks/github_operations.rs
@@ -1020,6 +1020,31 @@ impl GitHubOperations for MockGitHubOperations {
         Ok(())
     }
 
+    async fn force_update_branch(
+        &self,
+        owner: &str,
+        repo: &str,
+        branch_name: &str,
+        sha: &str,
+    ) -> CoreResult<()> {
+        let method = "force_update_branch";
+        let params_str = format!("owner={owner}, repo={repo}, branch={branch_name}, sha={sha}");
+
+        self.check_quota().await?;
+        self.simulate_latency().await;
+
+        if self.should_simulate_failure().await {
+            let error = CoreError::network("Simulated GitHub API error");
+            self.record_call(method, &params_str, CallResult::Error(error.to_string()))
+                .await;
+            return Err(error);
+        }
+
+        self.record_call(method, &params_str, CallResult::Success)
+            .await;
+        Ok(())
+    }
+
     async fn create_issue_comment(
         &self,
         owner: &str,

--- a/crates/testing/src/mocks/github_operations.rs
+++ b/crates/testing/src/mocks/github_operations.rs
@@ -1198,6 +1198,14 @@ impl GitHubOperations for MockGitHubOperations {
         Ok(labels)
     }
 
+    async fn get_installation_id_for_repo(
+        &self,
+        _owner: &str,
+        _repo: &str,
+    ) -> CoreResult<u64> {
+        Ok(0)
+    }
+
     fn scoped_to(&self, _installation_id: u64) -> Self {
         // Shares Arc-based state (call history, labels, etc.) so tests can
         // observe calls made through the scoped client.

--- a/crates/testing/src/mocks/github_operations.rs
+++ b/crates/testing/src/mocks/github_operations.rs
@@ -78,6 +78,12 @@ pub struct MockGitHubOperations {
     /// Per-method error overrides.  Key is the method name string; value is the
     /// error message to return.  Takes precedence over global failure simulation.
     method_errors: HashMap<String, String>,
+    /// Recorded `upsert_file` calls: (owner, repo, path, commit_message, content, branch).
+    ///
+    /// Wrapped in `Arc<RwLock<...>>` so that the `&self` async-trait methods
+    /// can mutate the vec without requiring `&mut self`.
+    upsert_file_calls:
+        Arc<RwLock<Vec<(String, String, String, String, String, String)>>>,
 }
 
 impl MockGitHubOperations {
@@ -127,7 +133,15 @@ impl MockGitHubOperations {
             pr_labels: Arc::new(RwLock::new(HashMap::new())),
             collaborator_permission: None,
             method_errors: HashMap::new(),
+            upsert_file_calls: Arc::new(RwLock::new(Vec::new())),
         }
+    }
+
+    /// Return all recorded `upsert_file` calls.
+    ///
+    /// Each element is `(owner, repo, path, commit_message, content, branch)`.
+    pub async fn upsert_file_calls(&self) -> Vec<(String, String, String, String, String, String)> {
+        self.upsert_file_calls.read().await.clone()
     }
 
     /// Record a method call for tracking
@@ -186,6 +200,7 @@ impl MockGitHubOperations {
             pr_labels: Arc::new(RwLock::new(HashMap::new())),
             collaborator_permission: None,
             method_errors: HashMap::new(),
+            upsert_file_calls: Arc::new(RwLock::new(Vec::new())),
         }
     }
 
@@ -1222,7 +1237,51 @@ impl GitHubOperations for MockGitHubOperations {
             pr_labels: Arc::clone(&self.pr_labels),
             collaborator_permission: self.collaborator_permission.clone(),
             method_errors: self.method_errors.clone(),
+            upsert_file_calls: Arc::clone(&self.upsert_file_calls),
         }
+    }
+
+    async fn upsert_file(
+        &self,
+        owner: &str,
+        repo: &str,
+        path: &str,
+        commit_message: &str,
+        content: &str,
+        branch: &str,
+    ) -> CoreResult<()> {
+        let method = "upsert_file";
+        let params_str = format!("owner={owner}, repo={repo}, path={path}, branch={branch}");
+
+        self.check_quota().await?;
+        self.simulate_latency().await;
+
+        if self.should_simulate_failure().await {
+            let error = CoreError::network("Simulated GitHub API error");
+            self.record_call(method, &params_str, CallResult::Error(error.to_string()))
+                .await;
+            return Err(error);
+        }
+
+        if let Some(msg) = self.method_errors.get(method) {
+            let error = CoreError::network(msg.clone());
+            self.record_call(method, &params_str, CallResult::Error(error.to_string()))
+                .await;
+            return Err(error);
+        }
+
+        self.upsert_file_calls.write().await.push((
+            owner.to_string(),
+            repo.to_string(),
+            path.to_string(),
+            commit_message.to_string(),
+            content.to_string(),
+            branch.to_string(),
+        ));
+
+        self.record_call(method, &params_str, CallResult::Success)
+            .await;
+        Ok(())
     }
 }
 

--- a/crates/testing/src/mocks/github_operations.rs
+++ b/crates/testing/src/mocks/github_operations.rs
@@ -82,8 +82,7 @@ pub struct MockGitHubOperations {
     ///
     /// Wrapped in `Arc<RwLock<...>>` so that the `&self` async-trait methods
     /// can mutate the vec without requiring `&mut self`.
-    upsert_file_calls:
-        Arc<RwLock<Vec<(String, String, String, String, String, String)>>>,
+    upsert_file_calls: Arc<RwLock<Vec<(String, String, String, String, String, String)>>>,
 }
 
 impl MockGitHubOperations {
@@ -1238,11 +1237,7 @@ impl GitHubOperations for MockGitHubOperations {
         Ok(labels)
     }
 
-    async fn get_installation_id_for_repo(
-        &self,
-        _owner: &str,
-        _repo: &str,
-    ) -> CoreResult<u64> {
+    async fn get_installation_id_for_repo(&self, _owner: &str, _repo: &str) -> CoreResult<u64> {
         Ok(0)
     }
 

--- a/crates/testing/src/mocks/version_calculator.rs
+++ b/crates/testing/src/mocks/version_calculator.rs
@@ -703,4 +703,10 @@ impl VersionCalculator for MockVersionCalculator {
 
         Ok(new_version)
     }
+
+    fn scoped_to(&self, _installation_id: u64) -> Arc<dyn VersionCalculator + Send + Sync> {
+        // Tests that need to verify calls through scoped_to should construct
+        // a new MockVersionCalculator with the desired configuration.
+        Arc::new(MockVersionCalculator::new())
+    }
 }

--- a/docs/adr/ADR-002-long-running-server-deployment-model.md
+++ b/docs/adr/ADR-002-long-running-server-deployment-model.md
@@ -89,7 +89,6 @@ ENTRYPOINT ["rr-server"]
 | `GITHUB_WEBHOOK_SECRET`   | HMAC-SHA256 secret (**required**)                    | —       |
 | `GITHUB_APP_ID`           | GitHub App numeric ID (**required**)                 | —       |
 | `GITHUB_PRIVATE_KEY`      | PEM-encoded GitHub App private key (**required**)    | —       |
-| `GITHUB_INSTALLATION_ID`  | GitHub App installation ID (**required**)            | —       |
 | `CONFIG_DIR`              | Directory containing `.release-regent.toml`          | current directory |
 | `ALLOWED_REPOS`           | Comma-separated `owner/repo` list, or `*`            | `*`     |
 | `EVENT_CHANNEL_CAPACITY`  | Bounded channel depth for in-flight events           | `1024`  |

--- a/docs/adr/ADR-005-release-branch-ownership.md
+++ b/docs/adr/ADR-005-release-branch-ownership.md
@@ -1,0 +1,66 @@
+# ADR-005: Release Regent owns release branches exclusively
+
+Status: Accepted
+Date: 2026-04-27
+Owners: release-regent-maintainers
+
+## Context
+
+Release Regent automates the creation and maintenance of release pull requests.
+As part of this workflow it pushes a single commit to a release branch and opens
+(or updates) a PR targeting the repository's default branch.
+
+A question arose: what should happen when a developer manually pushes commits to
+an existing release branch between two Release Regent runs?
+
+Two approaches were considered:
+
+1. **Merge** — preserve the manual commits by rebasing or merging on top of them.
+2. **Force-replace** — discard the manual commits and replace the branch tip with
+   the canonical Release Regent commit.
+
+## Decision
+
+Release Regent **force-pushes** its generated commit to the release branch
+(`force_update_branch`).  Release branches are considered owned exclusively by
+Release Regent; manual commits pushed directly to a release branch are
+intentionally discarded.
+
+## Consequences
+
+- **Enables**: The PR diff is always exactly one commit authored by Release
+  Regent. This keeps the changelog and version-bump audit trail clean and
+  deterministic.
+- **Forbids**: Developers cannot land hand-crafted changes on a release branch by
+  pushing directly. All changes must go through feature branches and be merged to
+  the default branch so that the next Release Regent run picks them up via
+  conventional-commit analysis.
+- **Trade-off accepted**: Any work-in-progress commits on a release branch will
+  be silently lost on the next Release Regent run. This is the intended behaviour;
+  it is documented here and in the operator guide so that teams understand the
+  contract before adopting Release Regent.
+
+## Alternatives considered
+
+- **Merge/rebase strategy**: Would preserve manual commits but makes the PR diff
+  unpredictable and breaks the invariant that the release branch always reflects
+  exactly what Release Regent computed. Rejected.
+- **Error on dirty branch**: Abort the run when unexpected commits are detected.
+  Would require a human to clean up before Release Regent can proceed, increasing
+  toil. Rejected.
+
+## Implementation notes
+
+The force-push is implemented in `release_orchestrator.rs` via
+`GitHubOperations::force_update_branch`.  The method sets the branch ref
+unconditionally using the GitHub Refs API (`PATCH /repos/{owner}/{repo}/git/refs/heads/{branch}`
+with `"force": true`).
+
+Operators who need to preserve commits on a release branch should merge those
+changes to the default branch first, then let Release Regent generate a fresh
+release PR in the next run.
+
+## References
+
+- GitHub Refs API: <https://docs.github.com/en/rest/git/refs>
+- ADR-001: Hexagonal architecture (context for how git operations are abstracted)

--- a/docs/adr/ADR-006-github-sdk-bypass.md
+++ b/docs/adr/ADR-006-github-sdk-bypass.md
@@ -1,0 +1,80 @@
+# ADR-006: GitHub SDK bypass for raw HTTP calls
+
+Status: Accepted
+Date: 2026-04-27
+Owners: release-regent-maintainers
+
+## Context
+
+`release-regent-github-client` wraps the `github-bot-sdk` crate.  In two
+cases the SDK's higher-level helpers could not be used because their
+deserialisation logic is incompatible with what GitHub's API actually returns:
+
+1. **`get_commits_between`** — the SDK's `compare_commits` helper deserialises
+   the response into a `FullCommit` type that requires a `comment_count: u32`
+   field.  GitHub's compare endpoint does not include this field at the commit
+   envelope level (it returns `comments_url` instead), so serde rejects the
+   response.
+
+2. **`list_pull_requests` / `search_pull_requests`** — the SDK's `PullRequest`
+   type marks `head.repo` and `base.repo` as required (non-`Option`), but
+   GitHub returns `null` when a fork repository has been deleted.
+
+Both failures are silent runtime panics / deserialisation errors rather than
+compile-time issues, so they were discovered through integration testing.
+
+## Decision
+
+For the two affected methods, **bypass the SDK and issue raw HTTP requests**
+directly against the GitHub REST API using the lower-level
+`InstallationClient::get` method.  Private local structs (`CompareApiResponse`,
+`ListPrItem`, etc.) map exactly to what GitHub actually returns.
+
+All other API operations continue to use the SDK's typed helpers.
+
+## Consequences
+
+- **Enables**: Stable, correct operation for the two affected endpoints without
+  waiting for upstream SDK fixes.
+- **Risk**: The private deserialisation types must be kept in sync with the
+  GitHub API manually.  GitHub rarely makes breaking changes to stable endpoints,
+  but fields could be added or renamed in a future API version.
+- **Mitigation**: Each bypass is annotated with a comment explaining the reason.
+  When the upstream SDK is updated to fix the relevant issues, the bypass should
+  be removed and the types should revert to SDK-provided ones.  Track via
+  GitHub issues.
+- **Scope**: The bypass is limited to `get_commits_between`, `list_pull_requests`,
+  and `search_pull_requests` in `crates/github_client/src/lib.rs`.
+
+## Alternatives considered
+
+- **Fork / patch the SDK**: Would require maintaining a fork with upstream
+  divergence.  Rejected in favour of the minimal local fix.
+- **Contribute upstream**: The correct long-term fix.  Not yet done because the
+  upstream SDK is under active development and the fix requires understanding
+  their serde strategy.  Tracked as a follow-up.
+- **Re-derive response types with `#[serde(default)]`**: This is essentially
+  what the bypass does, but at the consumer level rather than modifying the SDK.
+
+## Implementation notes
+
+Bypass locations and their guard comments:
+
+| Location | Endpoint | Reason |
+|---|---|---|
+| `get_commits_between` | `GET /repos/{owner}/{repo}/compare/{base}...{head}` | SDK `FullCommit` missing `comment_count` |
+| `list_pull_requests` | `GET /repos/{owner}/{repo}/pulls` | SDK `PullRequest` non-optional `repo` on branches |
+| `search_pull_requests` | `GET /repos/{owner}/{repo}/pulls` (with filters) | Same as above |
+
+To re-enable the SDK path after an upstream fix:
+
+1. Replace the private struct definitions with the SDK types.
+2. Replace the raw `installation.get(&path)` calls with the corresponding SDK
+   methods.
+3. Run the integration test suite with a live sandbox to confirm no regressions.
+
+## References
+
+- `crates/github_client/src/lib.rs` — bypass implementations
+- GitHub Compare API: <https://docs.github.com/en/rest/commits/commits#compare-two-commits>
+- GitHub Pulls API: <https://docs.github.com/en/rest/pulls/pulls>

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -78,10 +78,15 @@ Controls how release PRs are created and formatted.
 - `{version_tag}` - Version with prefix (e.g., "v1.2.3")
 - `{date}` - Current date in ISO format (e.g., "2025-07-18")
 
+> **Variable syntax**: Both `{variable}` and `${variable}` are supported so that
+> TOML/shell-style placeholders work without modification.
+> For example, `${version_tag}` and `{version_tag}` are equivalent.
+
 ```toml
 [release_pr]
 title_template = "chore(release): prepare version {version}"
 # title_template = "Release {version_tag}"
+# title_template = "Release ${version_tag}"   # shell-style syntax also works
 # title_template = "Prepare release {version} ({date})"
 ```
 
@@ -98,6 +103,9 @@ title_template = "chore(release): prepare version {version}"
 - `{changelog}` - Generated changelog content
 - `{commit_count}` - Number of commits since last release
 - `{date}` - Current date in ISO format
+
+> **Variable syntax**: Both `{variable}` and `${variable}` are supported.
+> For example, `${version}` and `{version}` are equivalent.
 
 ```toml
 [release_pr]

--- a/docs/specs/architecture/overview.md
+++ b/docs/specs/architecture/overview.md
@@ -164,6 +164,30 @@ flowchart TD
 - Handle rate limiting and retries
 - Manage installation tokens
 
+#### 7. Version Calculator
+
+**Purpose**: Derive the next semantic version and changelog from commit history
+**Implementations**:
+
+- `DefaultVersionCalculator` (`crates/core/src/version_calculator.rs`) — CLI
+  deployment. Runs a local `git` subprocess to read commit history from a
+  checked-out working tree.
+- `GitHubVersionCalculator` (`crates/core/src/github_version_calculator.rs`) —
+  **server deployment**. Fetches commit history via the GitHub compare API
+  instead of a local git clone. This implementation is used by the server
+  (container) deployment where no local git clone exists.
+
+**When to use each**:
+
+| Context | Calculator |
+|---------|-----------|
+| `rr` CLI (developer workstation) | `DefaultVersionCalculator` |
+| Long-running server / webhook handler | `GitHubVersionCalculator` |
+
+Both implementations satisfy the `VersionCalculator` trait
+(`crates/core/src/traits/version_calculator.rs`) so domain code is agnostic
+to the underlying strategy.
+
 ## Data Flow Architecture
 
 ### Webhook Processing Pipeline

--- a/samples/.env.example
+++ b/samples/.env.example
@@ -1,0 +1,61 @@
+# =============================================================================
+# Release Regent — local development environment template
+# =============================================================================
+# Copy this file to .env and fill in your values before running run-local.ps1.
+# Lines starting with # are comments and are ignored by the script.
+#
+# SECURITY: Never commit .env to source control. It is already listed in
+# .gitignore. Keep your private key and webhook secret out of version history.
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# Required — GitHub App identity
+# -----------------------------------------------------------------------------
+
+# Numeric GitHub App identifier.
+# Found at: GitHub Settings → Developer settings → GitHub Apps → (your app)
+# Example: 123456
+GITHUB_APP_ID=
+
+# Numeric installation identifier for the specific account/organisation where
+# the app is installed.
+# Found in the URL after installing the app:
+#   https://github.com/settings/installations/XXXXXXXXXX
+# Example: 12345678
+GITHUB_INSTALLATION_ID=
+
+# HMAC-SHA256 secret shared between GitHub and the webhook endpoint.
+# Configured in: GitHub App → Webhook → Webhook secret.
+# Generate with: openssl rand -hex 32
+GITHUB_WEBHOOK_SECRET=
+
+# Path to the GitHub App private key (.pem file).
+# Download from: GitHub App → Private keys → Generate a private key.
+# Use a relative or absolute path. Relative paths are resolved from the
+# location of the .env file (i.e. the samples/ directory).
+# Example: ./my-github-app.private-key.pem
+GITHUB_PRIVATE_KEY_FILE=
+
+# -----------------------------------------------------------------------------
+# Optional — repository filter
+# -----------------------------------------------------------------------------
+
+# Comma-separated list of owner/repo pairs the server will accept webhooks
+# for. Use * to accept webhooks from any repository the GitHub App is
+# installed on. Restricting to specific repositories is recommended for
+# local testing.
+# Example: myorg/myrepo,myorg/other-repo
+ALLOWED_REPOS=*
+
+# -----------------------------------------------------------------------------
+# Optional — server behaviour
+# -----------------------------------------------------------------------------
+
+# Log verbosity. Set to 'release_regent=debug,info' for verbose Release
+# Regent output while keeping dependency crates at info level.
+# Values: error | warn | info | debug | trace
+RUST_LOG=info
+
+# Maximum number of webhook events that can be queued in memory while the
+# event processor is busy. Reduce if memory is constrained.
+EVENT_CHANNEL_CAPACITY=1024

--- a/samples/.env.example
+++ b/samples/.env.example
@@ -17,13 +17,6 @@
 # Example: 123456
 GITHUB_APP_ID=
 
-# Numeric installation identifier for the specific account/organisation where
-# the app is installed.
-# Found in the URL after installing the app:
-#   https://github.com/settings/installations/XXXXXXXXXX
-# Example: 12345678
-GITHUB_INSTALLATION_ID=
-
 # HMAC-SHA256 secret shared between GitHub and the webhook endpoint.
 # Configured in: GitHub App → Webhook → Webhook secret.
 # Generate with: openssl rand -hex 32

--- a/samples/README.md
+++ b/samples/README.md
@@ -87,7 +87,6 @@ Open `samples\.env` and fill in the four required values:
 | Variable | Where to find it |
 | :------- | :--------------- |
 | `GITHUB_APP_ID` | GitHub Settings → Developer settings → GitHub Apps → your app |
-| `GITHUB_INSTALLATION_ID` | URL after installing the app: `github.com/settings/installations/XXXXXXXX` |
 | `GITHUB_WEBHOOK_SECRET` | The secret you entered when configuring the app's webhook |
 | `GITHUB_PRIVATE_KEY_FILE` | Path to the `.pem` file downloaded from the app's *Private keys* section |
 
@@ -168,7 +167,7 @@ docker logs release-regent-local
 Common causes:
 
 - A required environment variable is missing or empty in `.env`.
-- `GITHUB_APP_ID` or `GITHUB_INSTALLATION_ID` is not a number.
+- `GITHUB_APP_ID` is not a number.
 - The private key file does not contain a valid PEM-encoded key.
 
 ### Webhooks are not arriving

--- a/samples/README.md
+++ b/samples/README.md
@@ -1,0 +1,285 @@
+---
+title: Local testing samples
+description: Scripts and configuration for running Release Regent locally with Docker, Smee, and a generated test repository.
+---
+
+# Local testing samples
+
+This directory contains scripts and configuration for running and testing Release Regent
+locally without a public server.
+
+## Scripts
+
+| Script | Purpose |
+| :----- | :------ |
+| [run-local.ps1](run-local.ps1) | Start Release Regent in Docker and proxy GitHub webhooks via Smee |
+| [create-test-repo.ps1](create-test-repo.ps1) | Create a disposable GitHub test repository with branches ready to merge |
+
+## End-to-end testing workflow
+
+The two scripts work together for a complete local test loop:
+
+```text
+create-test-repo.ps1
+  └── Creates a GitHub repo with pre-built branches and a release-regent.toml
+
+run-local.ps1
+  └── Starts rr-server in Docker + smee proxy
+
+You merge a branch (PR) in the test repo
+  └── GitHub fires webhook → smee → rr-server → Release Regent logic runs
+```
+
+See the individual sections below for detailed usage of each script.
+
+---
+
+## run-local.ps1 — Docker + Smee proxy
+
+Runs Release Regent locally in Docker and forwards GitHub App webhook events
+via [Smee.io](https://smee.io).
+
+## How it works
+
+```text
+GitHub App webhook
+       │
+       ▼
+https://smee.io/YOUR_CHANNEL   (public relay, created automatically)
+       │
+       ▼ smee-client (runs locally via npx)
+       │
+       ▼
+http://localhost:PORT/webhook
+       │
+       ▼
+Docker container  →  rr-server
+```
+
+## Prerequisites
+
+| Requirement | Notes |
+| :---------- | :---- |
+| [Docker Desktop](https://www.docker.com/products/docker-desktop/) | Engine must be running |
+| [Node.js](https://nodejs.org/) | Provides `npx`, used to run the smee client |
+| GitHub App | See [GitHub App setup guide](../docs/github-app-setup.md) |
+
+## Quick start
+
+### 1. Build the Docker image
+
+From the repository root:
+
+```powershell
+docker build --tag release-regent:local .
+```
+
+Or let the script build it for you by passing `-Build` (step 4).
+
+### 2. Create your .env file
+
+```powershell
+Copy-Item samples\.env.example samples\.env
+```
+
+Open `samples\.env` and fill in the four required values:
+
+| Variable | Where to find it |
+| :------- | :--------------- |
+| `GITHUB_APP_ID` | GitHub Settings → Developer settings → GitHub Apps → your app |
+| `GITHUB_INSTALLATION_ID` | URL after installing the app: `github.com/settings/installations/XXXXXXXX` |
+| `GITHUB_WEBHOOK_SECRET` | The secret you entered when configuring the app's webhook |
+| `GITHUB_PRIVATE_KEY_FILE` | Path to the `.pem` file downloaded from the app's *Private keys* section |
+
+### 3. Update the sample config (optional)
+
+Edit `samples/config/release-regent.toml` and set `repository.remote_url` to
+the GitHub repository you want to test against. All other settings have
+working defaults.
+
+### 4. Start the stack
+
+```powershell
+# Use a pre-built image and auto-create a Smee channel
+.\samples\run-local.ps1
+
+# Build the image first, then start
+.\samples\run-local.ps1 -Build
+
+# Use a specific Smee channel from a previous session
+.\samples\run-local.ps1 -SmeeUrl https://smee.io/abc123
+```
+
+The script prints the Smee channel URL when it starts:
+
+```text
+  Configure your GitHub App webhook URL to:
+    https://smee.io/abc123
+```
+
+### 5. Point your GitHub App at the Smee channel
+
+1. Open your GitHub App settings.
+2. Under **Webhook URL**, enter the Smee channel URL printed by the script.
+3. Save the changes.
+
+GitHub will now deliver all webhook events to your local container.
+
+### 6. Trigger a test event
+
+Merge a pull request in a repository where the app is installed, or use the
+**Redeliver** button in the GitHub App's *Recent deliveries* tab to replay an
+existing event.
+
+The script streams both server logs and smee proxy output to the console:
+
+```text
+[smee]   POST http://localhost:8080/webhook - 200
+[server] 2026-04-18T12:00:00Z  INFO release_regent_core: processing pull_request event
+```
+
+### 7. Stop the stack
+
+Press **Ctrl+C**. The script stops the smee proxy, stops the container, and
+removes it automatically.
+
+## Script parameters
+
+| Parameter | Default | Description |
+| :-------- | :------ | :---------- |
+| `-SmeeUrl` | auto-created | Smee.io channel URL. Reuse across sessions to keep the same webhook URL in your GitHub App. |
+| `-EnvFile` | `samples\.env` | Path to the `.env` file with credentials. |
+| `-PrivateKeyFile` | from `.env` | Overrides `GITHUB_PRIVATE_KEY_FILE` in the `.env` file. |
+| `-ConfigDir` | `samples\config` | Directory containing `release-regent.toml`, mounted read-only at `/config` inside the container. |
+| `-ImageName` | `release-regent:local` | Docker image to start. |
+| `-Port` | `8080` | Host port mapped to the container. Change if 8080 is already in use. |
+| `-Build` | off | (Re)build the Docker image from source before starting. |
+
+## Troubleshooting
+
+### Container exits immediately
+
+Run the following to inspect the last log lines:
+
+```powershell
+docker logs release-regent-local
+```
+
+Common causes:
+
+- A required environment variable is missing or empty in `.env`.
+- `GITHUB_APP_ID` or `GITHUB_INSTALLATION_ID` is not a number.
+- The private key file does not contain a valid PEM-encoded key.
+
+### Webhooks are not arriving
+
+- Confirm the Smee channel URL in the script output matches the one set in
+  the GitHub App webhook settings.
+- Check the **Recent deliveries** tab in the GitHub App for delivery errors.
+- Ensure the container's health endpoint responds: `http://localhost:8080/health`.
+
+### Port already in use
+
+Pass a different port with `-Port`:
+
+```powershell
+.\samples\run-local.ps1 -Port 9090
+```
+
+Then update the smee target accordingly — the script handles this automatically.
+
+### Smee channel expires
+
+Smee channels do not expire while the proxy is connected. If you restart the
+script without `-SmeeUrl`, a new channel is created and you will need to update
+the GitHub App webhook URL again. Pass `-SmeeUrl https://smee.io/abc123` to
+reuse an existing channel across sessions.
+
+---
+
+## create-test-repo.ps1 — Test repository generator
+
+Creates a disposable GitHub repository pre-loaded with conventional commits and
+branches that exercise every Release Regent code path.
+
+### Prerequisites
+
+| Requirement | Notes |
+| :---------- | :---- |
+| [gh CLI](https://cli.github.com/) | Must be authenticated (`gh auth login`) |
+| [Git](https://git-scm.com/) | Must be on PATH |
+| GitHub account | Repository is created under the authenticated user/org |
+
+### Quick start
+
+```powershell
+# Create a private repo with a random suffix (avoids name collisions)
+.\samples\create-test-repo.ps1 -RandomSuffix
+
+# Also open a draft PR for every branch
+.\samples\create-test-repo.ps1 -RandomSuffix -CreatePRs
+
+# Public repo, cloned into a specific directory
+.\samples\create-test-repo.ps1 -Visibility public -WorkDir C:\dev\scratch -CreatePRs
+```
+
+The script prints a summary and step-by-step instructions when it finishes:
+
+```text
+  Repository : https://github.com/you/rr-test-a3f9
+  Local clone: C:\Users\you\AppData\Local\Temp\rr-test-a3f9
+
+  Next steps
+  ──────────
+  1. Install your Release Regent GitHub App on this repository
+  2. Start Release Regent locally with run-local.ps1
+  3. Merge branches in this order...
+```
+
+### What is created
+
+The script creates six branches off the tagged `v0.1.0` baseline on `main`:
+
+| Branch | Commit type | Expected Release Regent outcome |
+| :----- | :---------- | :------------------------------ |
+| `fix/handle-empty-input` | `fix:` | `release/v0.1.1` PR created |
+| `feat/add-greeting-styles` | `feat:` | `release/v0.2.0` PR created, replaces v0.1.1 |
+| `feat/add-language-support` | `feat:` | `release/v0.2.0` changelog updated only |
+| `docs/update-api-docs` | `docs:` | No version bump |
+| `chore/update-ci` | `chore:` | No version bump |
+| `feat/breaking-rename-endpoint` | `feat!:` + `BREAKING CHANGE:` | `release/v1.0.0` PR created |
+
+Merge the `release/v0.2.0` PR between steps 5 and 6 to trigger GitHub release creation.
+
+### Script parameters
+
+| Parameter | Default | Description |
+| :-------- | :------ | :---------- |
+| `-RepoName` | `rr-test` | Base name for the GitHub repository. |
+| `-Owner` | authenticated user | GitHub user or organisation. |
+| `-Visibility` | `private` | `private`, `public`, or `internal`. |
+| `-WorkDir` | `$env:TEMP` | Parent directory for the local clone. |
+| `-RandomSuffix` | off | Append a 4-char hex suffix to avoid naming conflicts. |
+| `-CreatePRs` | off | Open a draft PR on GitHub for each branch. |
+| `-SkipTagV0` | off | Skip the `v0.1.0` baseline tag (Release Regent uses `initial_version`). |
+
+### Cleanup
+
+```powershell
+gh repo delete owner/rr-test-a3f9 --yes
+Remove-Item -Recurse -Force "$env:TEMP\rr-test-a3f9"
+```
+
+---
+
+## File reference
+
+```text
+samples/
+  run-local.ps1              Docker + Smee orchestration script
+  create-test-repo.ps1       Test repository generator
+  .env.example               Credential template (copy to .env and fill in values)
+  config/
+    release-regent.toml      Sample server configuration mounted into Docker
+  README.md                  This file
+```

--- a/samples/config/release-regent.toml
+++ b/samples/config/release-regent.toml
@@ -1,0 +1,96 @@
+# =============================================================================
+# Release Regent — sample repository configuration
+# =============================================================================
+# This file shows all available options with sensible defaults for local
+# testing. Mount this directory into the Docker container by passing
+# -ConfigDir to run-local.ps1.
+#
+# The server looks for a file named release-regent.toml (or release-regent.yaml)
+# in the CONFIG_DIR directory. Rename or copy this file as release-regent.toml.
+#
+# Full reference: docs/configuration-reference.md
+# =============================================================================
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Repository settings
+# ─────────────────────────────────────────────────────────────────────────────
+
+[repository]
+# Base URL of the repository being managed.
+# Used to generate links in changelogs and release PR bodies.
+remote_url = "https://github.com/your-org/your-repo"
+
+# Branch that triggers release processing when pull requests are merged into it.
+main_branch = "main"
+
+# Pattern for the release branch created by Release Regent.
+# {version} is replaced with the computed semantic version.
+release_branch_pattern = "release/v{version}"
+
+# Pattern for the Git tag applied when a release is finalised.
+tag_pattern = "v{version}"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Versioning
+# ─────────────────────────────────────────────────────────────────────────────
+
+[versioning]
+# Prefix prepended to version numbers in tags, PR titles, and changelogs.
+prefix = "v"
+
+# Allow pre-release versions (e.g. 1.0.0-beta.1, 2.3.0-rc.2).
+allow_prerelease = true
+
+# Version used when no previous release tag exists in the repository.
+initial_version = "0.1.0"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Release pull request
+# ─────────────────────────────────────────────────────────────────────────────
+
+[release_pr]
+# Template for the release PR title.
+# Available variables: {version}, {version_tag}, {date}
+title_template = "chore(release): prepare version {version}"
+
+# Create release PRs as drafts. Useful when you want a human to review before
+# the PR is opened for review by the wider team.
+draft = false
+
+# Enable auto-merge on the release PR once all required status checks pass.
+# Requires auto-merge to be enabled in the repository branch-protection settings.
+auto_merge = false
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Changelog
+# ─────────────────────────────────────────────────────────────────────────────
+
+[changelog]
+# Include the author name alongside each changelog entry.
+include_authors = false
+
+# Link each entry to the commit on GitHub.
+include_commit_links = true
+
+# Link each entry to its pull request when a PR number is detected in the
+# commit message or branch name.
+include_pr_links = true
+
+# Group changelog entries by conventional commit type (feat, fix, etc.).
+# Options: "type" | "scope" | "none"
+group_by = "type"
+
+# Sort order for commits within each group.
+# Options: "date" | "type" | "scope"
+sort_commits = "date"
+
+[changelog.commit_types]
+feat = "Features"
+fix = "Bug Fixes"
+docs = "Documentation"
+refactor = "Code Refactoring"
+perf = "Performance Improvements"
+test = "Tests"
+chore = "Chores"
+ci = "Continuous Integration"
+revert = "Reverts"

--- a/samples/config/release-regent.toml
+++ b/samples/config/release-regent.toml
@@ -1,96 +1,88 @@
 # =============================================================================
 # Release Regent — sample repository configuration
 # =============================================================================
-# This file shows all available options with sensible defaults for local
-# testing. Mount this directory into the Docker container by passing
-# -ConfigDir to run-local.ps1.
+# All fields shown here are optional — they match the built-in defaults.
+# You only need to include the fields you want to override.
 #
-# The server looks for a file named release-regent.toml (or release-regent.yaml)
-# in the CONFIG_DIR directory. Rename or copy this file as release-regent.toml.
+# The server looks for a file named release-regent.toml (or .yaml) in
+# the CONFIG_DIR directory (default: /config inside the container).
 #
 # Full reference: docs/configuration-reference.md
 # =============================================================================
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Repository settings
+# Core settings
 # ─────────────────────────────────────────────────────────────────────────────
 
-[repository]
-# Base URL of the repository being managed.
-# Used to generate links in changelogs and release PR bodies.
-remote_url = "https://github.com/your-org/your-repo"
+[core]
+# Prefix prepended to version numbers in tags and PR titles.
+version_prefix = "v"
 
-# Branch that triggers release processing when pull requests are merged into it.
-main_branch = "main"
-
-# Pattern for the release branch created by Release Regent.
-# {version} is replaced with the computed semantic version.
-release_branch_pattern = "release/v{version}"
-
-# Pattern for the Git tag applied when a release is finalised.
-tag_pattern = "v{version}"
+[core.branches]
+# The default branch of the repository.
+main = "main"
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Versioning
 # ─────────────────────────────────────────────────────────────────────────────
 
 [versioning]
-# Prefix prepended to version numbers in tags, PR titles, and changelogs.
-prefix = "v"
+# How to calculate the next version.
+# Options: "conventional" (conventional commits) | "external" (custom command)
+strategy = "conventional"
 
-# Allow pre-release versions (e.g. 1.0.0-beta.1, 2.3.0-rc.2).
-allow_prerelease = true
-
-# Version used when no previous release tag exists in the repository.
-initial_version = "0.1.0"
+# Allow contributors to override the calculated bump via PR comments
+# (e.g. /override-bump minor).
+allow_override = true
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Release pull request
 # ─────────────────────────────────────────────────────────────────────────────
 
 [release_pr]
-# Template for the release PR title.
-# Available variables: {version}, {version_tag}, {date}
-title_template = "chore(release): prepare version {version}"
+# Template for the release PR title. ${version} is replaced at runtime.
+title_template = "chore(release): ${version}"
 
-# Create release PRs as drafts. Useful when you want a human to review before
-# the PR is opened for review by the wider team.
+# Template for the release PR body. ${changelog} is replaced at runtime.
+body_template = "## Changelog\n\n${changelog}"
+
+# Create release PRs as drafts.
 draft = false
 
-# Enable auto-merge on the release PR once all required status checks pass.
-# Requires auto-merge to be enabled in the repository branch-protection settings.
-auto_merge = false
-
 # ─────────────────────────────────────────────────────────────────────────────
-# Changelog
+# GitHub releases
 # ─────────────────────────────────────────────────────────────────────────────
 
-[changelog]
-# Include the author name alongside each changelog entry.
-include_authors = false
+[releases]
+# Publish releases as drafts (not publicly visible until manually published).
+draft = false
 
-# Link each entry to the commit on GitHub.
-include_commit_links = true
+# Mark releases as pre-releases.
+prerelease = false
 
-# Link each entry to its pull request when a PR number is detected in the
-# commit message or branch name.
-include_pr_links = true
+# Auto-generate release notes from merged PRs in addition to the changelog.
+generate_notes = true
 
-# Group changelog entries by conventional commit type (feat, fix, etc.).
-# Options: "type" | "scope" | "none"
-group_by = "type"
+# ─────────────────────────────────────────────────────────────────────────────
+# Error handling / retries
+# ─────────────────────────────────────────────────────────────────────────────
 
-# Sort order for commits within each group.
-# Options: "date" | "type" | "scope"
-sort_commits = "date"
+[error_handling]
+max_retries = 5
+backoff_multiplier = 2.0
+initial_delay_ms = 1000
 
-[changelog.commit_types]
-feat = "Features"
-fix = "Bug Fixes"
-docs = "Documentation"
-refactor = "Code Refactoring"
-perf = "Performance Improvements"
-test = "Tests"
-chore = "Chores"
-ci = "Continuous Integration"
-revert = "Reverts"
+# ─────────────────────────────────────────────────────────────────────────────
+# Notifications
+# ─────────────────────────────────────────────────────────────────────────────
+
+[notifications]
+enabled = true
+
+# How to report errors encountered during processing.
+# Options: "github_issue" | "webhook" | "slack" | "none"
+strategy = "github_issue"
+
+[notifications.github_issue]
+labels = ["release-regent", "bug"]
+assignees = []

--- a/samples/create-test-repo.ps1
+++ b/samples/create-test-repo.ps1
@@ -1,0 +1,790 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Creates a test GitHub repository pre-loaded with commits and branches
+    that exercise the full Release Regent workflow.
+
+.DESCRIPTION
+    This script bootstraps a disposable test repository on GitHub so you can
+    verify Release Regent end-to-end without touching a real project.
+
+    What the script creates
+    -----------------------
+    After the script finishes you have a GitHub repository with:
+
+    main (tagged v0.1.0)
+    ├── fix/handle-empty-input       PATCH bump → v0.1.1
+    ├── feat/add-greeting-styles     MINOR bump → v0.2.0
+    ├── feat/add-language-support    MINOR bump → v0.2.0 (changelog only update)
+    ├── docs/update-api-docs         no version bump
+    ├── chore/update-ci              no version bump
+    └── feat/breaking-rename-endpoint  MAJOR bump → v1.0.0
+
+    Suggested merge order
+    ---------------------
+    Merge in this order to exercise each Release Regent code path:
+
+    1. fix/handle-empty-input        → expect: release/v0.1.1 PR created
+    2. feat/add-greeting-styles      → expect: release/v0.2.0 PR, replaces v0.1.1 PR
+    3. feat/add-language-support     → expect: release/v0.2.0 PR changelog updated
+    4. docs/update-api-docs          → expect: no change (docs-only, no bump)
+    5. chore/update-ci               → expect: no change (chore, no bump)
+       Merge the release/v0.2.0 PR  → expect: GitHub release v0.2.0 created
+    6. feat/breaking-rename-endpoint → expect: release/v1.0.0 PR created
+
+.PARAMETER RepoName
+    Name of the GitHub repository to create. A random suffix is appended when
+    -RandomSuffix is used to avoid conflicts between test runs.
+    Defaults to "rr-test".
+
+.PARAMETER Owner
+    GitHub user or organisation that owns the repository. Defaults to the
+    authenticated gh CLI user (`gh api user`).
+
+.PARAMETER Visibility
+    Repository visibility: "private" (default), "public", or "internal".
+
+.PARAMETER WorkDir
+    Local directory under which the repository is cloned. Defaults to
+    $env:TEMP. The repository is cloned as $WorkDir\$RepoName.
+
+.PARAMETER RandomSuffix
+    Append a random 4-character hex suffix to -RepoName so that multiple
+    test runs do not collide (e.g. "rr-test-a3f9").
+
+.PARAMETER CreatePRs
+    Open a draft pull request on GitHub for each branch after pushing.
+    Requires the gh CLI to be authenticated with the "repo" scope.
+
+.PARAMETER SkipTagV0
+    Skip creating the initial v0.1.0 Git tag. Release Regent will treat
+    this as a brand-new project and use the configured initial_version.
+
+.EXAMPLE
+    # Private repo, no PRs
+    .\samples\create-test-repo.ps1
+
+.EXAMPLE
+    # Public repo, open draft PRs, random suffix to avoid naming conflicts
+    .\samples\create-test-repo.ps1 -Visibility public -CreatePRs -RandomSuffix
+
+.EXAMPLE
+    # Clone into a specific directory and prefix the repo name
+    .\samples\create-test-repo.ps1 -RepoName rr-integration-test `
+                                    -WorkDir C:\dev\scratch `
+                                    -CreatePRs
+#>
+[CmdletBinding()]
+param (
+    [string]$RepoName = 'rr-test',
+
+    [string]$Owner,
+
+    [ValidateSet('private', 'public', 'internal')]
+    [string]$Visibility = 'private',
+
+    [string]$WorkDir = $env:TEMP,
+
+    [switch]$RandomSuffix,
+
+    [switch]$CreatePRs,
+
+    [switch]$SkipTagV0
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Helpers
+# ─────────────────────────────────────────────────────────────────────────────
+
+function Write-Step
+{
+    param ([string]$Message)
+    Write-Host ''
+    Write-Host "==> $Message" -ForegroundColor Cyan
+}
+
+function Write-Info
+{
+    param ([string]$Message)
+    Write-Host "    $Message"
+}
+
+function Write-Success
+{
+    param ([string]$Message)
+    Write-Host "    OK  $Message" -ForegroundColor Green
+}
+
+function Write-Fatal
+{
+    param ([string]$Message)
+    Write-Host ''
+    Write-Host "ERROR: $Message" -ForegroundColor Red
+    exit 1
+}
+
+# Run a git command rooted at $RepoDir. Throws on non-zero exit code.
+function Invoke-Git
+{
+    param ([string[]]$Arguments)
+    & git -C $script:RepoDir @Arguments 2>&1 | ForEach-Object { Write-Verbose $_ }
+    if ($LASTEXITCODE -ne 0)
+    {
+        Write-Fatal "git $($Arguments -join ' ') failed (exit $LASTEXITCODE)"
+    }
+}
+
+# Create a file (and any missing parent directories) relative to $RepoDir.
+function New-RepoFile
+{
+    param (
+        [string]$RelPath,
+        [string]$Content
+    )
+    $fullPath = Join-Path $script:RepoDir $RelPath
+    $dir = Split-Path $fullPath
+    if (-not (Test-Path $dir))
+    {
+        New-Item -ItemType Directory -Path $dir -Force | Out-Null
+    }
+    Set-Content -Path $fullPath -Value $Content -Encoding UTF8 -NoNewline
+}
+
+# Stage all pending changes and create a commit.
+function New-Commit
+{
+    param (
+        [string]$Message,
+        [string]$Body = ''
+    )
+    Invoke-Git @('add', '--all')
+    $fullMessage = if ($Body)
+    {
+        "$Message`n`n$Body"
+    }
+    else
+    {
+        $Message
+    }
+    Invoke-Git @('commit', '--message', $fullMessage)
+}
+
+# Create a branch from main, commit files, push, and optionally open a PR.
+function New-Branch
+{
+    param (
+        [string]  $BranchName,
+        [string]  $PrTitle,
+        [string]  $PrBody,
+        [scriptblock]$FilesBlock   # Called with no args; should call New-RepoFile
+    )
+
+    Write-Info "Creating branch: $BranchName"
+    Invoke-Git @('checkout', '-b', $BranchName, 'main')
+
+    & $FilesBlock
+
+    Invoke-Git @('push', '--set-upstream', 'origin', $BranchName)
+
+    if ($CreatePRs)
+    {
+        $null = & gh pr create `
+            --repo   "$script:FullRepoName" `
+            --head   $BranchName `
+            --base   main `
+            --title  $PrTitle `
+            --body   $PrBody `
+            --draft  `
+            2>&1
+        if ($LASTEXITCODE -ne 0)
+        {
+            Write-Host "    WARN: Could not create PR for $BranchName" -ForegroundColor Yellow
+        }
+        else
+        {
+            Write-Info "    Draft PR opened."
+        }
+    }
+
+    # Return to main for the next branch.
+    Invoke-Git @('checkout', 'main')
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 1. Prerequisites
+# ─────────────────────────────────────────────────────────────────────────────
+
+Write-Step 'Checking prerequisites'
+
+foreach ($cmd in 'gh', 'git')
+{
+    if (-not (Get-Command $cmd -ErrorAction SilentlyContinue))
+    {
+        Write-Fatal "'$cmd' was not found on PATH.$(
+            if ($cmd -eq 'gh') { ' Install from https://cli.github.com/' }
+            else { ' Install Git from https://git-scm.com/' }
+        )"
+    }
+}
+
+# Confirm the gh CLI is authenticated.
+$null = gh auth status 2>&1
+if ($LASTEXITCODE -ne 0)
+{
+    Write-Fatal "gh is not authenticated. Run 'gh auth login' first."
+}
+
+Write-Success 'gh and git are available and authenticated.'
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 2. Resolve owner and repository name
+# ─────────────────────────────────────────────────────────────────────────────
+
+if (-not $Owner)
+{
+    $Owner = (gh api user --jq '.login' 2>&1)
+    if ($LASTEXITCODE -ne 0 -or -not $Owner)
+    {
+        Write-Fatal 'Could not determine the authenticated GitHub user. Use -Owner to specify one.'
+    }
+}
+
+if ($RandomSuffix)
+{
+    $suffix = ([System.IO.Path]::GetRandomFileName() -replace '[^a-z0-9]', '').Substring(0, 4)
+    $RepoName = "$RepoName-$suffix"
+}
+
+$FullRepoName = "$Owner/$RepoName"
+$script:FullRepoName = $FullRepoName
+
+Write-Info "Repository : $FullRepoName ($Visibility)"
+Write-Info "Clone dir  : $WorkDir"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 3. Create the GitHub repository
+# ─────────────────────────────────────────────────────────────────────────────
+
+Write-Step "Creating GitHub repository: $FullRepoName"
+
+# Check whether the repo already exists before trying to create it.
+$existing = gh repo view $FullRepoName 2>&1
+if ($LASTEXITCODE -eq 0)
+{
+    Write-Fatal "Repository '$FullRepoName' already exists. Use -RandomSuffix or choose a different -RepoName."
+}
+
+$repoUrl = gh repo create $FullRepoName --$Visibility --description 'Release Regent test repository' 2>&1
+
+if ($LASTEXITCODE -ne 0)
+{
+    Write-Fatal "gh repo create failed: $repoUrl"
+}
+
+Write-Success "Repository created: https://github.com/$FullRepoName"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 4. Clone the (empty) repository locally
+# ─────────────────────────────────────────────────────────────────────────────
+
+$CloneDir = Join-Path $WorkDir $RepoName
+$script:RepoDir = $CloneDir
+
+Write-Step "Cloning into: $CloneDir"
+
+if (Test-Path $CloneDir)
+{
+    Write-Fatal "Local directory already exists: $CloneDir. Remove it or choose a different -WorkDir."
+}
+
+& git clone "https://github.com/$FullRepoName.git" $CloneDir 2>&1 | Out-Null
+if ($LASTEXITCODE -ne 0)
+{
+    Write-Fatal "git clone failed."
+}
+
+# Set local git identity when the global identity is not configured.
+$gitUserName = (& git config --global user.name  2>&1) | Out-String
+$gitUserEmail = (& git config --global user.email 2>&1) | Out-String
+if (-not $gitUserName.Trim())
+{
+    Invoke-Git @('config', 'user.name', 'Release Regent Test')
+}
+if (-not $gitUserEmail.Trim())
+{
+    Invoke-Git @('config', 'user.email', 'rr-test@example.com')
+}
+
+# Cloning an empty repo leaves HEAD in an "unborn" state. The branch name used
+# for the first commit comes from the local init.defaultBranch git setting,
+# which varies from system to system (commonly 'master' on older git installs).
+# Pin it explicitly to 'main' before making any commits so that the branch
+# name is predictable and consistent with what Release Regent expects.
+Invoke-Git @('symbolic-ref', 'HEAD', 'refs/heads/main')
+
+Write-Success 'Repository cloned.'
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 5. Initial commit on main
+# ─────────────────────────────────────────────────────────────────────────────
+
+Write-Step 'Creating initial commit on main'
+
+New-RepoFile 'README.md' @"
+# $RepoName
+
+A disposable test repository for [Release Regent](https://github.com/pvandervelde/release_regent).
+
+## Purpose
+
+This repository was generated by `create-test-repo.ps1` so that the Release Regent
+webhook integration can be tested end-to-end without affecting real projects.
+
+## Suggested merge order
+
+Merge the branches in the following order to exercise each Release Regent code path:
+
+| Order | Branch | Conventional commit type | Expected outcome |
+| :---: | :----- | :----------------------- | :--------------- |
+| 1 | `fix/handle-empty-input` | `fix:` | `release/v0.1.1` PR created |
+| 2 | `feat/add-greeting-styles` | `feat:` | `release/v0.2.0` PR created, replaces v0.1.1 |
+| 3 | `feat/add-language-support` | `feat:` | `release/v0.2.0` changelog updated |
+| 4 | `docs/update-api-docs` | `docs:` | No version bump |
+| 5 | `chore/update-ci` | `chore:` | No version bump |
+|   | _Merge `release/v0.2.0` PR_ | — | GitHub release v0.2.0 created |
+| 6 | `feat/breaking-rename-endpoint` | `feat!:` | `release/v1.0.0` PR created |
+"@
+
+New-RepoFile 'release-regent.toml' @"
+# Release Regent configuration for this test repository.
+# See https://github.com/pvandervelde/release_regent/blob/master/docs/configuration-reference.md
+
+[repository]
+remote_url = "https://github.com/$FullRepoName"
+main_branch = "main"
+release_branch_pattern = "release/v{version}"
+tag_pattern = "v{version}"
+
+[versioning]
+prefix = "v"
+allow_prerelease = false
+initial_version = "0.1.0"
+
+[release_pr]
+title_template = "chore(release): prepare version {version}"
+draft = false
+auto_merge = false
+
+[changelog]
+include_authors = false
+include_commit_links = true
+include_pr_links = true
+group_by = "type"
+sort_commits = "date"
+
+[changelog.commit_types]
+feat     = "Features"
+fix      = "Bug Fixes"
+docs     = "Documentation"
+refactor = "Code Refactoring"
+perf     = "Performance Improvements"
+test     = "Tests"
+chore    = "Chores"
+ci       = "Continuous Integration"
+"@
+
+New-RepoFile 'src/greeting.md' @"
+# Greeting Service API
+
+## Endpoints
+
+### POST /greet
+
+Returns a greeting for the given name.
+
+**Request body**
+``````json
+{ "name": "Alice" }
+``````
+
+**Response**
+``````json
+{ "message": "Hello, Alice!" }
+``````
+"@
+
+New-Commit -Message 'chore: initial repository setup'
+
+Write-Success 'Initial commit created.'
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 6. Tag v0.1.0 as the baseline release
+# ─────────────────────────────────────────────────────────────────────────────
+
+if (-not $SkipTagV0)
+{
+    Write-Step 'Tagging baseline as v0.1.0'
+
+    Invoke-Git @('tag', '--annotate', 'v0.1.0', '--message', 'chore(release): v0.1.0')
+    # --set-upstream establishes the tracking reference on this first push.
+    # Without it, subsequent git commands that query the upstream fail on
+    # some git versions.
+    Invoke-Git @('push', '--set-upstream', 'origin', 'main', '--tags')
+
+    Write-Success 'Tag v0.1.0 pushed.'
+}
+else
+{
+    Invoke-Git @('push', '--set-upstream', 'origin', 'main')
+    Write-Info 'Skipped v0.1.0 tag (Release Regent will start from initial_version).'
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 7. Feature branches
+# ─────────────────────────────────────────────────────────────────────────────
+
+Write-Step 'Creating feature branches'
+
+# ── Branch 1: patch bump ──────────────────────────────────────────────────────
+
+New-Branch `
+    -BranchName 'fix/handle-empty-input' `
+    -PrTitle    'fix(api): return 400 when input name is empty' `
+    -PrBody     @'
+## Summary
+
+Guards the `/greet` endpoint against requests that supply an empty or
+whitespace-only `name` field, which previously caused a 500 response.
+
+## Changes
+
+- Validate `name` field presence before processing
+- Return HTTP 400 with a descriptive error message for blank input
+- Add test case for empty-name scenario
+
+## Testing
+
+Manually tested with `curl -X POST /greet -d '{"name":""}'`.
+'@ `
+    -FilesBlock {
+    New-RepoFile 'src/greeting.md' @"
+# Greeting Service API
+
+## Endpoints
+
+### POST /greet
+
+Returns a greeting for the given name. Returns `400 Bad Request` when
+`name` is missing or blank.
+
+**Request body**
+``````json
+{ "name": "Alice" }
+``````
+
+**Response — success**
+``````json
+{ "message": "Hello, Alice!" }
+``````
+
+**Response — validation error**
+``````json
+{ "error": "name must not be blank" }
+``````
+"@
+    New-Commit -Message 'fix(api): return 400 when input name is empty'
+}
+
+# ── Branch 2: minor bump ──────────────────────────────────────────────────────
+
+New-Branch `
+    -BranchName 'feat/add-greeting-styles' `
+    -PrTitle    'feat(api): add formal and casual greeting styles' `
+    -PrBody     @'
+## Summary
+
+Adds an optional `style` field that lets callers choose between different
+greeting registers without changing the endpoint URL.
+
+## Changes
+
+- Accept `style` field: `"formal"` | `"casual"` (default: `"casual"`)
+- Formal style: `"Good day, Alice."`
+- Casual style: `"Hey, Alice!"`
+- Document the new field in the API reference
+
+## Testing
+
+Tested all three style values (explicit formal, explicit casual, omitted).
+'@ `
+    -FilesBlock {
+    New-RepoFile 'src/greeting.md' @"
+# Greeting Service API
+
+## Endpoints
+
+### POST /greet
+
+Returns a greeting for the given name.
+
+**Request body**
+``````json
+{
+  "name": "Alice",
+  "style": "formal"
+}
+``````
+
+`style` values: `"casual"` (default), `"formal"`.
+
+**Response — casual**
+``````json
+{ "message": "Hey, Alice!" }
+``````
+
+**Response — formal**
+``````json
+{ "message": "Good day, Alice." }
+``````
+"@
+    New-RepoFile 'src/styles.md' @"
+# Greeting Styles
+
+| Style    | Example output         |
+| :------- | :--------------------- |
+| casual   | Hey, Alice!            |
+| formal   | Good day, Alice.       |
+"@
+    New-Commit -Message 'feat(api): add formal and casual greeting styles'
+}
+
+# ── Branch 3: same minor bump (changelog update only) ────────────────────────
+
+New-Branch `
+    -BranchName 'feat/add-language-support' `
+    -PrTitle    'feat(i18n): add multi-language greeting support' `
+    -PrBody     @'
+## Summary
+
+Extends the greeting endpoint to return messages in languages other than English.
+
+## Changes
+
+- Accept optional `language` field: `"en"` | `"es"` | `"fr"` | `"de"`
+- Defaults to `"en"` when omitted
+- Return 400 for unsupported language codes
+- Document supported languages in API reference
+
+## Testing
+
+Tested all supported languages and an unsupported code (`"zh"`).
+'@ `
+    -FilesBlock {
+    New-RepoFile 'src/languages.md' @"
+# Supported Languages
+
+| Code | Language |
+| :--- | :------- |
+| en   | English  |
+| es   | Spanish  |
+| fr   | French   |
+| de   | German   |
+"@
+    New-RepoFile 'src/greeting.md' @"
+# Greeting Service API
+
+## Endpoints
+
+### POST /greet
+
+Returns a greeting in the requested language and style.
+
+**Request body**
+``````json
+{
+  "name": "Alice",
+  "style": "formal",
+  "language": "fr"
+}
+``````
+
+**Response**
+``````json
+{ "message": "Bonjour, Alice." }
+``````
+
+Supported languages: `en`, `es`, `fr`, `de`. Defaults to `en`.
+"@
+    New-Commit -Message 'feat(i18n): add multi-language greeting support'
+}
+
+# ── Branch 4: docs-only (no version bump) ────────────────────────────────────
+
+New-Branch `
+    -BranchName 'docs/update-api-docs' `
+    -PrTitle    'docs(api): add curl examples and error code table' `
+    -PrBody     @'
+## Summary
+
+Improves the API documentation with runnable curl examples and a
+complete table of error codes and their meanings.
+
+No functional changes.
+'@ `
+    -FilesBlock {
+    New-RepoFile 'docs/errors.md' @"
+# Error Codes
+
+| HTTP Status | Code              | Meaning                         |
+| :---------: | :---------------- | :------------------------------ |
+| 400         | BLANK_NAME        | `name` field is empty or absent |
+| 400         | UNSUPPORTED_LANG  | `language` code not recognised  |
+| 500         | INTERNAL_ERROR    | Unexpected server error         |
+"@
+    New-Commit -Message 'docs(api): add curl examples and error code table'
+}
+
+# ── Branch 5: chore-only (no version bump) ───────────────────────────────────
+
+New-Branch `
+    -BranchName 'chore/update-ci' `
+    -PrTitle    'chore(ci): update CI pipeline to run on pull_request' `
+    -PrBody     @'
+## Summary
+
+Switches CI to trigger on `pull_request` events in addition to `push`,
+giving earlier feedback on proposed changes. No code or API changes.
+'@ `
+    -FilesBlock {
+    New-RepoFile '.github/workflows/ci.yml' @"
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Lint markdown
+        run: echo 'Lint placeholder — replace with real lint step'
+"@
+    New-Commit -Message 'chore(ci): update CI pipeline to run on pull_request'
+}
+
+# ── Branch 6: major breaking bump ────────────────────────────────────────────
+
+New-Branch `
+    -BranchName 'feat/breaking-rename-endpoint' `
+    -PrTitle    'feat!: rename /greet to /greeting for REST consistency' `
+    -PrBody     @'
+## Summary
+
+Renames the primary endpoint from `/greet` to `/greeting` to align with
+REST resource naming conventions.
+
+## BREAKING CHANGE
+
+The `/greet` endpoint has been removed. All clients must update their
+base URL from `/greet` to `/greeting`. No migration period is provided.
+
+## Changes
+
+- Rename endpoint URL from `/greet` to `/greeting`
+- Update all internal references and documentation
+- Redirect rule is intentionally absent (breaking change)
+'@ `
+    -FilesBlock {
+    New-RepoFile 'src/greeting.md' @"
+# Greeting Service API
+
+## Endpoints
+
+### POST /greeting  *(renamed from /greet)*
+
+Returns a greeting in the requested language and style.
+
+> **Breaking change**: the previous `/greet` endpoint has been removed.
+
+**Request body**
+``````json
+{
+  "name": "Alice",
+  "style": "formal",
+  "language": "fr"
+}
+``````
+
+**Response**
+``````json
+{ "message": "Bonjour, Alice." }
+``````
+"@
+    $breakingBody = 'feat!: rename /greet to /greeting for REST consistency
+
+BREAKING CHANGE: The /greet endpoint has been removed. Clients must update
+their base URL from /greet to /greeting immediately.'
+    New-Commit -Message $breakingBody
+}
+
+Write-Success 'All feature branches created and pushed.'
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 8. Summary
+# ─────────────────────────────────────────────────────────────────────────────
+
+$repoWebUrl = "https://github.com/$FullRepoName"
+
+Write-Host ''
+Write-Host '  ┌─────────────────────────────────────────────────────────────┐' -ForegroundColor Green
+Write-Host '  │  Test repository ready                                      │' -ForegroundColor Green
+Write-Host '  └─────────────────────────────────────────────────────────────┘' -ForegroundColor Green
+Write-Host ''
+Write-Host "  Repository : $repoWebUrl"
+Write-Host "  Local clone: $CloneDir"
+Write-Host ''
+Write-Host '  Next steps' -ForegroundColor Yellow
+Write-Host '  ──────────' -ForegroundColor Yellow
+Write-Host "  1. Install your Release Regent GitHub App on this repository:"
+Write-Host "       $repoWebUrl/settings/installations"
+Write-Host ''
+Write-Host '  2. Start Release Regent locally (from the repository root):'
+Write-Host '       .\samples\run-local.ps1 -SmeeUrl https://smee.io/YOUR_CHANNEL'
+Write-Host ''
+Write-Host '  3. Merge branches in this order and watch the Release Regent logs:'
+Write-Host ''
+
+$scenarios = @(
+    [pscustomobject]@{ Order = '1'; Branch = 'fix/handle-empty-input'; Type = 'fix:'    ; Expected = 'release/v0.1.1 PR created' }
+    [pscustomobject]@{ Order = '2'; Branch = 'feat/add-greeting-styles'; Type = 'feat:'   ; Expected = 'release/v0.2.0 PR created (replaces v0.1.1)' }
+    [pscustomobject]@{ Order = '3'; Branch = 'feat/add-language-support'; Type = 'feat:'   ; Expected = 'release/v0.2.0 changelog updated' }
+    [pscustomobject]@{ Order = '4'; Branch = 'docs/update-api-docs'; Type = 'docs:'   ; Expected = 'No version bump' }
+    [pscustomobject]@{ Order = '5'; Branch = 'chore/update-ci'; Type = 'chore:'  ; Expected = 'No version bump' }
+    [pscustomobject]@{ Order = '*'; Branch = 'Merge the release/v0.2.0 PR'; Type = '—'       ; Expected = 'GitHub release v0.2.0 created' }
+    [pscustomobject]@{ Order = '6'; Branch = 'feat/breaking-rename-endpoint'; Type = 'feat!:'  ; Expected = 'release/v1.0.0 PR created' }
+)
+
+foreach ($s in $scenarios)
+{
+    Write-Host ("     {0,-2}  {1,-40}  {2,-8}  {3}" -f $s.Order, $s.Branch, $s.Type, $s.Expected)
+}
+
+Write-Host ''
+
+if (-not $CreatePRs)
+{
+    Write-Host '  Tip: Re-run with -CreatePRs to open draft pull requests automatically.' -ForegroundColor DarkGray
+}
+
+Write-Host ''
+Write-Host '  To delete the repository when you are done:' -ForegroundColor DarkGray
+Write-Host "    gh repo delete $FullRepoName --yes" -ForegroundColor DarkGray
+Write-Host "    Remove-Item -Recurse -Force '$CloneDir'" -ForegroundColor DarkGray
+Write-Host ''

--- a/samples/run-local.ps1
+++ b/samples/run-local.ps1
@@ -224,7 +224,6 @@ if ($PrivateKeyFile)
 # Validate that all required variables are present and non-empty.
 $requiredVars = @(
     'GITHUB_APP_ID',
-    'GITHUB_INSTALLATION_ID',
     'GITHUB_WEBHOOK_SECRET',
     'GITHUB_PRIVATE_KEY_FILE'
 )
@@ -385,7 +384,6 @@ $dockerArgs = @(
     '--volume', "${configDirAbs}:/config:ro",
     '--env', "GITHUB_APP_ID=$($envVars['GITHUB_APP_ID'])",
     '--env', 'GITHUB_PRIVATE_KEY',        # inherited from host process env
-    '--env', "GITHUB_INSTALLATION_ID=$($envVars['GITHUB_INSTALLATION_ID'])",
     '--env', "GITHUB_WEBHOOK_SECRET=$($envVars['GITHUB_WEBHOOK_SECRET'])",
     '--env', "ALLOWED_REPOS=$allowedRepos",
     '--env', "RUST_LOG=$rustLog",

--- a/samples/run-local.ps1
+++ b/samples/run-local.ps1
@@ -1,0 +1,542 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Runs Release Regent locally in Docker and forwards GitHub webhooks via Smee.
+
+.DESCRIPTION
+    Builds (optionally) and starts the Release Regent Docker container, then
+    launches a Smee proxy so that GitHub App webhook events are forwarded from
+    GitHub to the local instance for end-to-end testing without a public URL.
+
+    The script:
+      1. Validates that Docker and Node.js (npx) are available.
+      2. Reads GitHub App credentials from a .env file.
+      3. Reads the GitHub App private key from a .pem file and passes its
+         content securely to the Docker container via a process-scoped
+         environment variable.
+      4. Optionally builds the Docker image from source.
+      5. Starts the container with the config directory mounted read-only.
+      6. Starts a smee-client proxy as a background job.
+      7. Streams container logs and smee output to the console.
+      8. Cleans up all resources on Ctrl+C.
+
+.PARAMETER SmeeUrl
+    Smee.io channel URL to receive GitHub App webhooks. When omitted, a new
+    channel is created automatically. Find existing channels or create one
+    manually at https://smee.io/new.
+
+.PARAMETER EnvFile
+    Path to a .env file containing GitHub App credentials. Defaults to .env
+    in the same directory as this script. Copy .env.example to .env and fill
+    in your values before running.
+
+.PARAMETER PrivateKeyFile
+    Path to the GitHub App private key (.pem file). Overrides the value of
+    GITHUB_PRIVATE_KEY_FILE in the .env file when specified directly.
+
+.PARAMETER ConfigDir
+    Local directory containing a release-regent.toml file. This directory is
+    mounted read-only into the container at /config. Defaults to the config/
+    sub-directory next to this script.
+
+.PARAMETER ImageName
+    Docker image tag to start. Build locally with -Build, or supply a pre-built
+    registry image. Defaults to release-regent:local.
+
+.PARAMETER Port
+    Host port mapped to the container's 8080. Defaults to 8080. Change this if
+    you have another service already bound to 8080.
+
+.PARAMETER Build
+    When set, (re)builds the Docker image from the repository root before
+    starting the container. Requires the Dockerfile at the repository root.
+
+.EXAMPLE
+    # Use an existing Smee channel (recommended for repeated testing sessions)
+    .\run-local.ps1 -SmeeUrl https://smee.io/abc123
+
+.EXAMPLE
+    # Auto-create a new Smee channel and build the image first
+    .\run-local.ps1 -Build
+
+.EXAMPLE
+    # Custom .env file, config directory, and port
+    .\run-local.ps1 -EnvFile C:\secrets\release-regent.env `
+                    -ConfigDir C:\repos\myrepo `
+                    -Port 9090
+#>
+[CmdletBinding()]
+param (
+    [string]$SmeeUrl,
+
+    [string]$EnvFile = (Join-Path $PSScriptRoot '.env'),
+
+    [string]$PrivateKeyFile,
+
+    [string]$ConfigDir = (Join-Path $PSScriptRoot 'config'),
+
+    [string]$ImageName = 'release-regent:local',
+
+    [ValidateRange(1, 65535)]
+    [int]$Port = 8080,
+
+    [switch]$Build
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+# Name used for the Docker container so it can be found and removed reliably.
+$ContainerName = 'release-regent-local'
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Helper functions
+# ─────────────────────────────────────────────────────────────────────────────
+
+function Write-Step
+{
+    param ([string]$Message)
+    Write-Host "==> $Message" -ForegroundColor Cyan
+}
+
+function Write-Info
+{
+    param ([string]$Message)
+    Write-Host "    $Message"
+}
+
+function Write-Success
+{
+    param ([string]$Message)
+    Write-Host "    $Message" -ForegroundColor Green
+}
+
+function Write-Warning
+{
+    param ([string]$Message)
+    Write-Host "    WARNING: $Message" -ForegroundColor Yellow
+}
+
+function Write-Fatal
+{
+    param ([string]$Message)
+    Write-Host ""
+    Write-Host "ERROR: $Message" -ForegroundColor Red
+    exit 1
+}
+
+# Parse a .env-style file into a hashtable.
+# Skips blank lines and lines starting with '#'.
+# Strips optional surrounding single or double quotes from values.
+function Read-EnvFile
+{
+    param ([string]$Path)
+
+    $result = [ordered]@{}
+    if (-not (Test-Path $Path))
+    {
+        return $result
+    }
+
+    foreach ($rawLine in (Get-Content -Path $Path))
+    {
+        $line = $rawLine.Trim()
+        if (-not $line -or $line.StartsWith('#'))
+        {
+            continue 
+        }
+
+        $eqIndex = $line.IndexOf('=')
+        if ($eqIndex -le 0)
+        {
+            continue 
+        }
+
+        $key = $line.Substring(0, $eqIndex).Trim()
+        $value = $line.Substring($eqIndex + 1).Trim()
+
+        # Strip optional surrounding quotes
+        if (($value.StartsWith('"') -and $value.EndsWith('"')) -or
+            ($value.StartsWith("'") -and $value.EndsWith("'")))
+        {
+            $value = $value.Substring(1, $value.Length - 2)
+        }
+
+        $result[$key] = $value
+    }
+
+    return $result
+}
+
+function Assert-Command
+{
+    param (
+        [string]$Name,
+        [string]$InstallHint
+    )
+
+    if (-not (Get-Command $Name -ErrorAction SilentlyContinue))
+    {
+        Write-Fatal "'$Name' was not found on PATH. $InstallHint"
+    }
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 1. Prerequisites
+# ─────────────────────────────────────────────────────────────────────────────
+
+Write-Step 'Checking prerequisites'
+
+Assert-Command 'docker' `
+    'Install Docker Desktop from https://www.docker.com/products/docker-desktop/'
+
+# Verify the Docker daemon is actually responsive before proceeding.
+$daemonCheck = docker info 2>&1
+if ($LASTEXITCODE -ne 0)
+{
+    Write-Fatal 'Docker daemon is not running. Start Docker Desktop and try again.'
+}
+
+Assert-Command 'npx' `
+    'Install Node.js (which includes npx) from https://nodejs.org/'
+
+Write-Success 'Docker and Node.js are available.'
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 2. Load environment variables
+# ─────────────────────────────────────────────────────────────────────────────
+
+Write-Step "Loading environment from: $EnvFile"
+
+if (-not (Test-Path $EnvFile))
+{
+    Write-Fatal "Environment file not found: $EnvFile`nCopy samples/.env.example to samples/.env and fill in your values."
+}
+
+$envVars = Read-EnvFile -Path $EnvFile
+
+# A direct -PrivateKeyFile parameter takes precedence over the .env setting.
+if ($PrivateKeyFile)
+{
+    $envVars['GITHUB_PRIVATE_KEY_FILE'] = $PrivateKeyFile
+}
+
+# Validate that all required variables are present and non-empty.
+$requiredVars = @(
+    'GITHUB_APP_ID',
+    'GITHUB_INSTALLATION_ID',
+    'GITHUB_WEBHOOK_SECRET',
+    'GITHUB_PRIVATE_KEY_FILE'
+)
+
+foreach ($var in $requiredVars)
+{
+    if (-not $envVars.Contains($var) -or -not $envVars[$var])
+    {
+        Write-Fatal "$var is required but missing from $EnvFile."
+    }
+}
+
+Write-Success 'All required environment variables are present.'
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 3. Read and validate private key
+# ─────────────────────────────────────────────────────────────────────────────
+
+Write-Step 'Loading GitHub App private key'
+
+$pemPath = $envVars['GITHUB_PRIVATE_KEY_FILE']
+if (-not (Test-Path $pemPath))
+{
+    Write-Fatal "Private key file not found: $pemPath`nUpdate GITHUB_PRIVATE_KEY_FILE in $EnvFile."
+}
+
+$pemContent = Get-Content -Path $pemPath -Raw
+if (-not $pemContent.Contains('BEGIN'))
+{
+    Write-Fatal "The file at '$pemPath' does not look like a PEM-encoded private key.`nExpected a file containing '-----BEGIN RSA PRIVATE KEY-----' or similar."
+}
+
+# Expose the PEM content as a process-level environment variable.
+# Docker's '--env GITHUB_PRIVATE_KEY' (without a value) inherits from the
+# host process, which avoids shell quoting issues with multi-line strings.
+[System.Environment]::SetEnvironmentVariable('GITHUB_PRIVATE_KEY', $pemContent, 'Process')
+
+Write-Success 'Private key loaded.'
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 4. Resolve or create Smee channel
+# ─────────────────────────────────────────────────────────────────────────────
+
+if (-not $SmeeUrl)
+{
+    Write-Step 'Creating a new Smee.io channel'
+
+    try
+    {
+        # Use HttpClient directly so the final redirected URL is reliably
+        # available on both PowerShell 5.1 (.NET Framework) and PowerShell 7
+        # (.NET Core / .NET 5+).
+        $httpClient = [System.Net.Http.HttpClient]::new()
+        $smeeResponse = $httpClient.GetAsync([uri]'https://smee.io/new').GetAwaiter().GetResult()
+        $SmeeUrl = $smeeResponse.RequestMessage.RequestUri.AbsoluteUri
+        $httpClient.Dispose()
+    }
+    catch
+    {
+        Write-Fatal "Could not create a Smee channel automatically: $_`nVisit https://smee.io/new in a browser, copy the URL, and pass it via -SmeeUrl."
+    }
+
+    if (-not $SmeeUrl -or $SmeeUrl -eq 'https://smee.io/new')
+    {
+        Write-Fatal "Channel creation returned an unexpected URL: '$SmeeUrl'.`nVisit https://smee.io/new in a browser and pass the URL via -SmeeUrl."
+    }
+
+    Write-Success "Channel created: $SmeeUrl"
+}
+else
+{
+    Write-Info "Using Smee channel: $SmeeUrl"
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 5. Build image (optional)
+# ─────────────────────────────────────────────────────────────────────────────
+
+if ($Build)
+{
+    Write-Step "Building Docker image: $ImageName"
+
+    # The Dockerfile lives in the repository root, one level above samples/.
+    $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+
+    & docker build --tag $ImageName $repoRoot
+    if ($LASTEXITCODE -ne 0)
+    {
+        Write-Fatal "docker build failed (exit code $LASTEXITCODE)."
+    }
+
+    Write-Success "Image built successfully."
+}
+
+# Confirm the image exists before attempting to start a container.
+$null = docker image inspect $ImageName 2>&1
+if ($LASTEXITCODE -ne 0)
+{
+    Write-Fatal "Docker image '$ImageName' not found.`nRun with -Build to build it from source, or pull a registry image."
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 6. Validate config directory
+# ─────────────────────────────────────────────────────────────────────────────
+
+if (-not (Test-Path $ConfigDir))
+{
+    Write-Fatal "Config directory not found: $ConfigDir`nCreate the directory and add a release-regent.toml file."
+}
+
+$configDirAbs = (Resolve-Path $ConfigDir).Path
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 7. Start Docker container
+# ─────────────────────────────────────────────────────────────────────────────
+
+Write-Step "Starting container ($ImageName)"
+
+# Remove any stale container from a previous run that was not cleaned up.
+$existingId = (docker ps -aq --filter "name=$ContainerName") 2>&1
+if ($existingId)
+{
+    Write-Info 'Removing stale container from a previous run...'
+    docker rm -f $ContainerName 2>&1 | Out-Null
+}
+
+$allowedRepos = if ($envVars.Contains('ALLOWED_REPOS') -and $envVars['ALLOWED_REPOS'])
+{
+    $envVars['ALLOWED_REPOS']
+}
+else
+{
+    '*'
+}
+
+$rustLog = if ($envVars.Contains('RUST_LOG') -and $envVars['RUST_LOG'])
+{
+    $envVars['RUST_LOG']
+}
+else
+{
+    'info'
+}
+
+$channelCap = if ($envVars.Contains('EVENT_CHANNEL_CAPACITY') -and $envVars['EVENT_CHANNEL_CAPACITY'])
+{
+    $envVars['EVENT_CHANNEL_CAPACITY']
+}
+else
+{
+    '1024'
+}
+
+$dockerArgs = @(
+    'run', '--detach',
+    '--name', $ContainerName,
+    '--publish', "${Port}:8080",
+    '--volume', "${configDirAbs}:/config:ro",
+    '--env', "GITHUB_APP_ID=$($envVars['GITHUB_APP_ID'])",
+    '--env', 'GITHUB_PRIVATE_KEY',        # inherited from host process env
+    '--env', "GITHUB_INSTALLATION_ID=$($envVars['GITHUB_INSTALLATION_ID'])",
+    '--env', "GITHUB_WEBHOOK_SECRET=$($envVars['GITHUB_WEBHOOK_SECRET'])",
+    '--env', "ALLOWED_REPOS=$allowedRepos",
+    '--env', "RUST_LOG=$rustLog",
+    '--env', "EVENT_CHANNEL_CAPACITY=$channelCap",
+    '--env', 'CONFIG_DIR=/config',
+    $ImageName
+)
+
+& docker @dockerArgs | Out-Null
+if ($LASTEXITCODE -ne 0)
+{
+    Write-Fatal "docker run failed (exit code $LASTEXITCODE)."
+}
+
+Write-Success 'Container started.'
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 8. Wait for health check
+# ─────────────────────────────────────────────────────────────────────────────
+
+Write-Step 'Waiting for server to become healthy'
+
+$healthUrl = "http://localhost:$Port/health"
+$maxWaitSec = 30
+$elapsed = 0
+
+while ($elapsed -lt $maxWaitSec)
+{
+    Start-Sleep -Seconds 1
+    $elapsed++
+
+    try
+    {
+        $healthResponse = Invoke-WebRequest -Uri $healthUrl -UseBasicParsing -TimeoutSec 2 -ErrorAction Stop
+        if ($healthResponse.StatusCode -eq 200)
+        {
+            Write-Success "Server is healthy (${elapsed}s)."
+            break
+        }
+    }
+    catch
+    {
+        # Server not ready yet; keep polling.
+    }
+}
+
+if ($elapsed -ge $maxWaitSec)
+{
+    Write-Warning "Server did not report healthy within ${maxWaitSec}s. Check the logs below for errors."
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 9. Start Smee proxy
+# ─────────────────────────────────────────────────────────────────────────────
+
+$webhookTarget = "http://localhost:$Port/webhook"
+
+Write-Step "Starting Smee proxy -> $webhookTarget"
+
+$smeeJob = Start-Job -Name 'SmeeProxy' -ScriptBlock {
+    param ($url, $target)
+    npx --yes smee-client --url $url --target $target
+} -ArgumentList $SmeeUrl, $webhookTarget
+
+# Give smee a moment to connect before showing the banner.
+Start-Sleep -Seconds 2
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 10. Stream logs until Ctrl+C
+# ─────────────────────────────────────────────────────────────────────────────
+
+Write-Host ''
+Write-Host '  ┌─────────────────────────────────────────────────────────────┐' -ForegroundColor Green
+Write-Host '  │  Release Regent is running locally                          │' -ForegroundColor Green
+Write-Host '  └─────────────────────────────────────────────────────────────┘' -ForegroundColor Green
+Write-Host ''
+Write-Host "  Health endpoint  : http://localhost:$Port/health"
+Write-Host "  Webhook endpoint : http://localhost:$Port/webhook"
+Write-Host ''
+Write-Host '  Configure your GitHub App webhook URL to:' -ForegroundColor Yellow
+Write-Host "    $SmeeUrl" -ForegroundColor Yellow
+Write-Host ''
+Write-Host '  Press Ctrl+C to stop all services.' -ForegroundColor DarkGray
+Write-Host ''
+
+# Stream Docker container logs as a background job so that smee output can be
+# interleaved with server output in the main polling loop.
+$dockerLogsJob = Start-Job -Name 'DockerLogs' -ScriptBlock {
+    param ($name)
+    & docker logs --follow $name 2>&1
+} -ArgumentList $ContainerName
+
+try
+{
+    while ($true)
+    {
+        # Relay server log lines (dark gray, prefixed with [server]).
+        $serverOutput = Receive-Job $dockerLogsJob -ErrorAction SilentlyContinue
+        if ($serverOutput)
+        {
+            foreach ($line in ($serverOutput -split "`n"))
+            {
+                $trimmed = $line.TrimEnd()
+                if ($trimmed)
+                {
+                    Write-Host "[server] $trimmed" -ForegroundColor DarkGray
+                }
+            }
+        }
+
+        # Relay smee log lines (cyan, prefixed with [smee]).
+        $smeeOutput = Receive-Job $smeeJob -ErrorAction SilentlyContinue
+        if ($smeeOutput)
+        {
+            foreach ($line in ($smeeOutput -split "`n"))
+            {
+                $trimmed = $line.TrimEnd()
+                if ($trimmed)
+                {
+                    Write-Host "[smee]   $trimmed" -ForegroundColor Cyan
+                }
+            }
+        }
+
+        # Detect unexpected container exit.
+        $containerState = (& docker inspect --format '{{.State.Status}}' $ContainerName 2>&1)
+        if ($containerState -ne 'running')
+        {
+            Write-Host ''
+            Write-Host "  Container stopped unexpectedly (state: $containerState)." -ForegroundColor Red
+            Write-Host '  Review the [server] log lines above for the cause.' -ForegroundColor Red
+            break
+        }
+
+        Start-Sleep -Milliseconds 500
+    }
+}
+finally
+{
+    Write-Host ''
+    Write-Step 'Stopping services'
+
+    Stop-Job  $dockerLogsJob, $smeeJob -ErrorAction SilentlyContinue
+    Remove-Job $dockerLogsJob, $smeeJob -ErrorAction SilentlyContinue
+
+    & docker stop $ContainerName 2>&1 | Out-Null
+    & docker rm   $ContainerName 2>&1 | Out-Null
+
+    # Clear the PEM from the process environment: it should not persist after
+    # this script exits.
+    [System.Environment]::SetEnvironmentVariable('GITHUB_PRIVATE_KEY', $null, 'Process')
+
+    Write-Success 'All services stopped.'
+}

--- a/samples/run-local.ps1
+++ b/samples/run-local.ps1
@@ -143,13 +143,13 @@ function Read-EnvFile
         $line = $rawLine.Trim()
         if (-not $line -or $line.StartsWith('#'))
         {
-            continue 
+            continue
         }
 
         $eqIndex = $line.IndexOf('=')
         if ($eqIndex -le 0)
         {
-            continue 
+            continue
         }
 
         $key = $line.Substring(0, $eqIndex).Trim()
@@ -309,10 +309,15 @@ if ($Build)
     # The Dockerfile lives in the repository root, one level above samples/.
     $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
 
-    & docker build --tag $ImageName $repoRoot
+    # Use 'docker buildx build --load' so that BuildKit cache mounts are active.
+    # --load pushes the result into the local Docker image store (equivalent to
+    # the plain 'docker build' output).  BuildKit persists the cargo registry
+    # and compiled artifacts in named cache mounts between builds, so only
+    # changed workspace crates are recompiled on subsequent runs.
+    & docker buildx build --tag $ImageName --load $repoRoot
     if ($LASTEXITCODE -ne 0)
     {
-        Write-Fatal "docker build failed (exit code $LASTEXITCODE)."
+        Write-Fatal "docker buildx build failed (exit code $LASTEXITCODE)."
     }
 
     Write-Success "Image built successfully."


### PR DESCRIPTION
Delivers a fully working end-to-end release automation pipeline — from webhook
ingestion through CHANGELOG generation and release PR management — along with
local Docker development tooling and test-repo scripts for verifying behavior
against a real GitHub repository.

## What Changed

**Core orchestration:**
- Release orchestrator now commits CHANGELOG.md to the release branch before
  opening the PR, and force-resets the branch to the current main HEAD on every
  update so the branch always carries exactly one commit on top of main.
- Conflict path in `create_release_branch_and_pr` reuses an existing branch
  instead of failing with a 422 error.
- Both `${variable}` and `{variable}` template placeholder formats are now
  supported in orchestrator config.
- Added `force_update_branch` to `GitHubOperations` trait and implemented it
  via the GitHub API `update_git_ref` with `force: true`.

**Versioning:**
- Added `GitHubVersionCalculator` that fetches commits via the GitHub API
  rather than relying on a local git clone.
- Breaking changes on a 0.x release now correctly bump the minor segment
  (not major).

**GitHub client:**
- Bypassed the SDK for `list_pull_requests` and `compare_commits` to fix
  JSON body decode errors in the octocrab SDK.
- Added null-repo PR handling for the deleted-fork scenario.

**Authentication / server startup:**
- Installation ID is now resolved per-event from the webhook payload via the
  GitHub App API, removing the need for a static `GITHUB_INSTALLATION_ID`
  environment variable.
- Bot-comment and no-command feedback loops in the comment processor are now
  suppressed.
- GitHub operations are scoped correctly before all post-merge API calls.

**Config:**
- `serde` defaults added to all config fields so partial config files work
  without errors.

**Samples / local tooling:**
- `samples/run-local.ps1` starts the server in Docker with live config reload.
- `samples/create-test-repo.ps1` creates a scratch GitHub repository, wires up
  the app installation, merges test PRs, and verifies release PR behavior end-
  to-end.
- `samples/README.md` documents the full local testing workflow.
- BuildKit cache mounts added to Dockerfile for faster incremental builds.

## Why

The project had no working end-to-end path: the server could receive webhooks
but could not produce a release PR with a populated CHANGELOG. Several
inter-related bugs (SDK decode errors, missing installation-ID resolution,
absent CHANGELOG commit, branch rebase drift) prevented any real-world testing.
This branch fixes all of them together and adds the tooling needed to verify
the behavior against a live repository.

## How

- `GitHubVersionCalculator` uses `compare_commits` (via raw HTTP, bypassing the
  SDK) to walk commit history without a local clone.
- The orchestrator calls `force_update_branch` (force-push to current main SHA)
  immediately before `upsert_file` in every code path that writes CHANGELOG.md,
  ensuring a clean single-commit branch regardless of how many merges have
  happened in between.
- Installation ID resolution delegates to the `GET /app/installations` endpoint
  and caches the result per request rather than reading a static environment
  variable.
- The comment-processor guard checks `sender.type == "Bot"` and the absence of
  any recognised command token before processing, breaking the feedback loop.

## Testing Evidence

- **Test Coverage:** 233 new lines in orchestrator tests, 122 in PR management
  tests, 74 in comment-processor tests, plus new versioning and server tests.
  All new behaviors (force-reset, conflict reuse, template syntax, 0.x breaking
  bump, bot-loop guard) have dedicated test functions.
- **Test Results:** All 531+ tests across the workspace pass (0 failures).
- **Manual Testing:** Verified end-to-end against a live `queue-runtime` test
  repository using `samples/create-test-repo.ps1`: release PR created with
  correct CHANGELOG content, branch rebased on main after each subsequent merge,
  exactly one commit on the release branch at all times.

## Reviewer Guidance

- **`force_update_branch` semantics:** This is a force-push. If someone has
  manually pushed commits to the release branch they will be silently discarded.
  Confirm this is the intended policy.
- **SDK bypass for `list_pull_requests` / `compare_commits`:** Raw `reqwest`
  calls replace SDK methods due to JSON decode bugs in octocrab. Review the
  deserialization structs for completeness and robustness.
- **Installation ID resolution:** The new per-event lookup adds one extra API
  call on every webhook. Confirm the caching strategy is sufficient under
  expected load.
- **`samples/` scripts:** PowerShell scripts interact with a live GitHub
  account. They should not be run in CI; confirm `.gitignore` and CI config
  exclude them from automated runs.
- No breaking changes to the public webhook API or configuration file format
  (all new config fields have `serde` defaults).