### PR TITLE
feat(versioning): consolidate bump logic and add atomic manifest file commits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2743,6 +2743,7 @@ dependencies = [
  "futures",
  "git-cliff-core",
  "git-conventional",
+ "regex",
  "release_regent_testing",
  "serde",
  "serde_json",
@@ -2752,6 +2753,7 @@ dependencies = [
  "tokio-test",
  "tokio-util",
  "toml 0.8.23",
+ "toml_edit",
  "tracing",
  "tracing-test",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.9"
 toml = "0.8"
+toml_edit = "0.22"
 
 # GitHub integration
 github-bot-sdk = { git = "https://github.com/pvandervelde/github-bot-sdk", rev = "5ea985e" }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -26,6 +26,8 @@ git-cliff-core = { version = "2.12", default-features = false, features = [
     "repo",
 ] }
 toml = { workspace = true }
+toml_edit = { workspace = true }
+regex = { workspace = true }
 
 [dev-dependencies]
 tokio-test = { workspace = true }

--- a/crates/core/src/comment_command_processor_tests.rs
+++ b/crates/core/src/comment_command_processor_tests.rs
@@ -495,6 +495,27 @@ impl GitHubOperations for TestGitHub {
         Ok(())
     }
 
+    async fn get_file_content(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _path: &str,
+        _branch: &str,
+    ) -> CoreResult<Option<String>> {
+        Ok(None)
+    }
+
+    async fn batch_commit_files(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _branch: &str,
+        _files: &[crate::traits::github_operations::FileUpdate],
+        _message: &str,
+    ) -> CoreResult<()> {
+        Ok(())
+    }
+
     fn scoped_to(&self, _installation_id: u64) -> Self {
         Self {
             state: Arc::clone(&self.state),

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -3,7 +3,7 @@
 //! This module handles loading and validating Release Regent configuration from
 //! YAML files with support for both application-wide and repository-specific settings.
 
-use crate::{CoreError, CoreResult};
+use crate::{manifest::ManifestFileConfig, CoreError, CoreResult};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::Path;
@@ -159,6 +159,12 @@ pub struct ReleasePrConfig {
     /// Whether to create PRs as drafts
     #[serde(default)]
     pub draft: bool,
+    /// Manifest files to update on the release branch.
+    #[serde(default)]
+    pub manifest_files: Vec<ManifestFileConfig>,
+    /// Whether to auto-detect standard language manifests (Cargo.toml, package.json, etc.).
+    #[serde(default = "default_auto_detect_manifests")]
+    pub auto_detect_manifests: bool,
 }
 
 fn default_pr_title_template() -> String {
@@ -167,6 +173,9 @@ fn default_pr_title_template() -> String {
 fn default_pr_body_template() -> String {
     "## Changelog\n\n${changelog}".to_string()
 }
+fn default_auto_detect_manifests() -> bool {
+    true
+}
 
 impl Default for ReleasePrConfig {
     fn default() -> Self {
@@ -174,12 +183,14 @@ impl Default for ReleasePrConfig {
             title_template: default_pr_title_template(),
             body_template: default_pr_body_template(),
             draft: false,
+            manifest_files: Vec::new(),
+            auto_detect_manifests: default_auto_detect_manifests(),
         }
     }
 }
 
 /// Main Release Regent configuration
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ReleaseRegentConfig {
     /// Core settings
     #[serde(default)]
@@ -303,19 +314,6 @@ pub enum VersioningStrategy {
     Conventional,
     /// Use external script/command
     External,
-}
-
-impl Default for ReleaseRegentConfig {
-    fn default() -> Self {
-        Self {
-            core: CoreConfig::default(),
-            release_pr: ReleasePrConfig::default(),
-            releases: ReleasesConfig::default(),
-            error_handling: ErrorHandlingConfig::default(),
-            notifications: NotificationConfig::default(),
-            versioning: VersioningConfig::default(),
-        }
-    }
 }
 
 impl ReleaseRegentConfig {

--- a/crates/core/src/default_version_calculator.rs
+++ b/crates/core/src/default_version_calculator.rs
@@ -22,7 +22,7 @@ use crate::{
         VersionCalculator as VersionCalculatorTrait, VersionContext, VersioningStrategy,
     },
     versioning::{
-        ConventionalCommit, SemanticVersion, VersionBump as LocalVersionBump,
+        apply_semver_bump, ConventionalCommit, SemanticVersion, VersionBump as LocalVersionBump,
         VersionCalculator as ConventionalCalculator,
     },
     CoreError, CoreResult,
@@ -72,7 +72,6 @@ impl DefaultVersionCalculator {
     }
 
     /// Map from the trait-layer `VersionBump` to core `versioning::VersionBump`.
-    #[allow(dead_code)] // only called from tests; kept for symmetry with local_to_trait_bump
     fn trait_to_local_bump(bump: &TraitVersionBump) -> LocalVersionBump {
         match bump {
             TraitVersionBump::Major => LocalVersionBump::Major,
@@ -411,6 +410,9 @@ impl VersionCalculatorTrait for DefaultVersionCalculator {
 
     /// Apply a version bump to an existing version.
     ///
+    /// Delegates to [`apply_semver_bump`] — the single canonical arithmetic
+    /// implementation — after converting from the trait-layer bump type.
+    ///
     /// When `major == 0` (pre-1.0 development), a `Major` bump is treated as a
     /// `Minor` bump so the project stays on `0.x` until it deliberately ships 1.0.0.
     fn apply_version_bump(
@@ -420,37 +422,8 @@ impl VersionCalculatorTrait for DefaultVersionCalculator {
         prerelease: Option<String>,
         build: Option<String>,
     ) -> CoreResult<SemanticVersion> {
-        let mut next = match bump_type {
-            TraitVersionBump::Major if current_version.major == 0 => SemanticVersion {
-                major: 0,
-                minor: current_version.minor + 1,
-                patch: 0,
-                prerelease: None,
-                build: None,
-            },
-            TraitVersionBump::Major => SemanticVersion {
-                major: current_version.major + 1,
-                minor: 0,
-                patch: 0,
-                prerelease: None,
-                build: None,
-            },
-            TraitVersionBump::Minor => SemanticVersion {
-                major: current_version.major,
-                minor: current_version.minor + 1,
-                patch: 0,
-                prerelease: None,
-                build: None,
-            },
-            TraitVersionBump::Patch => SemanticVersion {
-                major: current_version.major,
-                minor: current_version.minor,
-                patch: current_version.patch + 1,
-                prerelease: None,
-                build: None,
-            },
-            TraitVersionBump::None => current_version,
-        };
+        let local_bump = Self::trait_to_local_bump(&bump_type);
+        let mut next = apply_semver_bump(&current_version, local_bump);
         next.prerelease = prerelease;
         next.build = build;
         Ok(next)

--- a/crates/core/src/github_version_calculator.rs
+++ b/crates/core/src/github_version_calculator.rs
@@ -16,7 +16,10 @@ use crate::{
             VersionCalculator as VersionCalculatorTrait, VersionContext, VersioningStrategy,
         },
     },
-    versioning::{SemanticVersion, VersionCalculator as ConventionalCalculator},
+    versioning::{
+        apply_semver_bump, SemanticVersion, VersionBump as LocalVersionBump,
+        VersionCalculator as ConventionalCalculator,
+    },
     CoreError, CoreResult,
 };
 use async_trait::async_trait;
@@ -146,6 +149,9 @@ impl<G: GitHubOperations> GitHubVersionCalculator<G> {
 
     /// Apply a version bump to a semantic version, returning the bumped version.
     ///
+    /// Delegates to [`apply_semver_bump`] — the single canonical semver
+    /// arithmetic — after mapping from the trait-layer bump type.
+    ///
     /// When `major == 0` (pre-1.0 development), a `Major` bump is treated as a
     /// `Minor` bump. Semver 2.0 allows breaking changes within major version 0 to
     /// only advance the minor component so that projects stay on `0.x` until they
@@ -156,37 +162,13 @@ impl<G: GitHubOperations> GitHubVersionCalculator<G> {
         prerelease: Option<String>,
         build: Option<String>,
     ) -> CoreResult<SemanticVersion> {
-        let mut next = match bump {
-            TraitVersionBump::Major if current.major == 0 => SemanticVersion {
-                major: 0,
-                minor: current.minor + 1,
-                patch: 0,
-                prerelease: None,
-                build: None,
-            },
-            TraitVersionBump::Major => SemanticVersion {
-                major: current.major + 1,
-                minor: 0,
-                patch: 0,
-                prerelease: None,
-                build: None,
-            },
-            TraitVersionBump::Minor => SemanticVersion {
-                major: current.major,
-                minor: current.minor + 1,
-                patch: 0,
-                prerelease: None,
-                build: None,
-            },
-            TraitVersionBump::Patch => SemanticVersion {
-                major: current.major,
-                minor: current.minor,
-                patch: current.patch + 1,
-                prerelease: None,
-                build: None,
-            },
-            TraitVersionBump::None => current,
+        let local_bump = match bump {
+            TraitVersionBump::Major => LocalVersionBump::Major,
+            TraitVersionBump::Minor => LocalVersionBump::Minor,
+            TraitVersionBump::Patch => LocalVersionBump::Patch,
+            TraitVersionBump::None => LocalVersionBump::None,
         };
+        let mut next = apply_semver_bump(&current, local_bump);
         next.prerelease = prerelease;
         next.build = build;
         Ok(next)

--- a/crates/core/src/github_version_calculator.rs
+++ b/crates/core/src/github_version_calculator.rs
@@ -156,6 +156,7 @@ impl<G: GitHubOperations> GitHubVersionCalculator<G> {
     /// `Minor` bump. Semver 2.0 allows breaking changes within major version 0 to
     /// only advance the minor component so that projects stay on `0.x` until they
     /// deliberately ship their first stable `1.0.0` release.
+    #[allow(clippy::result_large_err)] // CoreError is intentionally large; established pattern
     fn bump_version(
         current: SemanticVersion,
         bump: &TraitVersionBump,

--- a/crates/core/src/github_version_calculator.rs
+++ b/crates/core/src/github_version_calculator.rs
@@ -174,24 +174,6 @@ impl<G: GitHubOperations> GitHubVersionCalculator<G> {
         next.build = build;
         Ok(next)
     }
-
-    /// Map from core `versioning::VersionBump` to the trait-layer `VersionBump`.
-    ///
-    /// This conversion helper is not yet called by any production code path — the
-    /// trait's `VersionBump` is currently derived directly from
-    /// `ConventionalCommit.breaking_change` / `commit_type` in
-    /// [`to_commit_analysis`].  It is retained here because future refactors may
-    /// need to convert an already-computed `versioning::VersionBump` (e.g., when
-    /// integrating with `DefaultVersionCalculator` output) into the trait type.
-    #[allow(dead_code)]
-    fn local_to_trait_bump(bump: &crate::versioning::VersionBump) -> TraitVersionBump {
-        match bump {
-            crate::versioning::VersionBump::Major => TraitVersionBump::Major,
-            crate::versioning::VersionBump::Minor => TraitVersionBump::Minor,
-            crate::versioning::VersionBump::Patch => TraitVersionBump::Patch,
-            crate::versioning::VersionBump::None => TraitVersionBump::None,
-        }
-    }
 }
 
 #[async_trait]

--- a/crates/core/src/github_version_calculator_tests.rs
+++ b/crates/core/src/github_version_calculator_tests.rs
@@ -368,6 +368,27 @@ impl GitHubOperations for StubGitHub {
         Ok(())
     }
 
+    async fn get_file_content(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _path: &str,
+        _branch: &str,
+    ) -> CoreResult<Option<String>> {
+        Ok(None)
+    }
+
+    async fn batch_commit_files(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _branch: &str,
+        _files: &[crate::traits::github_operations::FileUpdate],
+        _message: &str,
+    ) -> CoreResult<()> {
+        Ok(())
+    }
+
     fn scoped_to(&self, _installation_id: u64) -> Self {
         self.clone()
     }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -209,6 +209,7 @@ pub mod config;
 pub(crate) mod default_version_calculator;
 pub mod errors;
 pub(crate) mod github_version_calculator;
+pub mod manifest;
 pub mod release_automator;
 pub mod release_orchestrator;
 pub mod traits;
@@ -217,6 +218,7 @@ pub mod versioning;
 pub use default_version_calculator::DefaultVersionCalculator;
 pub use errors::{CoreError, CoreResult};
 pub use github_version_calculator::GitHubVersionCalculator;
+pub use manifest::{ManifestFileConfig, ManifestFormat};
 pub use traits::{ConfigurationProvider, GitHubOperations, GitOperations, VersionCalculator};
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -348,6 +350,8 @@ where
                 branch_prefix: release_orchestrator::OrchestratorConfig::default().branch_prefix,
                 title_template: repo_config.release_pr.title_template.clone(),
                 changelog_header: "## Changelog".to_string(),
+                manifest_files: repo_config.release_pr.manifest_files.clone(),
+                auto_detect_manifests: repo_config.release_pr.auto_detect_manifests,
             },
             allow_override: repo_config.versioning.allow_override,
         };
@@ -743,6 +747,8 @@ where
                 .to_string(),
             title_template: repo_config.release_pr.title_template.clone(),
             changelog_header: "## Changelog".to_string(),
+            manifest_files: repo_config.release_pr.manifest_files.clone(),
+            auto_detect_manifests: repo_config.release_pr.auto_detect_manifests,
         };
 
         // Determine whether the merged PR is itself a release PR by checking

--- a/crates/core/src/lib_tests.rs
+++ b/crates/core/src/lib_tests.rs
@@ -963,6 +963,27 @@ impl GitHubOperations for TestGitHubForLib {
         Ok(())
     }
 
+    async fn get_file_content(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _path: &str,
+        _branch: &str,
+    ) -> CoreResult<Option<String>> {
+        Ok(None)
+    }
+
+    async fn batch_commit_files(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _branch: &str,
+        _files: &[crate::traits::github_operations::FileUpdate],
+        _message: &str,
+    ) -> CoreResult<()> {
+        Ok(())
+    }
+
     fn scoped_to(&self, _installation_id: u64) -> Self {
         Self {
             tags: self.tags.clone(),

--- a/crates/core/src/manifest.rs
+++ b/crates/core/src/manifest.rs
@@ -224,66 +224,74 @@ pub fn detect_standard_manifests(existing_paths: &[&str]) -> Vec<ManifestFileCon
 // ─────────────────────────────────────────────────────────────────────────────
 
 /// Update the version in a TOML document at the given dot-separated key path.
+///
+/// The key path may have any number of dot-separated segments, e.g.:
+/// - `"version"` — top-level key
+/// - `"package.version"` — one table level
+/// - `"tool.poetry.version"` — two table levels (Poetry)
+///
+/// Each intermediate segment must be a TOML table.  The final segment must
+/// be an existing string value.
 #[allow(clippy::result_large_err)]
 fn update_toml(content: &str, key: &str, version: &str) -> CoreResult<String> {
     let mut doc: toml_edit::DocumentMut = content
         .parse()
         .map_err(|e| CoreError::invalid_input("manifest", format!("Failed to parse TOML: {e}")))?;
 
-    // Navigate the dot-separated key path.
-    let segments: Vec<&str> = key.splitn(2, '.').collect();
-    match segments.as_slice() {
-        [table_key, field_key] => {
-            let table = doc
-                .get_mut(table_key)
-                .and_then(|v| v.as_table_mut())
-                .ok_or_else(|| {
-                    CoreError::invalid_input(
-                        "manifest",
-                        format!("TOML key '{table_key}' not found or not a table"),
-                    )
-                })?;
-
-            let item = table.get_mut(field_key).ok_or_else(|| {
-                CoreError::invalid_input("manifest", format!(
-                    "TOML key '{key}' not found: field '{field_key}' missing from table '{table_key}'"
-                ))
-            })?;
-
-            if !item.is_str() {
-                return Err(CoreError::invalid_input(
-                    "manifest",
-                    format!("TOML key '{key}' is not a string value"),
-                ));
-            }
-
-            *item = toml_edit::value(version);
-        }
-        [field_key] => {
-            // Top-level key (no table).
-            let item = doc.get_mut(field_key).ok_or_else(|| {
-                CoreError::invalid_input(
-                    "manifest",
-                    format!("TOML top-level key '{key}' not found"),
-                )
-            })?;
-
-            if !item.is_str() {
-                return Err(CoreError::invalid_input(
-                    "manifest",
-                    format!("TOML key '{key}' is not a string value"),
-                ));
-            }
-
-            *item = toml_edit::value(version);
-        }
-        _ => {
+    let segments: Vec<&str> = key.split('.').collect();
+    let (table_segments, field_key) = match segments.split_last() {
+        Some((last, rest)) => (rest, *last),
+        None => {
             return Err(CoreError::invalid_input(
                 "manifest",
-                format!("TOML key path '{key}' is not supported (maximum one level of nesting)"),
+                format!("TOML key path '{key}' is empty"),
             ));
         }
+    };
+
+    // Navigate all intermediate table segments.
+    let mut current: &mut toml_edit::Item = doc.as_item_mut();
+    for segment in table_segments {
+        current = current
+            .as_table_mut()
+            .ok_or_else(|| {
+                CoreError::invalid_input(
+                    "manifest",
+                    format!("TOML path '{key}': '{segment}' is not a table"),
+                )
+            })?
+            .get_mut(segment)
+            .ok_or_else(|| {
+                CoreError::invalid_input(
+                    "manifest",
+                    format!("TOML path '{key}': table '{segment}' not found"),
+                )
+            })?;
     }
+
+    // Now `current` points at the innermost table; find the field.
+    let table = current.as_table_mut().ok_or_else(|| {
+        CoreError::invalid_input(
+            "manifest",
+            format!("TOML path '{key}': intermediate segment is not a table"),
+        )
+    })?;
+
+    let item = table.get_mut(field_key).ok_or_else(|| {
+        CoreError::invalid_input(
+            "manifest",
+            format!("TOML key '{key}': field '{field_key}' not found"),
+        )
+    })?;
+
+    if !item.is_str() {
+        return Err(CoreError::invalid_input(
+            "manifest",
+            format!("TOML key '{key}' is not a string value"),
+        ));
+    }
+
+    *item = toml_edit::value(version);
 
     Ok(doc.to_string())
 }

--- a/crates/core/src/manifest.rs
+++ b/crates/core/src/manifest.rs
@@ -1,0 +1,361 @@
+//! Version manifest file detection and update logic.
+//!
+//! This module provides:
+//!
+//! - [`ManifestFormat`] — the format of a version manifest file.
+//! - [`ManifestFileConfig`] — describes a single manifest file to update.
+//! - [`update_manifest_content`] — pure function that applies a version string
+//!   to a manifest file's content and returns the updated text.
+//! - [`detect_standard_manifests`] — inspects a set of file paths that exist
+//!   in the repository and returns configurations for the well-known manifest
+//!   files that are present.
+//!
+//! ## Supported languages / formats
+//!
+//! Auto-detection recognises the following files out of the box:
+//!
+//! | Language       | File              | Format      | Key                     |
+//! |----------------|-------------------|-------------|-------------------------|
+//! | Rust           | `Cargo.toml`      | TOML        | `package.version`       |
+//! | Node.js / npm  | `package.json`    | JSON        | `version`               |
+//! | Python PEP 517 | `pyproject.toml`  | TOML        | `project.version`       |
+//! | Python / Poetry| `pyproject.toml`  | TOML        | `tool.poetry.version`   |
+//! | PHP / Composer | `composer.json`   | JSON        | `version`               |
+//!
+//! The [`ManifestFormat::PlainText`] variant serves as an escape hatch for any
+//! other language (e.g. .NET `.csproj`, Ruby gemspec) via a user-supplied regex
+//! pattern with one capture group.
+//!
+//! ## Usage
+//!
+//! ```rust
+//! use release_regent_core::manifest::{ManifestFormat, update_manifest_content};
+//!
+//! let toml = "[package]\nversion = \"0.0.0\"\n";
+//! let updated = update_manifest_content(toml, &ManifestFormat::Toml, "package.version", "1.2.3")
+//!     .expect("should update");
+//! assert!(updated.contains("version = \"1.2.3\""));
+//! ```
+
+use crate::{CoreError, CoreResult};
+use serde::{Deserialize, Serialize};
+
+#[cfg(test)]
+#[path = "manifest_tests.rs"]
+mod tests;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Public types
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// The serialisation format of a version manifest file.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ManifestFormat {
+    /// TOML file (e.g. `Cargo.toml`, `pyproject.toml`).
+    ///
+    /// The `version_key` field of [`ManifestFileConfig`] is a dot-separated
+    /// table path such as `"package.version"` or `"tool.poetry.version"`.
+    Toml,
+
+    /// JSON file (e.g. `package.json`, `composer.json`).
+    ///
+    /// The `version_key` field is a top-level JSON object key such as
+    /// `"version"`.  Nested paths (e.g. `"info.version"`) are not supported
+    /// — use [`ManifestFormat::PlainText`] with a regex for those cases.
+    Json,
+
+    /// Arbitrary plain-text file using a regex replacement.
+    ///
+    /// The `version_key` field is a regex pattern with **exactly one** capture
+    /// group (`(...)`) that matches the current version string.  The matched
+    /// span (the full match, not just the capture group) is replaced with the
+    /// version string substituted in place of the capture group.
+    ///
+    /// Example pattern: `r#"^version = "(.+)"$"#` applied to
+    /// `version = "0.0.0"` produces `version = "1.2.3"`.
+    PlainText,
+}
+
+/// Configuration for a single version manifest file.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ManifestFileConfig {
+    /// Repo-relative path to the file (e.g. `"Cargo.toml"`, `"package.json"`).
+    pub path: String,
+
+    /// The serialisation format to use when reading and updating the file.
+    pub format: ManifestFormat,
+
+    /// Format-specific address of the version field.
+    ///
+    /// - **TOML**: dot-separated table path (e.g. `"package.version"`).
+    /// - **JSON**: top-level key (e.g. `"version"`).
+    /// - **PlainText**: regex pattern with one capture group (e.g.
+    ///   `r#"^version = "(.+)"$"#`).
+    pub version_key: String,
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Public functions
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Apply `version` to the version field in `content` and return the updated text.
+///
+/// This is a **pure function** — it does not touch the filesystem or the network.
+///
+/// # Errors
+///
+/// Returns [`CoreError::InvalidInput`] when:
+/// - `format` is [`ManifestFormat::Toml`] and `content` cannot be parsed as TOML,
+///   or the dot-separated `key` path does not lead to a string value.
+/// - `format` is [`ManifestFormat::Json`] and `content` cannot be parsed as JSON,
+///   or the `key` is not a top-level string value.
+/// - `format` is [`ManifestFormat::PlainText`] and `key` is not a valid regex,
+///   or the regex does not contain exactly one capture group,
+///   or no match is found in `content`.
+///
+/// # Examples
+///
+/// ```rust
+/// use release_regent_core::manifest::{ManifestFormat, update_manifest_content};
+///
+/// // TOML
+/// let toml = "[package]\nversion = \"0.0.0\"\n";
+/// let out = update_manifest_content(toml, &ManifestFormat::Toml, "package.version", "1.2.3").unwrap();
+/// assert!(out.contains("version = \"1.2.3\""));
+///
+/// // JSON
+/// let json = r#"{"name":"myapp","version":"0.0.0"}"#;
+/// let out = update_manifest_content(json, &ManifestFormat::Json, "version", "1.2.3").unwrap();
+/// assert!(out.contains(r#""version": "1.2.3""#));
+///
+/// // PlainText
+/// let text = "version = \"0.0.0\"\n";
+/// let out = update_manifest_content(text, &ManifestFormat::PlainText, r#"version = "([^"]+)""#, "1.2.3").unwrap();
+/// assert!(out.contains("version = \"1.2.3\""));
+/// ```
+// CoreError is intentionally large; this is the established pattern throughout the codebase.
+#[allow(clippy::result_large_err)]
+pub fn update_manifest_content(
+    content: &str,
+    format: &ManifestFormat,
+    key: &str,
+    version: &str,
+) -> CoreResult<String> {
+    match format {
+        ManifestFormat::Toml => update_toml(content, key, version),
+        ManifestFormat::Json => update_json(content, key, version),
+        ManifestFormat::PlainText => update_plain_text(content, key, version),
+    }
+}
+
+/// Return [`ManifestFileConfig`] entries for every well-known manifest file
+/// whose path appears in `existing_paths`.
+///
+/// This function is deterministic and pure — it does not read from disk.
+/// The caller is responsible for providing the set of paths that actually
+/// exist in the repository (e.g. by calling
+/// [`GitHubOperations::get_file_content`] for each candidate and collecting
+/// the `Some(_)` results).
+///
+/// When `pyproject.toml` is present, **two** entries are returned — one for
+/// the PEP 517 key (`project.version`) and one for the Poetry key
+/// (`tool.poetry.version`).  The orchestrator will attempt both; the one
+/// whose key is absent in the file will produce a
+/// [`CoreError::InvalidInput`] that is caught and skipped with a `warn!`.
+///
+/// Explicit entries in [`OrchestratorConfig::manifest_files`] take
+/// precedence: if the caller has already provided a config entry for a given
+/// path, it should remove that path from `existing_paths` before calling this
+/// function (or filter the results).
+///
+/// [`GitHubOperations::get_file_content`]: crate::traits::github_operations::GitHubOperations::get_file_content
+/// [`OrchestratorConfig::manifest_files`]: crate::release_orchestrator::OrchestratorConfig
+pub fn detect_standard_manifests(existing_paths: &[&str]) -> Vec<ManifestFileConfig> {
+    let path_set: std::collections::HashSet<&str> = existing_paths.iter().copied().collect();
+    let mut result = Vec::new();
+
+    // Rust
+    if path_set.contains("Cargo.toml") {
+        result.push(ManifestFileConfig {
+            path: "Cargo.toml".to_string(),
+            format: ManifestFormat::Toml,
+            version_key: "package.version".to_string(),
+        });
+    }
+
+    // Node.js / npm
+    if path_set.contains("package.json") {
+        result.push(ManifestFileConfig {
+            path: "package.json".to_string(),
+            format: ManifestFormat::Json,
+            version_key: "version".to_string(),
+        });
+    }
+
+    // Python — pyproject.toml: try PEP 517 key first, then Poetry key.
+    if path_set.contains("pyproject.toml") {
+        result.push(ManifestFileConfig {
+            path: "pyproject.toml".to_string(),
+            format: ManifestFormat::Toml,
+            version_key: "project.version".to_string(),
+        });
+        result.push(ManifestFileConfig {
+            path: "pyproject.toml".to_string(),
+            format: ManifestFormat::Toml,
+            version_key: "tool.poetry.version".to_string(),
+        });
+    }
+
+    // PHP / Composer
+    if path_set.contains("composer.json") {
+        result.push(ManifestFileConfig {
+            path: "composer.json".to_string(),
+            format: ManifestFormat::Json,
+            version_key: "version".to_string(),
+        });
+    }
+
+    result
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Private helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Update the version in a TOML document at the given dot-separated key path.
+#[allow(clippy::result_large_err)]
+fn update_toml(content: &str, key: &str, version: &str) -> CoreResult<String> {
+    let mut doc: toml_edit::DocumentMut = content
+        .parse()
+        .map_err(|e| CoreError::invalid_input("manifest", format!("Failed to parse TOML: {e}")))?;
+
+    // Navigate the dot-separated key path.
+    let segments: Vec<&str> = key.splitn(2, '.').collect();
+    match segments.as_slice() {
+        [table_key, field_key] => {
+            let table = doc
+                .get_mut(table_key)
+                .and_then(|v| v.as_table_mut())
+                .ok_or_else(|| {
+                    CoreError::invalid_input(
+                        "manifest",
+                        format!("TOML key '{table_key}' not found or not a table"),
+                    )
+                })?;
+
+            let item = table.get_mut(field_key).ok_or_else(|| {
+                CoreError::invalid_input("manifest", format!(
+                    "TOML key '{key}' not found: field '{field_key}' missing from table '{table_key}'"
+                ))
+            })?;
+
+            if !item.is_str() {
+                return Err(CoreError::invalid_input(
+                    "manifest",
+                    format!("TOML key '{key}' is not a string value"),
+                ));
+            }
+
+            *item = toml_edit::value(version);
+        }
+        [field_key] => {
+            // Top-level key (no table).
+            let item = doc.get_mut(field_key).ok_or_else(|| {
+                CoreError::invalid_input(
+                    "manifest",
+                    format!("TOML top-level key '{key}' not found"),
+                )
+            })?;
+
+            if !item.is_str() {
+                return Err(CoreError::invalid_input(
+                    "manifest",
+                    format!("TOML key '{key}' is not a string value"),
+                ));
+            }
+
+            *item = toml_edit::value(version);
+        }
+        _ => {
+            return Err(CoreError::invalid_input(
+                "manifest",
+                format!("TOML key path '{key}' is not supported (maximum one level of nesting)"),
+            ));
+        }
+    }
+
+    Ok(doc.to_string())
+}
+
+/// Update a top-level string key in a JSON object.
+#[allow(clippy::result_large_err)]
+fn update_json(content: &str, key: &str, version: &str) -> CoreResult<String> {
+    let mut value: serde_json::Value = serde_json::from_str(content)
+        .map_err(|e| CoreError::invalid_input("manifest", format!("Failed to parse JSON: {e}")))?;
+
+    let obj = value.as_object_mut().ok_or_else(|| {
+        CoreError::invalid_input("manifest", "JSON content is not an object".to_string())
+    })?;
+
+    match obj.get(key) {
+        None => {
+            return Err(CoreError::invalid_input(
+                "manifest",
+                format!("JSON key '{key}' not found in object"),
+            ));
+        }
+        Some(existing) if !existing.is_string() => {
+            return Err(CoreError::invalid_input(
+                "manifest",
+                format!("JSON key '{key}' is not a string value"),
+            ));
+        }
+        _ => {}
+    }
+
+    obj.insert(
+        key.to_string(),
+        serde_json::Value::String(version.to_string()),
+    );
+
+    serde_json::to_string_pretty(&value)
+        .map_err(|e| CoreError::invalid_input("manifest", format!("Failed to serialise JSON: {e}")))
+}
+
+/// Update a version string matched by a regex pattern with one capture group.
+#[allow(clippy::result_large_err)]
+fn update_plain_text(content: &str, pattern: &str, version: &str) -> CoreResult<String> {
+    let re = regex::Regex::new(pattern).map_err(|e| {
+        CoreError::invalid_input(
+            "manifest",
+            format!("PlainText pattern '{pattern}' is not a valid regex: {e}"),
+        )
+    })?;
+
+    if re.captures_len() != 2 {
+        // captures_len() == 1 means the regex has no capture groups;
+        // == 2 means exactly one explicit group plus the implicit whole-match group.
+        return Err(CoreError::invalid_input(
+            "manifest",
+            format!("PlainText pattern '{pattern}' must contain exactly one capture group"),
+        ));
+    }
+
+    let caps = re.captures(content).ok_or_else(|| {
+        CoreError::invalid_input(
+            "manifest",
+            format!("PlainText pattern '{pattern}' did not match any text in the file"),
+        )
+    })?;
+
+    let full_match = caps.get(0).expect("captures(0) always exists").as_str();
+    let capture = caps
+        .get(1)
+        .expect("captures(1) exists; checked above")
+        .as_str();
+
+    // Replace the captured version substring within the full match.
+    let new_match = full_match.replacen(capture, version, 1);
+    Ok(content.replacen(full_match, &new_match, 1))
+}

--- a/crates/core/src/manifest_tests.rs
+++ b/crates/core/src/manifest_tests.rs
@@ -21,18 +21,25 @@ fn update_manifest_content_toml_replaces_package_version() {
 #[test]
 fn update_manifest_content_toml_replaces_tool_poetry_version() {
     let content = "[tool.poetry]\nname = \"mypkg\"\nversion = \"0.1.0\"\n";
-    // Two-level key requires two dot segments; our impl only supports one level of nesting.
-    // tool.poetry.version would need three segments — this test validates the rejection path.
     let result = update_manifest_content(
         content,
         &ManifestFormat::Toml,
         "tool.poetry.version",
         "2.0.0",
     );
-    // Three-segment key is not supported — expect an error.
     assert!(
-        result.is_err(),
-        "three-segment TOML key should return an error"
+        result.is_ok(),
+        "three-segment TOML key should succeed: {:?}",
+        result
+    );
+    let updated = result.unwrap();
+    assert!(
+        updated.contains("2.0.0"),
+        "updated content should contain the new version"
+    );
+    assert!(
+        !updated.contains("0.1.0"),
+        "updated content should not contain the old version"
     );
 }
 

--- a/crates/core/src/manifest_tests.rs
+++ b/crates/core/src/manifest_tests.rs
@@ -1,0 +1,238 @@
+use super::*;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// update_manifest_content — TOML format
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn update_manifest_content_toml_replaces_package_version() {
+    let content = "[package]\nname = \"myapp\"\nversion = \"0.0.0\"\n";
+    let result =
+        update_manifest_content(content, &ManifestFormat::Toml, "package.version", "1.2.3");
+    assert!(result.is_ok(), "unexpected error: {:?}", result);
+    let updated = result.unwrap();
+    assert!(
+        updated.contains("version = \"1.2.3\""),
+        "expected version = \"1.2.3\" in:\n{updated}"
+    );
+    assert!(!updated.contains("0.0.0"), "old version should be gone");
+}
+
+#[test]
+fn update_manifest_content_toml_replaces_tool_poetry_version() {
+    let content = "[tool.poetry]\nname = \"mypkg\"\nversion = \"0.1.0\"\n";
+    // Two-level key requires two dot segments; our impl only supports one level of nesting.
+    // tool.poetry.version would need three segments — this test validates the rejection path.
+    let result = update_manifest_content(
+        content,
+        &ManifestFormat::Toml,
+        "tool.poetry.version",
+        "2.0.0",
+    );
+    // Three-segment key is not supported — expect an error.
+    assert!(
+        result.is_err(),
+        "three-segment TOML key should return an error"
+    );
+}
+
+#[test]
+fn update_manifest_content_toml_key_not_found_returns_error() {
+    let content = "[package]\nname = \"myapp\"\n";
+    let result =
+        update_manifest_content(content, &ManifestFormat::Toml, "package.version", "1.0.0");
+    assert!(result.is_err(), "missing key should return an error");
+    let msg = format!("{:?}", result.unwrap_err());
+    assert!(
+        msg.contains("version"),
+        "error should mention the missing key"
+    );
+}
+
+#[test]
+fn update_manifest_content_toml_malformed_returns_error() {
+    let content = "this is not toml @@@ {{{";
+    let result =
+        update_manifest_content(content, &ManifestFormat::Toml, "package.version", "1.0.0");
+    assert!(result.is_err(), "malformed TOML should return an error");
+}
+
+#[test]
+fn update_manifest_content_toml_preserves_other_fields() {
+    let content = "[package]\nname = \"myapp\"\nversion = \"0.0.0\"\nedition = \"2021\"\n";
+    let updated =
+        update_manifest_content(content, &ManifestFormat::Toml, "package.version", "1.5.0")
+            .expect("update should succeed");
+    assert!(
+        updated.contains("name = \"myapp\""),
+        "name field must be preserved"
+    );
+    assert!(
+        updated.contains("edition = \"2021\""),
+        "edition field must be preserved"
+    );
+    assert!(
+        updated.contains("version = \"1.5.0\""),
+        "version must be updated"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// update_manifest_content — JSON format
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn update_manifest_content_json_replaces_version_field() {
+    let content = r#"{"name":"myapp","version":"0.0.0"}"#;
+    let result = update_manifest_content(content, &ManifestFormat::Json, "version", "1.2.3");
+    assert!(result.is_ok(), "unexpected error: {:?}", result);
+    let updated = result.unwrap();
+    assert!(
+        updated.contains(r#""version": "1.2.3""#),
+        "expected updated version in:\n{updated}"
+    );
+    assert!(!updated.contains("0.0.0"), "old version should be gone");
+}
+
+#[test]
+fn update_manifest_content_json_key_not_found_returns_error() {
+    let content = r#"{"name":"myapp"}"#;
+    let result = update_manifest_content(content, &ManifestFormat::Json, "version", "1.0.0");
+    assert!(result.is_err(), "missing key should return an error");
+}
+
+#[test]
+fn update_manifest_content_json_malformed_returns_error() {
+    let content = "{ not valid json }}}";
+    let result = update_manifest_content(content, &ManifestFormat::Json, "version", "1.0.0");
+    assert!(result.is_err(), "malformed JSON should return an error");
+}
+
+#[test]
+fn update_manifest_content_json_preserves_other_fields() {
+    let content = r#"{"name":"myapp","version":"0.0.0","private":true}"#;
+    let updated = update_manifest_content(content, &ManifestFormat::Json, "version", "2.0.0")
+        .expect("update should succeed");
+    assert!(updated.contains("\"name\""), "name field must be preserved");
+    assert!(
+        updated.contains("\"private\""),
+        "private field must be preserved"
+    );
+    assert!(updated.contains("\"2.0.0\""), "version must be updated");
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// update_manifest_content — PlainText format
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn update_manifest_content_plaintext_replaces_regex_match() {
+    let content = "version = \"0.0.0\"\n";
+    let pattern = r#"version = "([^"]+)""#;
+    let result = update_manifest_content(content, &ManifestFormat::PlainText, pattern, "1.2.3");
+    assert!(result.is_ok(), "unexpected error: {:?}", result);
+    let updated = result.unwrap();
+    assert!(
+        updated.contains("version = \"1.2.3\""),
+        "expected updated version in:\n{updated}"
+    );
+    assert!(!updated.contains("0.0.0"), "old version should be gone");
+}
+
+#[test]
+fn update_manifest_content_plaintext_no_match_returns_error() {
+    let content = "completely unrelated content\n";
+    let pattern = r#"version = "([^"]+)""#;
+    let result = update_manifest_content(content, &ManifestFormat::PlainText, pattern, "1.0.0");
+    assert!(result.is_err(), "no match should return an error");
+}
+
+#[test]
+fn update_manifest_content_plaintext_invalid_regex_returns_error() {
+    let content = "version = \"0.0.0\"\n";
+    let pattern = r"[invalid regex(((";
+    let result = update_manifest_content(content, &ManifestFormat::PlainText, pattern, "1.0.0");
+    assert!(result.is_err(), "invalid regex should return an error");
+}
+
+#[test]
+fn update_manifest_content_plaintext_no_capture_group_returns_error() {
+    let content = "version = \"0.0.0\"\n";
+    // Pattern with no capture group — must be rejected.
+    let pattern = r#"version = "[^"]+""#;
+    let result = update_manifest_content(content, &ManifestFormat::PlainText, pattern, "1.0.0");
+    assert!(
+        result.is_err(),
+        "pattern without capture group should return an error"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// detect_standard_manifests
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn detect_standard_manifests_empty_list_returns_empty() {
+    let result = detect_standard_manifests(&[]);
+    assert!(result.is_empty());
+}
+
+#[test]
+fn detect_standard_manifests_cargo_toml_detected() {
+    let result = detect_standard_manifests(&["Cargo.toml"]);
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0].path, "Cargo.toml");
+    assert_eq!(result[0].format, ManifestFormat::Toml);
+    assert_eq!(result[0].version_key, "package.version");
+}
+
+#[test]
+fn detect_standard_manifests_package_json_detected() {
+    let result = detect_standard_manifests(&["package.json"]);
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0].path, "package.json");
+    assert_eq!(result[0].format, ManifestFormat::Json);
+    assert_eq!(result[0].version_key, "version");
+}
+
+#[test]
+fn detect_standard_manifests_pyproject_toml_returns_two_entries() {
+    // Both PEP 517 and Poetry keys are returned; the orchestrator tries both.
+    let result = detect_standard_manifests(&["pyproject.toml"]);
+    assert_eq!(result.len(), 2, "expected two entries for pyproject.toml");
+    let keys: Vec<&str> = result.iter().map(|m| m.version_key.as_str()).collect();
+    assert!(
+        keys.contains(&"project.version"),
+        "PEP 517 key must be present"
+    );
+    assert!(
+        keys.contains(&"tool.poetry.version"),
+        "Poetry key must be present"
+    );
+}
+
+#[test]
+fn detect_standard_manifests_composer_json_detected() {
+    let result = detect_standard_manifests(&["composer.json"]);
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0].path, "composer.json");
+    assert_eq!(result[0].format, ManifestFormat::Json);
+    assert_eq!(result[0].version_key, "version");
+}
+
+#[test]
+fn detect_standard_manifests_unknown_file_not_detected() {
+    let result = detect_standard_manifests(&["my-custom-file.txt", "README.md"]);
+    assert!(result.is_empty(), "unrecognised files must not be detected");
+}
+
+#[test]
+fn detect_standard_manifests_multiple_files_all_detected() {
+    let result = detect_standard_manifests(&["Cargo.toml", "package.json", "composer.json"]);
+    // Cargo.toml → 1, package.json → 1, composer.json → 1 = 3 total
+    assert_eq!(result.len(), 3);
+    let paths: Vec<&str> = result.iter().map(|m| m.path.as_str()).collect();
+    assert!(paths.contains(&"Cargo.toml"));
+    assert!(paths.contains(&"package.json"));
+    assert!(paths.contains(&"composer.json"));
+}

--- a/crates/core/src/release_automator_tests.rs
+++ b/crates/core/src/release_automator_tests.rs
@@ -449,6 +449,27 @@ impl GitHubOperations for TestGitHub {
         Ok(())
     }
 
+    async fn get_file_content(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _path: &str,
+        _branch: &str,
+    ) -> CoreResult<Option<String>> {
+        Ok(None)
+    }
+
+    async fn batch_commit_files(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _branch: &str,
+        _files: &[crate::traits::github_operations::FileUpdate],
+        _message: &str,
+    ) -> CoreResult<()> {
+        Ok(())
+    }
+
     fn scoped_to(&self, _installation_id: u64) -> Self {
         Self {
             state: Arc::clone(&self.state),

--- a/crates/core/src/release_orchestrator.rs
+++ b/crates/core/src/release_orchestrator.rs
@@ -47,7 +47,10 @@
 //! ```
 
 use crate::{
-    traits::github_operations::{CreatePullRequestParams, GitHubOperations, PullRequest},
+    manifest::ManifestFileConfig,
+    traits::github_operations::{
+        CreatePullRequestParams, FileUpdate, GitHubOperations, PullRequest,
+    },
     versioning::SemanticVersion,
     CoreError, CoreResult,
 };
@@ -77,6 +80,23 @@ pub struct OrchestratorConfig {
     ///
     /// Defaults to `"## Changelog"`.
     pub changelog_header: String,
+
+    /// Explicit list of version manifest files to update when creating or updating
+    /// the release branch.  Each entry is committed as part of the single atomic
+    /// batch commit together with `CHANGELOG.md`.
+    ///
+    /// Entries here take precedence over auto-detected files when the same path
+    /// appears in both lists.
+    ///
+    /// Defaults to an empty list (no explicit manifest files).
+    pub manifest_files: Vec<ManifestFileConfig>,
+
+    /// When `true` (the default), the orchestrator probes the repository for the
+    /// well-known manifest files defined in [`crate::manifest::detect_standard_manifests`]
+    /// and includes any that exist alongside the explicit [`Self::manifest_files`].
+    ///
+    /// Set to `false` to disable auto-detection and rely solely on the explicit list.
+    pub auto_detect_manifests: bool,
 }
 
 impl OrchestratorConfig {
@@ -90,6 +110,8 @@ impl Default for OrchestratorConfig {
             branch_prefix: Self::DEFAULT_BRANCH_PREFIX.to_string(),
             title_template: "chore(release): {version_tag}".to_string(),
             changelog_header: "## Changelog".to_string(),
+            manifest_files: Vec::new(),
+            auto_detect_manifests: true,
         }
     }
 }
@@ -303,6 +325,10 @@ impl<'a, G: GitHubOperations> ReleaseOrchestrator<'a, G> {
     ///
     /// On a `CoreError::Conflict` (branch already exists) the method retries once
     /// with a timestamped fallback branch name.
+    ///
+    /// All file changes (CHANGELOG.md plus any version manifest files) are made
+    /// in a **single atomic Git commit** via [`GitHubOperations::batch_commit_files`]
+    /// so the release branch always shows exactly one commit on top of the base branch.
     async fn create_release_branch_and_pr(
         &self,
         owner: &str,
@@ -340,20 +366,20 @@ impl<'a, G: GitHubOperations> ReleaseOrchestrator<'a, G> {
         let title = self.render_title(version);
         let body = self.render_body(changelog);
 
-        // Commit CHANGELOG.md to the release branch so the PR has a real diff.
-        let changelog_commit_message = format!(
-            "chore(release): update CHANGELOG for {}",
+        // Build the batch of files: CHANGELOG.md plus any manifest files.
+        let mut file_updates = vec![FileUpdate {
+            path: "CHANGELOG.md".to_string(),
+            content: changelog.to_string(),
+        }];
+        self.collect_manifest_updates(owner, repo, &actual_branch, version, &mut file_updates)
+            .await;
+
+        let commit_message = format!(
+            "chore(release): update release files for {}",
             version.to_string_with_prefix(true)
         );
         self.github
-            .upsert_file(
-                owner,
-                repo,
-                "CHANGELOG.md",
-                &changelog_commit_message,
-                changelog,
-                &actual_branch,
-            )
+            .batch_commit_files(owner, repo, &actual_branch, &file_updates, &commit_message)
             .await?;
 
         let pr = self
@@ -422,24 +448,36 @@ impl<'a, G: GitHubOperations> ReleaseOrchestrator<'a, G> {
             .await?;
 
         // Force-reset the release branch to the latest base SHA so the PR always
-        // shows exactly one commit (the CHANGELOG.md update) on top of main.
+        // shows exactly one commit on top of main.
         self.github
             .force_update_branch(owner, repo, &fresh_pr.head.ref_name, base_sha)
             .await?;
 
-        // Keep CHANGELOG.md on the release branch in sync with the PR body.
-        let changelog_commit_message = format!(
-            "chore(release): update CHANGELOG for {}",
+        // Build batch: CHANGELOG.md plus manifest files — all in one atomic commit.
+        let mut file_updates = vec![FileUpdate {
+            path: "CHANGELOG.md".to_string(),
+            content: merged_changelog.clone(),
+        }];
+        self.collect_manifest_updates(
+            owner,
+            repo,
+            &fresh_pr.head.ref_name,
+            version,
+            &mut file_updates,
+        )
+        .await;
+
+        let commit_message = format!(
+            "chore(release): update release files for {}",
             version.to_string_with_prefix(true)
         );
         self.github
-            .upsert_file(
+            .batch_commit_files(
                 owner,
                 repo,
-                "CHANGELOG.md",
-                &changelog_commit_message,
-                &merged_changelog,
                 &fresh_pr.head.ref_name,
+                &file_updates,
+                &commit_message,
             )
             .await?;
 
@@ -526,7 +564,135 @@ impl<'a, G: GitHubOperations> ReleaseOrchestrator<'a, G> {
         )
     }
 
-    // ── Template / body helpers ────────────────────────────────────────────
+    // ── Manifest file helpers ─────────────────────────────────────────────
+
+    /// Build the list of manifest [`FileUpdate`] entries for the release commit.
+    ///
+    /// Combines auto-detected and explicitly configured manifest files, reads
+    /// their current content from the branch, applies the version substitution,
+    /// and appends the results to `updates`.  Files that are absent on the branch
+    /// or whose update fails are skipped with a `warn!` log — they must not
+    /// prevent PR creation from succeeding.
+    ///
+    /// Explicit entries from `self.config.manifest_files` take precedence: if
+    /// a path appears in both the explicit list and the auto-detected set, the
+    /// explicit config is used and the auto-detected one is dropped.
+    async fn collect_manifest_updates(
+        &self,
+        owner: &str,
+        repo: &str,
+        branch: &str,
+        version: &SemanticVersion,
+        updates: &mut Vec<FileUpdate>,
+    ) {
+        use crate::manifest::{detect_standard_manifests, update_manifest_content};
+
+        let version_str = version.to_string();
+
+        // Build the effective manifest list: explicit entries first, then
+        // auto-detected ones that do not duplicate an explicit path.
+        let explicit_paths: std::collections::HashSet<&str> = self
+            .config
+            .manifest_files
+            .iter()
+            .map(|m| m.path.as_str())
+            .collect();
+
+        let mut manifests: Vec<std::borrow::Cow<'_, crate::manifest::ManifestFileConfig>> = self
+            .config
+            .manifest_files
+            .iter()
+            .map(std::borrow::Cow::Borrowed)
+            .collect();
+
+        if self.config.auto_detect_manifests {
+            // Probe the set of well-known files.
+            let candidates = [
+                "Cargo.toml",
+                "package.json",
+                "pyproject.toml",
+                "composer.json",
+            ];
+            let mut existing: Vec<&str> = Vec::new();
+            for &candidate in &candidates {
+                if explicit_paths.contains(candidate) {
+                    continue; // explicit list takes precedence
+                }
+                match self
+                    .github
+                    .get_file_content(owner, repo, candidate, branch)
+                    .await
+                {
+                    Ok(Some(_)) => existing.push(candidate),
+                    Ok(None) => {} // file not present — skip silently
+                    Err(e) => {
+                        warn!(
+                            path = candidate,
+                            error = %e,
+                            "Failed to probe for manifest file during auto-detection; skipping"
+                        );
+                    }
+                }
+            }
+            for cfg in detect_standard_manifests(&existing) {
+                manifests.push(std::borrow::Cow::Owned(cfg));
+            }
+        }
+
+        // For each manifest, read current content and apply update.
+        for manifest in &manifests {
+            let content = match self
+                .github
+                .get_file_content(owner, repo, &manifest.path, branch)
+                .await
+            {
+                Ok(Some(c)) => c,
+                Ok(None) => {
+                    warn!(
+                        path = %manifest.path,
+                        branch,
+                        "Manifest file not found on release branch; skipping"
+                    );
+                    continue;
+                }
+                Err(e) => {
+                    warn!(
+                        path = %manifest.path,
+                        error = %e,
+                        "Failed to read manifest file; skipping"
+                    );
+                    continue;
+                }
+            };
+
+            match update_manifest_content(
+                &content,
+                &manifest.format,
+                &manifest.version_key,
+                &version_str,
+            ) {
+                Ok(updated) => {
+                    updates.push(FileUpdate {
+                        path: manifest.path.clone(),
+                        content: updated,
+                    });
+                    debug!(
+                        path = %manifest.path,
+                        version = %version_str,
+                        "Manifest file queued for version update"
+                    );
+                }
+                Err(e) => {
+                    warn!(
+                        path = %manifest.path,
+                        key = %manifest.version_key,
+                        error = %e,
+                        "Failed to apply version to manifest file; skipping"
+                    );
+                }
+            }
+        }
+    }
 
     /// Render the PR title from the configured template.
     ///

--- a/crates/core/src/release_orchestrator.rs
+++ b/crates/core/src/release_orchestrator.rs
@@ -374,6 +374,11 @@ impl<'a, G: GitHubOperations> ReleaseOrchestrator<'a, G> {
         self.collect_manifest_updates(owner, repo, &actual_branch, version, &mut file_updates)
             .await;
 
+        // Deduplicate by path — detect_standard_manifests may emit two configs for
+        // the same file (e.g. PEP-617 + Poetry keys for pyproject.toml).  Keep the
+        // last entry per path to match the Git Trees API's last-writer-wins semantics.
+        let file_updates = dedup_file_updates_by_path(file_updates);
+
         let commit_message = format!(
             "chore(release): update release files for {}",
             version.to_string_with_prefix(true)
@@ -457,6 +462,9 @@ impl<'a, G: GitHubOperations> ReleaseOrchestrator<'a, G> {
             &mut file_updates,
         )
         .await;
+
+        // Deduplicate by path — see create_release_branch_and_pr for rationale.
+        let file_updates = dedup_file_updates_by_path(file_updates);
 
         let commit_message = format!(
             "chore(release): update release files for {}",
@@ -831,6 +839,29 @@ impl<'a, G: GitHubOperations> ReleaseOrchestrator<'a, G> {
         let version_str = branch.strip_prefix(&prefix)?;
         crate::versioning::VersionCalculator::parse_version(version_str).ok()
     }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Private helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Deduplicate a [`FileUpdate`] list by path, keeping the **last** entry for
+/// each unique path.
+///
+/// `detect_standard_manifests` may produce two configs for the same file (e.g.
+/// both `project.version` and `tool.poetry.version` for `pyproject.toml`).
+/// Passing duplicate paths to the Git Trees API results in silent data loss — the
+/// last blob silently wins.  This helper makes the last-writer-wins semantics
+/// explicit and predictable.
+fn dedup_file_updates_by_path(updates: Vec<FileUpdate>) -> Vec<FileUpdate> {
+    let mut seen = std::collections::HashSet::new();
+    let mut deduped: Vec<FileUpdate> = updates
+        .into_iter()
+        .rev()
+        .filter(|u| seen.insert(u.path.clone()))
+        .collect();
+    deduped.reverse();
+    deduped
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/crates/core/src/release_orchestrator.rs
+++ b/crates/core/src/release_orchestrator.rs
@@ -435,20 +435,11 @@ impl<'a, G: GitHubOperations> ReleaseOrchestrator<'a, G> {
             Some(new_title)
         };
 
-        let updated = self
-            .github
-            .update_pull_request(
-                owner,
-                repo,
-                fresh_pr.number,
-                title_update,
-                Some(new_body),
-                None,
-            )
-            .await?;
-
         // Force-reset the release branch to the latest base SHA so the PR always
         // shows exactly one commit on top of main.
+        //
+        // Files are committed BEFORE the PR metadata is updated so that, if the
+        // commit step fails, the PR body never drifts ahead of the branch content.
         self.github
             .force_update_branch(owner, repo, &fresh_pr.head.ref_name, base_sha)
             .await?;
@@ -478,6 +469,20 @@ impl<'a, G: GitHubOperations> ReleaseOrchestrator<'a, G> {
                 &fresh_pr.head.ref_name,
                 &file_updates,
                 &commit_message,
+            )
+            .await?;
+
+        // Update the PR title/body only after the branch files are committed so
+        // the metadata always reflects what is actually on the branch.
+        let updated = self
+            .github
+            .update_pull_request(
+                owner,
+                repo,
+                fresh_pr.number,
+                title_update,
+                Some(new_body),
+                None,
             )
             .await?;
 
@@ -606,14 +611,17 @@ impl<'a, G: GitHubOperations> ReleaseOrchestrator<'a, G> {
             .collect();
 
         if self.config.auto_detect_manifests {
-            // Probe the set of well-known files.
+            // Probe the set of well-known files.  We store the content from the
+            // probe so auto-detected files can be updated without a second API
+            // call.  Explicit-list files always do a fresh fetch below.
             let candidates = [
                 "Cargo.toml",
                 "package.json",
                 "pyproject.toml",
                 "composer.json",
             ];
-            let mut existing: Vec<&str> = Vec::new();
+            let mut probe_cache: std::collections::HashMap<&str, String> =
+                std::collections::HashMap::new();
             for &candidate in &candidates {
                 if explicit_paths.contains(candidate) {
                     continue; // explicit list takes precedence
@@ -623,7 +631,9 @@ impl<'a, G: GitHubOperations> ReleaseOrchestrator<'a, G> {
                     .get_file_content(owner, repo, candidate, branch)
                     .await
                 {
-                    Ok(Some(_)) => existing.push(candidate),
+                    Ok(Some(content)) => {
+                        probe_cache.insert(candidate, content);
+                    }
                     Ok(None) => {} // file not present — skip silently
                     Err(e) => {
                         warn!(
@@ -634,61 +644,122 @@ impl<'a, G: GitHubOperations> ReleaseOrchestrator<'a, G> {
                     }
                 }
             }
+            let existing: Vec<&str> = probe_cache.keys().copied().collect();
             for cfg in detect_standard_manifests(&existing) {
                 manifests.push(std::borrow::Cow::Owned(cfg));
             }
-        }
 
-        // For each manifest, read current content and apply update.
-        for manifest in &manifests {
-            let content = match self
-                .github
-                .get_file_content(owner, repo, &manifest.path, branch)
-                .await
-            {
-                Ok(Some(c)) => c,
-                Ok(None) => {
-                    warn!(
-                        path = %manifest.path,
-                        branch,
-                        "Manifest file not found on release branch; skipping"
-                    );
-                    continue;
-                }
-                Err(e) => {
-                    warn!(
-                        path = %manifest.path,
-                        error = %e,
-                        "Failed to read manifest file; skipping"
-                    );
-                    continue;
-                }
-            };
+            // For each manifest, read current content and apply update.
+            for manifest in &manifests {
+                // Reuse cached probe content for auto-detected files; explicit-list
+                // files always get a fresh fetch.
+                let content = if let Some(cached) = probe_cache.get(manifest.path.as_str()) {
+                    cached.clone()
+                } else {
+                    match self
+                        .github
+                        .get_file_content(owner, repo, &manifest.path, branch)
+                        .await
+                    {
+                        Ok(Some(c)) => c,
+                        Ok(None) => {
+                            warn!(
+                                path = %manifest.path,
+                                branch,
+                                "Manifest file not found on release branch; skipping"
+                            );
+                            continue;
+                        }
+                        Err(e) => {
+                            warn!(
+                                path = %manifest.path,
+                                error = %e,
+                                "Failed to read manifest file; skipping"
+                            );
+                            continue;
+                        }
+                    }
+                };
 
-            match update_manifest_content(
-                &content,
-                &manifest.format,
-                &manifest.version_key,
-                &version_str,
-            ) {
-                Ok(updated) => {
-                    updates.push(FileUpdate {
-                        path: manifest.path.clone(),
-                        content: updated,
-                    });
-                    debug!(
-                        path = %manifest.path,
-                        version = %version_str,
-                        "Manifest file queued for version update"
-                    );
+                match update_manifest_content(
+                    &content,
+                    &manifest.format,
+                    &manifest.version_key,
+                    &version_str,
+                ) {
+                    Ok(updated) => {
+                        updates.push(FileUpdate {
+                            path: manifest.path.clone(),
+                            content: updated,
+                        });
+                        debug!(
+                            path = %manifest.path,
+                            version = %version_str,
+                            "Manifest file queued for version update"
+                        );
+                    }
+                    Err(e) => {
+                        warn!(
+                            path = %manifest.path,
+                            key = %manifest.version_key,
+                            error = %e,
+                            "Failed to apply version to manifest file; skipping"
+                        );
+                    }
                 }
-                Err(e) => {
-                    warn!(
-                        path = %manifest.path,
-                        key = %manifest.version_key,
-                        error = %e,
-                        "Failed to apply version to manifest file; skipping"
-                    );
+            }
+        } else {
+            // No auto-detection; process only explicitly configured manifests.
+            for manifest in &manifests {
+                let content = match self
+                    .github
+                    .get_file_content(owner, repo, &manifest.path, branch)
+                    .await
+                {
+                    Ok(Some(c)) => c,
+                    Ok(None) => {
+                        warn!(
+                            path = %manifest.path,
+                            branch,
+                            "Manifest file not found on release branch; skipping"
+                        );
+                        continue;
+                    }
+                    Err(e) => {
+                        warn!(
+                            path = %manifest.path,
+                            error = %e,
+                            "Failed to read manifest file; skipping"
+                        );
+                        continue;
+                    }
+                };
+
+                match update_manifest_content(
+                    &content,
+                    &manifest.format,
+                    &manifest.version_key,
+                    &version_str,
+                ) {
+                    Ok(updated) => {
+                        updates.push(FileUpdate {
+                            path: manifest.path.clone(),
+                            content: updated,
+                        });
+                        debug!(
+                            path = %manifest.path,
+                            version = %version_str,
+                            "Manifest file queued for version update"
+                        );
+                    }
+                    Err(e) => {
+                        warn!(
+                            path = %manifest.path,
+                            key = %manifest.version_key,
+                            error = %e,
+                            "Failed to apply version to manifest file; skipping"
+                        );
+                    }
                 }
             }
         }

--- a/crates/core/src/release_orchestrator_tests.rs
+++ b/crates/core/src/release_orchestrator_tests.rs
@@ -5,8 +5,9 @@ use crate::{
             GetCommitsOptions, GitCommit, GitOperations, GitRepository, GitTag, ListTagsOptions,
         },
         github_operations::{
-            CreatePullRequestParams, CreateReleaseParams, GitHubOperations, GitUser as GitHubUser,
-            PullRequest, PullRequestBranch, Release, Repository, Tag, UpdateReleaseParams,
+            CreatePullRequestParams, CreateReleaseParams, FileUpdate, GitHubOperations,
+            GitUser as GitHubUser, PullRequest, PullRequestBranch, Release, Repository, Tag,
+            UpdateReleaseParams,
         },
     },
     versioning::SemanticVersion,
@@ -45,6 +46,10 @@ struct TestState {
     force_updated_branches: Vec<(String, String)>,
     /// Recorded `upsert_file` calls: (path, branch).
     upserted_files: Vec<(String, String)>,
+    /// Recorded `batch_commit_files` calls: (branch, paths, message).
+    batch_commits: Vec<(String, Vec<String>, String)>,
+    /// Pre-loaded file contents for `get_file_content`: (path, branch) → content.
+    file_contents: std::collections::HashMap<(String, String), String>,
     /// Sequential PR number to return from `create_pull_request`.
     next_pr_number: u64,
     /// Whether `search_pull_requests` should return an error.
@@ -110,6 +115,20 @@ impl TestGitHub {
 
     async fn upserted_files(&self) -> Vec<(String, String)> {
         self.state.lock().await.upserted_files.clone()
+    }
+
+    async fn batch_commits(&self) -> Vec<(String, Vec<String>, String)> {
+        self.state.lock().await.batch_commits.clone()
+    }
+
+    /// Pre-load a file content so `get_file_content` returns it.
+    async fn with_file_content(self, path: &str, branch: &str, content: &str) -> Self {
+        self.state
+            .lock()
+            .await
+            .file_contents
+            .insert((path.to_string(), branch.to_string()), content.to_string());
+        self
     }
 }
 
@@ -448,6 +467,37 @@ impl GitHubOperations for TestGitHub {
         Ok(())
     }
 
+    async fn get_file_content(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        path: &str,
+        branch: &str,
+    ) -> CoreResult<Option<String>> {
+        let st = self.state.lock().await;
+        Ok(st
+            .file_contents
+            .get(&(path.to_string(), branch.to_string()))
+            .cloned())
+    }
+
+    async fn batch_commit_files(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        branch: &str,
+        files: &[FileUpdate],
+        message: &str,
+    ) -> CoreResult<()> {
+        let paths: Vec<String> = files.iter().map(|f| f.path.clone()).collect();
+        self.state.lock().await.batch_commits.push((
+            branch.to_string(),
+            paths,
+            message.to_string(),
+        ));
+        Ok(())
+    }
+
     fn scoped_to(&self, _installation_id: u64) -> Self {
         Self {
             state: Arc::clone(&self.state),
@@ -572,14 +622,14 @@ async fn test_orchestrate_no_existing_pr_creates_branch_and_pr() {
         .unwrap_or("")
         .contains("## Changelog"));
 
-    let upserted = github.upserted_files().await;
+    let commits = github.batch_commits().await;
     assert_eq!(
-        upserted.len(),
+        commits.len(),
         1,
         "CHANGELOG.md should be committed to the release branch"
     );
-    assert_eq!(upserted[0].0, "CHANGELOG.md");
-    assert_eq!(upserted[0].1, "release/v1.2.3");
+    assert!(commits[0].1.contains(&"CHANGELOG.md".to_string()));
+    assert_eq!(commits[0].0, "release/v1.2.3");
 }
 
 /// Existing PR has the same version → changelog is merged (Updated).
@@ -626,14 +676,14 @@ async fn test_orchestrate_existing_equal_version_pr_updates_changelog() {
     assert!(body.contains("new feature"), "should add new entry");
 
     // CHANGELOG.md should be committed to the existing branch.
-    let upserted = github.upserted_files().await;
+    let commits = github.batch_commits().await;
     assert_eq!(
-        upserted.len(),
+        commits.len(),
         1,
         "CHANGELOG.md should be updated on the existing branch"
     );
-    assert_eq!(upserted[0].0, "CHANGELOG.md");
-    assert_eq!(upserted[0].1, "release/v1.0.0");
+    assert!(commits[0].1.contains(&"CHANGELOG.md".to_string()));
+    assert_eq!(commits[0].0, "release/v1.0.0");
 
     // The release branch should be force-reset to the latest base SHA before the commit.
     let force_updated = github.force_updated_branches().await;
@@ -695,14 +745,14 @@ async fn test_orchestrate_existing_lower_version_pr_renames() {
     );
 
     // CHANGELOG.md should be committed to the new release branch.
-    let upserted = github.upserted_files().await;
+    let commits = github.batch_commits().await;
     assert_eq!(
-        upserted.len(),
+        commits.len(),
         1,
         "CHANGELOG.md should be committed to the new release branch"
     );
-    assert_eq!(upserted[0].0, "CHANGELOG.md");
-    assert_eq!(upserted[0].1, "release/v1.1.0");
+    assert!(commits[0].1.contains(&"CHANGELOG.md".to_string()));
+    assert_eq!(commits[0].0, "release/v1.1.0");
 }
 
 /// Existing PR has a *higher* version → NoOp (never downgrade).
@@ -740,7 +790,7 @@ async fn test_orchestrate_existing_higher_version_pr_is_no_op() {
     assert!(github.updated_prs().await.is_empty());
     assert!(github.deleted_branches().await.is_empty());
     assert!(
-        github.upserted_files().await.is_empty(),
+        github.batch_commits().await.is_empty(),
         "NoOp should not commit any files"
     );
 }
@@ -787,14 +837,14 @@ async fn test_orchestrate_branch_already_exists_reuses_it() {
     assert_eq!(prs[0].head, "release/v1.0.0");
 
     // CHANGELOG.md should be committed to the canonical branch.
-    let upserted = github.upserted_files().await;
+    let commits = github.batch_commits().await;
     assert_eq!(
-        upserted.len(),
+        commits.len(),
         1,
         "CHANGELOG.md should be committed to the existing branch"
     );
-    assert_eq!(upserted[0].0, "CHANGELOG.md");
-    assert_eq!(upserted[0].1, "release/v1.0.0");
+    assert!(commits[0].1.contains(&"CHANGELOG.md".to_string()));
+    assert_eq!(commits[0].0, "release/v1.0.0");
 
     // The existing branch should be force-reset to the current base SHA before the commit.
     let force_updated = github.force_updated_branches().await;
@@ -870,14 +920,14 @@ async fn test_orchestrate_changelog_merge_deduplicates_commits() {
     );
 
     // CHANGELOG.md should be committed to the existing branch.
-    let upserted = github.upserted_files().await;
+    let commits = github.batch_commits().await;
     assert_eq!(
-        upserted.len(),
+        commits.len(),
         1,
         "CHANGELOG.md should be updated on the existing branch"
     );
-    assert_eq!(upserted[0].0, "CHANGELOG.md");
-    assert_eq!(upserted[0].1, "release/v1.0.0");
+    assert!(commits[0].1.contains(&"CHANGELOG.md".to_string()));
+    assert_eq!(commits[0].0, "release/v1.0.0");
 }
 
 /// Branch name helper: `make_branch_name` formats as `"release/v{major}.{minor}.{patch}"`.

--- a/crates/core/src/traits/github_operations.rs
+++ b/crates/core/src/traits/github_operations.rs
@@ -588,10 +588,66 @@ pub trait GitHubOperations: GitOperations + Send + Sync {
     fn scoped_to(&self, installation_id: u64) -> Self
     where
         Self: Sized;
+
+    /// Retrieve the raw UTF-8 content of a file from a branch.
+    ///
+    /// Returns `Ok(None)` when the file does not exist (HTTP 404).  Returns
+    /// `Err` only for hard API failures (auth, network, invalid path, etc.).
+    ///
+    /// # Parameters
+    /// - `owner`: Repository owner name
+    /// - `repo`: Repository name
+    /// - `path`: File path relative to the repository root
+    /// - `branch`: Branch (ref) to read from
+    ///
+    /// # Errors
+    /// - `CoreError::GitHub` — the API call failed for any reason other than 404
+    async fn get_file_content(
+        &self,
+        owner: &str,
+        repo: &str,
+        path: &str,
+        branch: &str,
+    ) -> CoreResult<Option<String>>;
+
+    /// Atomically commit multiple file changes to a branch in a single Git commit.
+    ///
+    /// Uses the GitHub Git Trees API (create blob → create tree → create commit →
+    /// update ref) so that all file changes land in exactly one commit regardless
+    /// of how many files are included.  The release branch will therefore always
+    /// show a single commit on top of the base branch.
+    ///
+    /// # Parameters
+    /// - `owner`: Repository owner name
+    /// - `repo`: Repository name
+    /// - `branch`: Branch to commit to (must already exist)
+    /// - `files`: Slice of [`FileUpdate`] describing each file path and its new content
+    /// - `message`: Commit message for the batch commit
+    ///
+    /// # Errors
+    /// - `CoreError::GitHub` — any step in the Trees/Commits/Refs pipeline failed
+    /// - `CoreError::InvalidInput` — `files` is empty
+    async fn batch_commit_files(
+        &self,
+        owner: &str,
+        repo: &str,
+        branch: &str,
+        files: &[FileUpdate],
+        message: &str,
+    ) -> CoreResult<()>;
 }
 
 // Note: Git commit information is now provided by GitOperations trait
 // Use super::git_operations::GitCommit for commit data
+
+/// A single file path and content pair used by [`GitHubOperations::batch_commit_files`].
+#[derive(Debug, Clone)]
+pub struct FileUpdate {
+    /// Repo-relative file path (e.g. `"Cargo.toml"`, `"package.json"`).
+    pub path: String,
+    /// Full UTF-8 file content to write.
+    pub content: String,
+}
 
 /// Parameters for creating a new pull request
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/core/src/traits/github_operations.rs
+++ b/crates/core/src/traits/github_operations.rs
@@ -9,6 +9,15 @@ use crate::CoreResult;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 
+/// A single file path and content pair used by [`GitHubOperations::batch_commit_files`].
+#[derive(Debug, Clone)]
+pub struct FileUpdate {
+    /// Repo-relative file path (e.g. `"Cargo.toml"`, `"package.json"`).
+    pub path: String,
+    /// Full UTF-8 file content to write.
+    pub content: String,
+}
+
 /// GitHub API operations contract
 ///
 /// This trait extends `GitOperations` with GitHub-specific functionality including
@@ -664,15 +673,6 @@ pub trait GitHubOperations: GitOperations + Send + Sync {
 
 // Note: Git commit information is now provided by GitOperations trait
 // Use super::git_operations::GitCommit for commit data
-
-/// A single file path and content pair used by [`GitHubOperations::batch_commit_files`].
-#[derive(Debug, Clone)]
-pub struct FileUpdate {
-    /// Repo-relative file path (e.g. `"Cargo.toml"`, `"package.json"`).
-    pub path: String,
-    /// Full UTF-8 file content to write.
-    pub content: String,
-}
 
 /// Parameters for creating a new pull request
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/core/src/traits/github_operations.rs
+++ b/crates/core/src/traits/github_operations.rs
@@ -602,6 +602,15 @@ pub trait GitHubOperations: GitOperations + Send + Sync {
     ///
     /// # Errors
     /// - `CoreError::GitHub` — the API call failed for any reason other than 404
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// match github.get_file_content("owner", "repo", "Cargo.toml", "release/v1.2.3").await? {
+    ///     Some(content) => println!("File content: {content}"),
+    ///     None => println!("File does not exist on this branch"),
+    /// }
+    /// ```
     async fn get_file_content(
         &self,
         owner: &str,
@@ -627,6 +636,22 @@ pub trait GitHubOperations: GitOperations + Send + Sync {
     /// # Errors
     /// - `CoreError::GitHub` — any step in the Trees/Commits/Refs pipeline failed
     /// - `CoreError::InvalidInput` — `files` is empty
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// use release_regent_core::traits::github_operations::FileUpdate;
+    ///
+    /// github.batch_commit_files(
+    ///     "owner", "repo",
+    ///     "release/v1.2.3",
+    ///     &[
+    ///         FileUpdate { path: "CHANGELOG.md".to_string(), content: "## Changelog\n\n- feat: add thing".to_string() },
+    ///         FileUpdate { path: "Cargo.toml".to_string(), content: updated_cargo_toml },
+    ///     ],
+    ///     "chore(release): update manifests for v1.2.3",
+    /// ).await?;
+    /// ```
     async fn batch_commit_files(
         &self,
         owner: &str,

--- a/crates/core/src/versioning.rs
+++ b/crates/core/src/versioning.rs
@@ -419,42 +419,11 @@ impl VersionCalculator {
 
     /// Apply version bump to base version
     ///
-    /// When `major == 0` (pre-1.0 development), a `Major` bump is treated as a
-    /// `Minor` bump. Semver 2.0 allows breaking changes within major version 0 to
-    /// only advance the minor component so that projects stay on `0.x` until they
-    /// deliberately ship their first stable `1.0.0` release.
+    /// Delegates to the public [`apply_semver_bump`] free function so that all
+    /// callers share the single canonical semver arithmetic — including the
+    /// pre-1.0 rule.
     fn apply_version_bump(base: &SemanticVersion, bump: &VersionBump) -> SemanticVersion {
-        match bump {
-            VersionBump::Major if base.major == 0 => SemanticVersion {
-                major: 0,
-                minor: base.minor + 1,
-                patch: 0,
-                prerelease: None,
-                build: None,
-            },
-            VersionBump::Major => SemanticVersion {
-                major: base.major + 1,
-                minor: 0,
-                patch: 0,
-                prerelease: None,
-                build: None,
-            },
-            VersionBump::Minor => SemanticVersion {
-                major: base.major,
-                minor: base.minor + 1,
-                patch: 0,
-                prerelease: None,
-                build: None,
-            },
-            VersionBump::Patch => SemanticVersion {
-                major: base.major,
-                minor: base.minor,
-                patch: base.patch + 1,
-                prerelease: None,
-                build: None,
-            },
-            VersionBump::None => base.clone(),
-        }
+        apply_semver_bump(base, bump.clone())
     }
 
     /// Parse a semantic version string
@@ -674,6 +643,77 @@ impl VersionCalculator {
                 }
             }
         }
+    }
+}
+
+/// Apply a standard semver bump to a base version.
+///
+/// This is the single canonical implementation of semver arithmetic for
+/// Release Regent. All version calculators — [`VersionCalculator`],
+/// [`DefaultVersionCalculator`], and [`GitHubVersionCalculator`] — delegate
+/// to this function so that the bump rules are defined exactly once.
+///
+/// Custom [`crate::traits::version_calculator::VersionCalculator`]
+/// implementations may also call this function to reuse the standard semver
+/// arithmetic, including the pre-1.0 rule, rather than re-implementing it.
+///
+/// ## Pre-1.0 rule
+///
+/// When `base.major == 0`, a `Major` bump is treated as a `Minor` bump.
+/// Semver 2.0 allows breaking changes within major version 0 to only advance
+/// the minor component, so that projects stay on `0.x` until they
+/// deliberately ship their first stable `1.0.0` release.
+///
+/// ## Examples
+///
+/// ```
+/// use release_regent_core::versioning::{apply_semver_bump, SemanticVersion, VersionBump};
+///
+/// let v = SemanticVersion { major: 1, minor: 2, patch: 3,
+///                            prerelease: None, build: None };
+///
+/// assert_eq!(apply_semver_bump(&v, VersionBump::Major).to_string(), "2.0.0");
+/// assert_eq!(apply_semver_bump(&v, VersionBump::Minor).to_string(), "1.3.0");
+/// assert_eq!(apply_semver_bump(&v, VersionBump::Patch).to_string(), "1.2.4");
+/// assert_eq!(apply_semver_bump(&v, VersionBump::None).to_string(),  "1.2.3");
+///
+/// // Pre-1.0: Major bump advances minor only.
+/// let pre = SemanticVersion { major: 0, minor: 1, patch: 0,
+///                              prerelease: None, build: None };
+/// assert_eq!(apply_semver_bump(&pre, VersionBump::Major).to_string(), "0.2.0");
+/// ```
+#[must_use]
+pub fn apply_semver_bump(base: &SemanticVersion, bump: VersionBump) -> SemanticVersion {
+    match bump {
+        VersionBump::Major if base.major == 0 => SemanticVersion {
+            major: 0,
+            minor: base.minor + 1,
+            patch: 0,
+            prerelease: None,
+            build: None,
+        },
+        VersionBump::Major => SemanticVersion {
+            major: base.major + 1,
+            minor: 0,
+            patch: 0,
+            prerelease: None,
+            build: None,
+        },
+        VersionBump::Minor => SemanticVersion {
+            major: base.major,
+            minor: base.minor + 1,
+            patch: 0,
+            prerelease: None,
+            build: None,
+        },
+        VersionBump::Patch => SemanticVersion {
+            major: base.major,
+            minor: base.minor,
+            patch: base.patch + 1,
+            prerelease: None,
+            build: None,
+        },
+        VersionBump::None => base.clone(),
     }
 }
 

--- a/crates/core/src/versioning_tests.rs
+++ b/crates/core/src/versioning_tests.rs
@@ -1015,3 +1015,368 @@ fn test_apply_bump_floor_raises_patch_to_minor() {
 
     assert_eq!(result.to_string(), "1.3.0");
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// apply_semver_bump — canonical free function
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn apply_semver_bump_major_bumps_major_for_v1_plus() {
+    let base = SemanticVersion {
+        major: 1,
+        minor: 2,
+        patch: 3,
+        prerelease: None,
+        build: None,
+    };
+    let result = apply_semver_bump(&base, VersionBump::Major);
+    assert_eq!(result.major, 2);
+    assert_eq!(result.minor, 0);
+    assert_eq!(result.patch, 0);
+    assert!(result.prerelease.is_none());
+    assert!(result.build.is_none());
+}
+
+#[test]
+fn apply_semver_bump_major_on_pre_one_zero_bumps_minor_not_major() {
+    // The canonical pre-1.0 rule: breaking change on 0.x must not cross the major boundary.
+    let base = SemanticVersion {
+        major: 0,
+        minor: 1,
+        patch: 0,
+        prerelease: None,
+        build: None,
+    };
+    let result = apply_semver_bump(&base, VersionBump::Major);
+    assert_eq!(result.major, 0, "major must stay 0 in pre-1.0 mode");
+    assert_eq!(result.minor, 2, "0.1.0 + Major → 0.2.0, not 1.0.0");
+    assert_eq!(result.patch, 0);
+}
+
+#[test]
+fn apply_semver_bump_minor_increments_minor_and_resets_patch() {
+    let base = SemanticVersion {
+        major: 1,
+        minor: 2,
+        patch: 3,
+        prerelease: None,
+        build: None,
+    };
+    let result = apply_semver_bump(&base, VersionBump::Minor);
+    assert_eq!(result.major, 1);
+    assert_eq!(result.minor, 3);
+    assert_eq!(result.patch, 0);
+}
+
+#[test]
+fn apply_semver_bump_patch_increments_patch_only() {
+    let base = SemanticVersion {
+        major: 1,
+        minor: 2,
+        patch: 3,
+        prerelease: None,
+        build: None,
+    };
+    let result = apply_semver_bump(&base, VersionBump::Patch);
+    assert_eq!(result.major, 1);
+    assert_eq!(result.minor, 2);
+    assert_eq!(result.patch, 4);
+}
+
+#[test]
+fn apply_semver_bump_none_leaves_version_unchanged() {
+    let base = SemanticVersion {
+        major: 3,
+        minor: 4,
+        patch: 5,
+        prerelease: None,
+        build: None,
+    };
+    let result = apply_semver_bump(&base, VersionBump::None);
+    assert_eq!(result, base);
+}
+
+#[test]
+fn apply_semver_bump_strips_prerelease_and_build_metadata() {
+    // The output of a bump should never carry pre-release/build from the input.
+    let base = SemanticVersion {
+        major: 1,
+        minor: 0,
+        patch: 0,
+        prerelease: Some("rc.1".to_string()),
+        build: Some("20240101".to_string()),
+    };
+    let result = apply_semver_bump(&base, VersionBump::Patch);
+    assert!(
+        result.prerelease.is_none(),
+        "bumped version must not carry pre-release tag"
+    );
+    assert!(
+        result.build.is_none(),
+        "bumped version must not carry build metadata"
+    );
+    assert_eq!(result.to_string(), "1.0.1");
+}
+
+// Cross-entry-point consistency test: all three calculator paths must produce
+// identical output for the same (0.1.0, Major) input, exercising the pre-1.0 rule.
+#[cfg(test)]
+mod cross_calculator_consistency {
+    use super::*;
+    use crate::default_version_calculator::DefaultVersionCalculator;
+    use crate::github_version_calculator::GitHubVersionCalculator;
+    use crate::traits::git_operations::{
+        GetCommitsOptions, GitCommit, GitOperations, GitRepository, ListTagsOptions,
+    };
+    use crate::traits::github_operations::{
+        CollaboratorPermission, CreatePullRequestParams, CreateReleaseParams, GitHubOperations,
+        GitUser, Label, PullRequest, Release, Repository, Tag, UpdateReleaseParams,
+    };
+    use crate::traits::version_calculator::{
+        VersionBump as TraitVersionBump, VersionCalculator as VersionCalculatorTrait,
+    };
+    use async_trait::async_trait;
+
+    // Minimal stub that satisfies GitHubOperations for GitHubVersionCalculator.
+    #[derive(Clone)]
+    struct StubGitHub;
+
+    #[async_trait]
+    impl GitOperations for StubGitHub {
+        async fn get_commits_between(
+            &self,
+            _: &str,
+            _: &str,
+            _: &str,
+            _: &str,
+            _: GetCommitsOptions,
+        ) -> crate::CoreResult<Vec<GitCommit>> {
+            Ok(vec![])
+        }
+        async fn get_commit(&self, _: &str, _: &str, _: &str) -> crate::CoreResult<GitCommit> {
+            Err(crate::CoreError::not_found("stub"))
+        }
+        async fn list_tags(
+            &self,
+            _: &str,
+            _: &str,
+            _: ListTagsOptions,
+        ) -> crate::CoreResult<Vec<GitTag>> {
+            Ok(vec![])
+        }
+        async fn get_tag(&self, _: &str, _: &str, _: &str) -> crate::CoreResult<GitTag> {
+            Err(crate::CoreError::not_found("stub"))
+        }
+        async fn tag_exists(&self, _: &str, _: &str, _: &str) -> crate::CoreResult<bool> {
+            Ok(false)
+        }
+        async fn get_head_commit(
+            &self,
+            _: &str,
+            _: &str,
+            _: Option<&str>,
+        ) -> crate::CoreResult<GitCommit> {
+            Err(crate::CoreError::not_found("stub"))
+        }
+        async fn get_repository_info(&self, _: &str, _: &str) -> crate::CoreResult<GitRepository> {
+            Err(crate::CoreError::not_found("stub"))
+        }
+    }
+
+    #[async_trait]
+    impl GitHubOperations for StubGitHub {
+        async fn add_labels(&self, _: &str, _: &str, _: u64, _: &[&str]) -> crate::CoreResult<()> {
+            Ok(())
+        }
+        async fn create_branch(&self, _: &str, _: &str, _: &str, _: &str) -> crate::CoreResult<()> {
+            Ok(())
+        }
+        async fn create_issue_comment(
+            &self,
+            _: &str,
+            _: &str,
+            _: u64,
+            _: &str,
+        ) -> crate::CoreResult<()> {
+            Ok(())
+        }
+        async fn create_pull_request(
+            &self,
+            _: &str,
+            _: &str,
+            _: CreatePullRequestParams,
+        ) -> crate::CoreResult<PullRequest> {
+            Err(crate::CoreError::not_found("stub"))
+        }
+        async fn create_release(
+            &self,
+            _: &str,
+            _: &str,
+            _: CreateReleaseParams,
+        ) -> crate::CoreResult<Release> {
+            Err(crate::CoreError::not_found("stub"))
+        }
+        async fn create_tag(
+            &self,
+            _: &str,
+            _: &str,
+            _: &str,
+            _: &str,
+            _: Option<String>,
+            _: Option<GitUser>,
+        ) -> crate::CoreResult<Tag> {
+            Err(crate::CoreError::not_found("stub"))
+        }
+        async fn delete_branch(&self, _: &str, _: &str, _: &str) -> crate::CoreResult<()> {
+            Ok(())
+        }
+        async fn force_update_branch(
+            &self,
+            _: &str,
+            _: &str,
+            _: &str,
+            _: &str,
+        ) -> crate::CoreResult<()> {
+            Ok(())
+        }
+        async fn get_collaborator_permission(
+            &self,
+            _: &str,
+            _: &str,
+            _: &str,
+        ) -> crate::CoreResult<CollaboratorPermission> {
+            Ok(CollaboratorPermission::Write)
+        }
+        async fn get_installation_id_for_repo(&self, _: &str, _: &str) -> crate::CoreResult<u64> {
+            Ok(0)
+        }
+        async fn get_latest_release(&self, _: &str, _: &str) -> crate::CoreResult<Option<Release>> {
+            Ok(None)
+        }
+        async fn get_pull_request(
+            &self,
+            _: &str,
+            _: &str,
+            _: u64,
+        ) -> crate::CoreResult<PullRequest> {
+            Err(crate::CoreError::not_found("stub"))
+        }
+        async fn get_release_by_tag(
+            &self,
+            _: &str,
+            _: &str,
+            _: &str,
+        ) -> crate::CoreResult<Release> {
+            Err(crate::CoreError::not_found("stub"))
+        }
+        async fn list_pr_labels(&self, _: &str, _: &str, _: u64) -> crate::CoreResult<Vec<Label>> {
+            Ok(vec![])
+        }
+        async fn list_pull_requests(
+            &self,
+            _: &str,
+            _: &str,
+            _: Option<&str>,
+            _: Option<&str>,
+            _: Option<&str>,
+            _: Option<u8>,
+            _: Option<u32>,
+        ) -> crate::CoreResult<Vec<PullRequest>> {
+            Ok(vec![])
+        }
+        async fn list_releases(
+            &self,
+            _: &str,
+            _: &str,
+            _: Option<u8>,
+            _: Option<u32>,
+        ) -> crate::CoreResult<Vec<Release>> {
+            Ok(vec![])
+        }
+        async fn remove_label(&self, _: &str, _: &str, _: u64, _: &str) -> crate::CoreResult<()> {
+            Ok(())
+        }
+        async fn search_pull_requests(
+            &self,
+            _: &str,
+            _: &str,
+            _: &str,
+        ) -> crate::CoreResult<Vec<PullRequest>> {
+            Ok(vec![])
+        }
+        async fn update_pull_request(
+            &self,
+            _: &str,
+            _: &str,
+            _: u64,
+            _: Option<String>,
+            _: Option<String>,
+            _: Option<String>,
+        ) -> crate::CoreResult<PullRequest> {
+            Err(crate::CoreError::not_found("stub"))
+        }
+        async fn update_release(
+            &self,
+            _: &str,
+            _: &str,
+            _: u64,
+            _: UpdateReleaseParams,
+        ) -> crate::CoreResult<Release> {
+            Err(crate::CoreError::not_found("stub"))
+        }
+        async fn upsert_file(
+            &self,
+            _: &str,
+            _: &str,
+            _: &str,
+            _: &str,
+            _: &str,
+            _: &str,
+        ) -> crate::CoreResult<()> {
+            Ok(())
+        }
+        fn scoped_to(&self, _: u64) -> Self {
+            Self
+        }
+    }
+
+    #[test]
+    fn all_three_calculators_agree_on_pre_one_zero_major_bump() {
+        // ( 0.1.0, Major ) → 0.2.0 — the pre-1.0 rule — must be identical
+        // across all three calculator paths.
+        let base = SemanticVersion {
+            major: 0,
+            minor: 1,
+            patch: 0,
+            prerelease: None,
+            build: None,
+        };
+
+        // Path 1: VersionCalculator (core versioning engine)
+        let v1 = VersionCalculator::apply_version_bump(&base, &VersionBump::Major);
+        assert_eq!(v1.to_string(), "0.2.0", "VersionCalculator path");
+
+        // Path 2: DefaultVersionCalculator
+        let calc2 = DefaultVersionCalculator::new();
+        let v2 = calc2
+            .apply_version_bump(base.clone(), TraitVersionBump::Major, None, None)
+            .expect("DefaultVersionCalculator::apply_version_bump should not fail");
+        assert_eq!(v2.to_string(), "0.2.0", "DefaultVersionCalculator path");
+
+        // Path 3: GitHubVersionCalculator (via apply_version_bump trait method)
+        let calc3 = GitHubVersionCalculator::new(StubGitHub);
+        let v3 = calc3
+            .apply_version_bump(base.clone(), TraitVersionBump::Major, None, None)
+            .expect("GitHubVersionCalculator::apply_version_bump should not fail");
+        assert_eq!(v3.to_string(), "0.2.0", "GitHubVersionCalculator path");
+
+        assert_eq!(
+            v1, v2,
+            "VersionCalculator and DefaultVersionCalculator must agree"
+        );
+        assert_eq!(
+            v2, v3,
+            "DefaultVersionCalculator and GitHubVersionCalculator must agree"
+        );
+    }
+}

--- a/crates/core/src/versioning_tests.rs
+++ b/crates/core/src/versioning_tests.rs
@@ -1335,6 +1335,25 @@ mod cross_calculator_consistency {
         ) -> crate::CoreResult<()> {
             Ok(())
         }
+        async fn get_file_content(
+            &self,
+            _: &str,
+            _: &str,
+            _: &str,
+            _: &str,
+        ) -> crate::CoreResult<Option<String>> {
+            Ok(None)
+        }
+        async fn batch_commit_files(
+            &self,
+            _: &str,
+            _: &str,
+            _: &str,
+            _: &[crate::traits::github_operations::FileUpdate],
+            _: &str,
+        ) -> crate::CoreResult<()> {
+            Ok(())
+        }
         fn scoped_to(&self, _: u64) -> Self {
             Self
         }

--- a/crates/github_client/src/lib.rs
+++ b/crates/github_client/src/lib.rs
@@ -22,9 +22,9 @@ use release_regent_core::{
             GitUser as GitOpsUser, ListTagsOptions, TagSortOrder,
         },
         github_operations::{
-            CollaboratorPermission, CreatePullRequestParams, CreateReleaseParams, GitHubOperations,
-            GitUser as GitHubUser, Label, PullRequest, PullRequestBranch, Release, Repository, Tag,
-            UpdateReleaseParams,
+            CollaboratorPermission, CreatePullRequestParams, CreateReleaseParams, FileUpdate,
+            GitHubOperations, GitUser as GitHubUser, Label, PullRequest, PullRequestBranch,
+            Release, Repository, Tag, UpdateReleaseParams,
         },
     },
     CoreError, CoreResult,
@@ -994,9 +994,10 @@ impl GitHubOperations for GitHubClient {
                     None
                 } else {
                     let body = resp.text().await.unwrap_or_default();
-                    return Err(CoreError::github(std::io::Error::other(format!(
-                        "GET /contents failed with status {status}: {body}"
-                    ))));
+                    return Err(CoreError::github(std::io::Error::new(
+                        std::io::ErrorKind::Other,
+                        format!("GET /contents failed with status {status}: {body}"),
+                    )));
                 }
             }
             Err(ApiError::NotFound) => None,
@@ -1022,12 +1023,242 @@ impl GitHubOperations for GitHubClient {
         let status = response.status().as_u16();
         if !(200..=201).contains(&status) {
             let resp_body = response.text().await.unwrap_or_default();
-            return Err(CoreError::github(std::io::Error::other(format!(
-                "PUT /contents failed with status {status}: {resp_body}"
-            ))));
+            return Err(CoreError::github(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                format!("PUT /contents failed with status {status}: {resp_body}"),
+            )));
         }
 
         info!(owner, repo, path, branch, "File upserted successfully");
+        Ok(())
+    }
+
+    #[instrument(skip(self))]
+    async fn get_file_content(
+        &self,
+        owner: &str,
+        repo: &str,
+        path: &str,
+        branch: &str,
+    ) -> CoreResult<Option<String>> {
+        info!(
+            owner,
+            repo, path, branch, "Getting file content from branch"
+        );
+
+        let installation = self.installation().await?;
+        let get_url = format!(
+            "/repos/{owner}/{repo}/contents/{}?ref={}",
+            urlencoding_encode(path),
+            urlencoding_encode_query_value(branch),
+        );
+
+        match installation.get(&get_url).await {
+            Ok(resp) => {
+                let status = resp.status().as_u16();
+                if status == 200 {
+                    let json: serde_json::Value = resp.json().await.map_err(CoreError::github)?;
+                    let encoded = json["content"]
+                        .as_str()
+                        .unwrap_or("")
+                        .replace(['\n', '\r'], "");
+                    let bytes = base64::engine::general_purpose::STANDARD
+                        .decode(&encoded)
+                        .map_err(|e| {
+                            CoreError::github(std::io::Error::new(
+                                std::io::ErrorKind::Other,
+                                format!("base64 decode for {path}: {e}"),
+                            ))
+                        })?;
+                    Ok(Some(String::from_utf8_lossy(&bytes).into_owned()))
+                } else if status == 404 {
+                    Ok(None)
+                } else {
+                    let body = resp.text().await.unwrap_or_default();
+                    Err(CoreError::github(std::io::Error::new(
+                        std::io::ErrorKind::Other,
+                        format!("GET /contents failed with status {status}: {body}"),
+                    )))
+                }
+            }
+            Err(ApiError::NotFound) => Ok(None),
+            Err(e) => Err(map_sdk_error(e)),
+        }
+    }
+
+    #[instrument(skip(self, files))]
+    async fn batch_commit_files(
+        &self,
+        owner: &str,
+        repo: &str,
+        branch: &str,
+        files: &[FileUpdate],
+        message: &str,
+    ) -> CoreResult<()> {
+        info!(
+            owner,
+            repo,
+            branch,
+            file_count = files.len(),
+            "Committing files via Git Trees API"
+        );
+
+        let installation = self.installation().await?;
+
+        // Step 1: Get the current HEAD commit SHA for the branch.
+        let ref_url = format!("/repos/{owner}/{repo}/git/ref/heads/{branch}");
+        let ref_resp = installation.get(&ref_url).await.map_err(map_sdk_error)?;
+        let ref_status = ref_resp.status().as_u16();
+        let ref_json: serde_json::Value = ref_resp.json().await.map_err(CoreError::github)?;
+        if ref_status != 200 {
+            return Err(CoreError::github(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                format!("GET ref failed with status {ref_status}"),
+            )));
+        }
+        let head_sha = ref_json["object"]["sha"]
+            .as_str()
+            .ok_or_else(|| {
+                CoreError::github(std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    "ref response missing object.sha",
+                ))
+            })?
+            .to_owned();
+
+        // Step 2: Get the base tree SHA from the HEAD commit.
+        let commit_url = format!("/repos/{owner}/{repo}/git/commits/{head_sha}");
+        let commit_resp = installation.get(&commit_url).await.map_err(map_sdk_error)?;
+        let commit_json: serde_json::Value = commit_resp.json().await.map_err(CoreError::github)?;
+        let base_tree_sha = commit_json["tree"]["sha"]
+            .as_str()
+            .ok_or_else(|| {
+                CoreError::github(std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    "commit response missing tree.sha",
+                ))
+            })?
+            .to_owned();
+
+        // Step 3: Create a blob for each file.
+        let mut tree_entries = Vec::with_capacity(files.len());
+        for file in files {
+            let encoded = base64::engine::general_purpose::STANDARD.encode(file.content.as_bytes());
+            let blob_body = serde_json::json!({
+                "content": encoded,
+                "encoding": "base64",
+            });
+            let blob_url = format!("/repos/{owner}/{repo}/git/blobs");
+            let blob_resp = installation
+                .post(&blob_url, &blob_body)
+                .await
+                .map_err(map_sdk_error)?;
+            let blob_status = blob_resp.status().as_u16();
+            let blob_json: serde_json::Value = blob_resp.json().await.map_err(CoreError::github)?;
+            if blob_status != 201 {
+                return Err(CoreError::github(std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    format!(
+                        "POST /git/blobs failed with status {blob_status} for {}",
+                        file.path
+                    ),
+                )));
+            }
+            let blob_sha = blob_json["sha"]
+                .as_str()
+                .ok_or_else(|| {
+                    CoreError::github(std::io::Error::new(
+                        std::io::ErrorKind::Other,
+                        format!("blob response missing sha for {}", file.path),
+                    ))
+                })?
+                .to_owned();
+            tree_entries.push(serde_json::json!({
+                "path": file.path,
+                "mode": "100644",
+                "type": "blob",
+                "sha": blob_sha,
+            }));
+        }
+
+        // Step 4: Create a new tree.
+        let tree_body = serde_json::json!({
+            "base_tree": base_tree_sha,
+            "tree": tree_entries,
+        });
+        let tree_url = format!("/repos/{owner}/{repo}/git/trees");
+        let tree_resp = installation
+            .post(&tree_url, &tree_body)
+            .await
+            .map_err(map_sdk_error)?;
+        let tree_status = tree_resp.status().as_u16();
+        let tree_json: serde_json::Value = tree_resp.json().await.map_err(CoreError::github)?;
+        if tree_status != 201 {
+            return Err(CoreError::github(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                format!("POST /git/trees failed with status {tree_status}"),
+            )));
+        }
+        let new_tree_sha = tree_json["sha"]
+            .as_str()
+            .ok_or_else(|| {
+                CoreError::github(std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    "tree response missing sha",
+                ))
+            })?
+            .to_owned();
+
+        // Step 5: Create a new commit.
+        let new_commit_body = serde_json::json!({
+            "message": message,
+            "tree": new_tree_sha,
+            "parents": [head_sha],
+        });
+        let new_commit_url = format!("/repos/{owner}/{repo}/git/commits");
+        let new_commit_resp = installation
+            .post(&new_commit_url, &new_commit_body)
+            .await
+            .map_err(map_sdk_error)?;
+        let new_commit_status = new_commit_resp.status().as_u16();
+        let new_commit_json: serde_json::Value =
+            new_commit_resp.json().await.map_err(CoreError::github)?;
+        if new_commit_status != 201 {
+            return Err(CoreError::github(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                format!("POST /git/commits failed with status {new_commit_status}"),
+            )));
+        }
+        let new_commit_sha = new_commit_json["sha"]
+            .as_str()
+            .ok_or_else(|| {
+                CoreError::github(std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    "new commit response missing sha",
+                ))
+            })?
+            .to_owned();
+
+        // Step 6: Update the branch ref to point to the new commit.
+        let patch_ref_url = format!("/repos/{owner}/{repo}/git/refs/heads/{branch}");
+        let patch_body = serde_json::json!({
+            "sha": new_commit_sha,
+            "force": false,
+        });
+        let patch_resp = installation
+            .patch(&patch_ref_url, &patch_body)
+            .await
+            .map_err(map_sdk_error)?;
+        let patch_status = patch_resp.status().as_u16();
+        if patch_status != 200 {
+            let body = patch_resp.text().await.unwrap_or_default();
+            return Err(CoreError::github(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                format!("PATCH /git/refs failed with status {patch_status}: {body}"),
+            )));
+        }
+
+        info!(owner, repo, branch, commit_sha = %new_commit_sha, "Files committed successfully");
         Ok(())
     }
 
@@ -1042,7 +1273,8 @@ impl GitHubOperations for GitHubClient {
             .map_err(map_sdk_error)?;
         let body: serde_json::Value = response.json().await.map_err(CoreError::github)?;
         body["id"].as_u64().ok_or_else(|| CoreError::GitHub {
-            source: Box::new(std::io::Error::other(
+            source: Box::new(std::io::Error::new(
+                std::io::ErrorKind::Other,
                 "installation lookup response missing 'id' field",
             )),
             context: None,

--- a/crates/github_client/src/lib.rs
+++ b/crates/github_client/src/lib.rs
@@ -1070,7 +1070,13 @@ impl GitHubOperations for GitHubClient {
                                 format!("base64 decode for {path}: {e}"),
                             ))
                         })?;
-                    Ok(Some(String::from_utf8_lossy(&bytes).into_owned()))
+                    let text = String::from_utf8(bytes).map_err(|e| {
+                        CoreError::github(std::io::Error::new(
+                            std::io::ErrorKind::Other,
+                            format!("file {path} contains non-UTF-8 bytes: {e}"),
+                        ))
+                    })?;
+                    Ok(Some(text))
                 } else if status == 404 {
                     Ok(None)
                 } else {
@@ -1095,6 +1101,13 @@ impl GitHubOperations for GitHubClient {
         files: &[FileUpdate],
         message: &str,
     ) -> CoreResult<()> {
+        if files.is_empty() {
+            return Err(CoreError::invalid_input(
+                "batch_commit_files",
+                "files slice must not be empty".to_string(),
+            ));
+        }
+
         info!(
             owner,
             repo,

--- a/crates/testing/src/builders/configuration_builder.rs
+++ b/crates/testing/src/builders/configuration_builder.rs
@@ -92,6 +92,8 @@ fn create_default_config() -> ReleaseRegentConfig {
             title_template: "Release {{version}}".to_string(),
             body_template: "Release notes for {{version}}".to_string(),
             draft: false,
+            manifest_files: Vec::new(),
+            auto_detect_manifests: true,
         },
         releases: ReleasesConfig {
             draft: false,

--- a/crates/testing/src/mocks/github_operations.rs
+++ b/crates/testing/src/mocks/github_operations.rs
@@ -22,6 +22,14 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
+// ─── Type aliases to keep field types below the complexity threshold ──────────
+
+type GetFileContentCalls = Arc<RwLock<Vec<(String, String, String, String)>>>;
+type GetFileContentResponses =
+    Arc<RwLock<HashMap<(String, String, String, String), Option<String>>>>;
+type BatchCommitFilesCalls = Arc<RwLock<Vec<(String, String, String, Vec<String>, String)>>>;
+type UpsertFileCalls = Arc<RwLock<Vec<(String, String, String, String, String, String)>>>;
+
 /// Mock implementation of `GitHubOperations` trait
 ///
 /// This mock supports:
@@ -82,7 +90,13 @@ pub struct MockGitHubOperations {
     ///
     /// Wrapped in `Arc<RwLock<...>>` so that the `&self` async-trait methods
     /// can mutate the vec without requiring `&mut self`.
-    upsert_file_calls: Arc<RwLock<Vec<(String, String, String, String, String, String)>>>,
+    upsert_file_calls: UpsertFileCalls,
+    /// Recorded `get_file_content` calls: (owner, repo, path, branch).
+    get_file_content_calls: GetFileContentCalls,
+    /// Configurable responses for `get_file_content`. Key is (owner, repo, path, branch).
+    get_file_content_responses: GetFileContentResponses,
+    /// Recorded `batch_commit_files` calls: (owner, repo, branch, file_paths, message).
+    batch_commit_files_calls: BatchCommitFilesCalls,
 }
 
 impl MockGitHubOperations {
@@ -133,6 +147,9 @@ impl MockGitHubOperations {
             collaborator_permission: None,
             method_errors: HashMap::new(),
             upsert_file_calls: Arc::new(RwLock::new(Vec::new())),
+            get_file_content_calls: Arc::new(RwLock::new(Vec::new())),
+            get_file_content_responses: Arc::new(RwLock::new(HashMap::new())),
+            batch_commit_files_calls: Arc::new(RwLock::new(Vec::new())),
         }
     }
 
@@ -141,6 +158,42 @@ impl MockGitHubOperations {
     /// Each element is `(owner, repo, path, commit_message, content, branch)`.
     pub async fn upsert_file_calls(&self) -> Vec<(String, String, String, String, String, String)> {
         self.upsert_file_calls.read().await.clone()
+    }
+
+    /// Return all recorded `get_file_content` calls.
+    ///
+    /// Each element is `(owner, repo, path, branch)`.
+    pub async fn get_file_content_calls(&self) -> Vec<(String, String, String, String)> {
+        self.get_file_content_calls.read().await.clone()
+    }
+
+    /// Configure a response for a specific `get_file_content` call.
+    pub async fn with_file_content(
+        &self,
+        owner: &str,
+        repo: &str,
+        path: &str,
+        branch: &str,
+        content: Option<String>,
+    ) {
+        self.get_file_content_responses.write().await.insert(
+            (
+                owner.to_string(),
+                repo.to_string(),
+                path.to_string(),
+                branch.to_string(),
+            ),
+            content,
+        );
+    }
+
+    /// Return all recorded `batch_commit_files` calls.
+    ///
+    /// Each element is `(owner, repo, branch, file_paths, message)`.
+    pub async fn batch_commit_files_calls(
+        &self,
+    ) -> Vec<(String, String, String, Vec<String>, String)> {
+        self.batch_commit_files_calls.read().await.clone()
     }
 
     /// Record a method call for tracking
@@ -200,6 +253,9 @@ impl MockGitHubOperations {
             collaborator_permission: None,
             method_errors: HashMap::new(),
             upsert_file_calls: Arc::new(RwLock::new(Vec::new())),
+            get_file_content_calls: Arc::new(RwLock::new(Vec::new())),
+            get_file_content_responses: Arc::new(RwLock::new(HashMap::new())),
+            batch_commit_files_calls: Arc::new(RwLock::new(Vec::new())),
         }
     }
 
@@ -1258,6 +1314,9 @@ impl GitHubOperations for MockGitHubOperations {
             collaborator_permission: self.collaborator_permission.clone(),
             method_errors: self.method_errors.clone(),
             upsert_file_calls: Arc::clone(&self.upsert_file_calls),
+            get_file_content_calls: Arc::clone(&self.get_file_content_calls),
+            get_file_content_responses: Arc::clone(&self.get_file_content_responses),
+            batch_commit_files_calls: Arc::clone(&self.batch_commit_files_calls),
         }
     }
 
@@ -1297,6 +1356,103 @@ impl GitHubOperations for MockGitHubOperations {
             commit_message.to_string(),
             content.to_string(),
             branch.to_string(),
+        ));
+
+        self.record_call(method, &params_str, CallResult::Success)
+            .await;
+        Ok(())
+    }
+
+    async fn get_file_content(
+        &self,
+        owner: &str,
+        repo: &str,
+        path: &str,
+        branch: &str,
+    ) -> CoreResult<Option<String>> {
+        let method = "get_file_content";
+        let params_str = format!("owner={owner}, repo={repo}, path={path}, branch={branch}");
+
+        self.check_quota().await?;
+        self.simulate_latency().await;
+
+        if self.should_simulate_failure().await {
+            let error = CoreError::network("Simulated GitHub API error");
+            self.record_call(method, &params_str, CallResult::Error(error.to_string()))
+                .await;
+            return Err(error);
+        }
+
+        if let Some(msg) = self.method_errors.get(method) {
+            let error = CoreError::network(msg.clone());
+            self.record_call(method, &params_str, CallResult::Error(error.to_string()))
+                .await;
+            return Err(error);
+        }
+
+        self.get_file_content_calls.write().await.push((
+            owner.to_string(),
+            repo.to_string(),
+            path.to_string(),
+            branch.to_string(),
+        ));
+
+        let key = (
+            owner.to_string(),
+            repo.to_string(),
+            path.to_string(),
+            branch.to_string(),
+        );
+        let response = self
+            .get_file_content_responses
+            .read()
+            .await
+            .get(&key)
+            .cloned();
+
+        self.record_call(method, &params_str, CallResult::Success)
+            .await;
+        Ok(response.unwrap_or(None))
+    }
+
+    async fn batch_commit_files(
+        &self,
+        owner: &str,
+        repo: &str,
+        branch: &str,
+        files: &[release_regent_core::traits::github_operations::FileUpdate],
+        message: &str,
+    ) -> CoreResult<()> {
+        let method = "batch_commit_files";
+        let params_str = format!(
+            "owner={owner}, repo={repo}, branch={branch}, files={}",
+            files.len()
+        );
+
+        self.check_quota().await?;
+        self.simulate_latency().await;
+
+        if self.should_simulate_failure().await {
+            let error = CoreError::network("Simulated GitHub API error");
+            self.record_call(method, &params_str, CallResult::Error(error.to_string()))
+                .await;
+            return Err(error);
+        }
+
+        if let Some(msg) = self.method_errors.get(method) {
+            let error = CoreError::network(msg.clone());
+            self.record_call(method, &params_str, CallResult::Error(error.to_string()))
+                .await;
+            return Err(error);
+        }
+
+        let file_paths: Vec<String> = files.iter().map(|f| f.path.clone()).collect();
+        self.batch_commit_files_calls.write().await.push((
+            owner.to_string(),
+            repo.to_string(),
+            branch.to_string(),
+            file_paths,
+            message.to_string(),
         ));
 
         self.record_call(method, &params_str, CallResult::Success)

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -154,7 +154,53 @@ auto_merge = false  # Manual merge required
 # auto_merge = true # Auto-merge when checks pass
 ```
 
-## Changelog Configuration
+### `release_pr.auto_detect_manifests`
+
+**Type**: Boolean
+**Default**: `true`
+**Description**: When `true`, Release Regent automatically probes the repository for well-known
+manifest files (`Cargo.toml`, `package.json`, `pyproject.toml`, `composer.json`) and updates
+version fields in any that are present.  Files listed in `manifest_files` are always processed
+regardless of this setting.
+
+> **Migration note**: This setting defaults to `true`, which is a behaviour change for repositories
+> that were configured before manifest auto-detection was introduced.  If you do not want Release
+> Regent to probe for manifest files automatically, add `auto_detect_manifests = false` to your
+> `[release_pr]` section to preserve the previous behaviour.
+
+```toml
+[release_pr]
+auto_detect_manifests = true   # Default: probe for well-known manifest files
+# auto_detect_manifests = false # Disable; update only files listed in manifest_files
+```
+
+### `release_pr.manifest_files`
+
+**Type**: Array of inline tables
+**Default**: `[]` (empty — rely on auto-detection or no manifest updates)
+**Description**: Explicit list of manifest files to update on each release.  Each entry specifies
+the repository-relative path, the file format, and the dot-separated key path within the file
+that holds the version string.
+
+Supported formats: `"toml"`, `"json"`, `"yaml"`, `"python-pep621"`.
+
+| Format | Typical file | Default `version_key` |
+|---|---|---|
+| `"toml"` | `Cargo.toml` | `"package.version"` |
+| `"json"` | `package.json` | `"version"` |
+| `"yaml"` | `Chart.yaml` | `"version"` |
+| `"python-pep621"` | `pyproject.toml` | `"project.version"` |
+
+```toml
+[release_pr]
+manifest_files = [
+  { path = "Cargo.toml",     format = "toml",         version_key = "package.version"  },
+  { path = "package.json",   format = "json",          version_key = "version"          },
+  { path = "pyproject.toml", format = "python-pep621", version_key = "project.version"  },
+  # Poetry-style pyproject.toml uses a three-segment key:
+  # { path = "pyproject.toml", format = "toml", version_key = "tool.poetry.version"    },
+]
+```
 
 Release Regent uses the git-cliff-core library for advanced changelog generation, providing powerful templating and customization capabilities.
 

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -182,23 +182,25 @@ auto_detect_manifests = true   # Default: probe for well-known manifest files
 the repository-relative path, the file format, and the dot-separated key path within the file
 that holds the version string.
 
-Supported formats: `"toml"`, `"json"`, `"yaml"`, `"python-pep621"`.
+Supported formats: `"toml"`, `"json"`, `"plain_text"`.
 
-| Format | Typical file | Default `version_key` |
+| Format | Typical file | `version_key` meaning |
 |---|---|---|
-| `"toml"` | `Cargo.toml` | `"package.version"` |
-| `"json"` | `package.json` | `"version"` |
-| `"yaml"` | `Chart.yaml` | `"version"` |
-| `"python-pep621"` | `pyproject.toml` | `"project.version"` |
+| `"toml"` | `Cargo.toml`, `pyproject.toml` | Dot-separated table path, e.g. `"package.version"` or `"tool.poetry.version"` |
+| `"json"` | `package.json`, `composer.json` | Top-level JSON key, e.g. `"version"` |
+| `"plain_text"` | any text file | Regex with one capture group matching the current version |
 
 ```toml
 [release_pr]
 manifest_files = [
-  { path = "Cargo.toml",     format = "toml",         version_key = "package.version"  },
-  { path = "package.json",   format = "json",          version_key = "version"          },
-  { path = "pyproject.toml", format = "python-pep621", version_key = "project.version"  },
-  # Poetry-style pyproject.toml uses a three-segment key:
-  # { path = "pyproject.toml", format = "toml", version_key = "tool.poetry.version"    },
+  { path = "Cargo.toml",     format = "toml",       version_key = "package.version"       },
+  { path = "package.json",   format = "json",       version_key = "version"               },
+  # Standard pyproject.toml (PEP 621):
+  { path = "pyproject.toml", format = "toml",       version_key = "project.version"       },
+  # Poetry-style pyproject.toml:
+  # { path = "pyproject.toml", format = "toml",     version_key = "tool.poetry.version"   },
+  # Plain-text escape hatch (regex with one capture group):
+  # { path = "version.txt",  format = "plain_text", version_key = "^([0-9]+\\.[0-9]+\\.[0-9]+)$" },
 ]
 ```
 

--- a/samples/create-test-repo.ps1
+++ b/samples/create-test-repo.ps1
@@ -376,7 +376,17 @@ initial_version = "0.1.0"
 [release_pr]
 title_template = "chore(release): prepare version {version}"
 draft = false
-auto_merge = false
+auto_detect_manifests = false
+
+[[release_pr.manifest_files]]
+path = "package.json"
+format = "json"
+version_key = "version"
+
+[[release_pr.manifest_files]]
+path = "version.txt"
+format = "plain_text"
+version_key = 'version = "([^"]+)"'
 
 [changelog]
 include_authors = false
@@ -415,6 +425,17 @@ Returns a greeting for the given name.
 { "message": "Hello, Alice!" }
 ``````
 "@
+
+New-RepoFile 'package.json' @"
+{
+  "name": "greeting-service",
+  "version": "0.1.0",
+  "description": "A simple greeting service API",
+  "license": "MIT"
+}
+"@
+
+New-RepoFile 'version.txt' 'version = "0.1.0"'
 
 New-Commit -Message 'chore: initial repository setup'
 
@@ -470,30 +491,17 @@ whitespace-only `name` field, which previously caused a 500 response.
 Manually tested with `curl -X POST /greet -d '{"name":""}'`.
 '@ `
     -FilesBlock {
-    New-RepoFile 'src/greeting.md' @"
-# Greeting Service API
+    New-RepoFile 'src/validation.md' @"
+# Input Validation
 
-## Endpoints
+## POST /greet
 
-### POST /greet
+| Field | Type   | Required | Rules                         |
+| :---- | :----- | :------: | :---------------------------- |
+| name  | string | yes      | Non-blank; max 200 characters |
 
-Returns a greeting for the given name. Returns `400 Bad Request` when
-`name` is missing or blank.
-
-**Request body**
-``````json
-{ "name": "Alice" }
-``````
-
-**Response — success**
-``````json
-{ "message": "Hello, Alice!" }
-``````
-
-**Response — validation error**
-``````json
-{ "error": "name must not be blank" }
-``````
+When the name field is missing or blank the endpoint returns HTTP 400
+with body: { "error": "name must not be blank" }
 "@
     New-Commit -Message 'fix(api): return 400 when input name is empty'
 }
@@ -521,42 +529,17 @@ greeting registers without changing the endpoint URL.
 Tested all three style values (explicit formal, explicit casual, omitted).
 '@ `
     -FilesBlock {
-    New-RepoFile 'src/greeting.md' @"
-# Greeting Service API
-
-## Endpoints
-
-### POST /greet
-
-Returns a greeting for the given name.
-
-**Request body**
-``````json
-{
-  "name": "Alice",
-  "style": "formal"
-}
-``````
-
-`style` values: `"casual"` (default), `"formal"`.
-
-**Response — casual**
-``````json
-{ "message": "Hey, Alice!" }
-``````
-
-**Response — formal**
-``````json
-{ "message": "Good day, Alice." }
-``````
-"@
     New-RepoFile 'src/styles.md' @"
 # Greeting Styles
 
-| Style    | Example output         |
-| :------- | :--------------------- |
-| casual   | Hey, Alice!            |
-| formal   | Good day, Alice.       |
+Greeting style is controlled by the optional style field in the request body.
+
+| Style  | Description          | Example output      |
+| :----- | :------------------- | :------------------ |
+| casual | Friendly, informal   | Hey, Alice!         |
+| formal | Professional, polite | Good day, Alice.    |
+
+Default style is casual.
 "@
     New-Commit -Message 'feat(api): add formal and casual greeting styles'
 }
@@ -586,37 +569,17 @@ Tested all supported languages and an unsupported code (`"zh"`).
     New-RepoFile 'src/languages.md' @"
 # Supported Languages
 
+Pass an ISO 639-1 language code in the language field to receive a
+greeting in a language other than the default English.
+
 | Code | Language |
 | :--- | :------- |
 | en   | English  |
 | es   | Spanish  |
 | fr   | French   |
 | de   | German   |
-"@
-    New-RepoFile 'src/greeting.md' @"
-# Greeting Service API
 
-## Endpoints
-
-### POST /greet
-
-Returns a greeting in the requested language and style.
-
-**Request body**
-``````json
-{
-  "name": "Alice",
-  "style": "formal",
-  "language": "fr"
-}
-``````
-
-**Response**
-``````json
-{ "message": "Bonjour, Alice." }
-``````
-
-Supported languages: `en`, `es`, `fr`, `de`. Defaults to `en`.
+Default language is en. Unknown codes return HTTP 400.
 "@
     New-Commit -Message 'feat(i18n): add multi-language greeting support'
 }


### PR DESCRIPTION
Consolidates the three parallel version-bump code paths into a single canonical
function and adds support for atomically committing version manifest files
(Cargo.toml, package.json, etc.) to the release branch in one Git commit.

## What Changed

**Version bump consolidation (task 17):**
- Added `apply_semver_bump(base, bump) -> SemanticVersion` as a public free
  function in `versioning.rs`, which implements the pre-1.0 major-bump rule
  (`0.x -> 0.(x+1)`) in one authoritative place
- Rewrote `VersionCalculator::apply_version_bump`,
  `DefaultVersionCalculator::apply_version_bump`, and
  `GitHubVersionCalculator::bump_version` to each delegate to this function
  rather than duplicating the match arithmetic

**Manifest file commits (task 18):**
- Added `FileUpdate` struct and two new `GitHubOperations` trait methods:
  `get_file_content` and `batch_commit_files`
- Created `crates/core/src/manifest.rs` with `ManifestFormat` (Toml / Json /
  PlainText), `ManifestFileConfig`, `update_manifest_content`, and
  `detect_standard_manifests` (auto-detects Cargo.toml, package.json,
  pyproject.toml, composer.json)
- Extended `OrchestratorConfig` and `ReleasePrConfig` with `manifest_files`
  and `auto_detect_manifests` fields
- `ReleaseOrchestrator` now calls a private `collect_manifest_updates` helper
  and commits CHANGELOG.md together with all manifest files in one atomic call
  to `batch_commit_files` — replacing the previous per-file `upsert_file` pattern
- Implemented `get_file_content` and `batch_commit_files` in `GitHubClient`
  using the GitHub Git Trees API (create blob → create tree → create commit →
  update ref)
- Updated `MockGitHubOperations` with call recording for both new methods
- Updated `create-test-repo.ps1` to create `package.json` and `version.txt`
  manifest files and register them in the sample `release-regent.toml`; also
  reworked branch file changes so merging branches no longer produces conflicts
  on `src/greeting.md`

## Why

Three independent implementations of the same bumping logic created a risk of
them drifting apart (notably the pre-1.0 major-bump special case). Making that
logic a single public function lets custom `VersionCalculator` implementations
reuse it as a building block.

The release workflow previously committed each file — changelog and any manifest
— as a separate `upsert_file` call, producing N commits on the release branch.
The user requirement is a single, atomic commit so that the release branch always
has one clean commit on top of the base branch.

## How

`apply_semver_bump` is a free function (not a method) so it is callable from all
three calculator paths without any shared state or trait object. Each calculator
converts its own `VersionBump` representation to the canonical one and delegates.

`batch_commit_files` follows the GitHub Git Trees API sequence: one blob is
created per file, a new tree is built on top of the current HEAD tree, a commit
object is created pointing at the new tree, and the branch ref is advanced with
a non-force patch. `collect_manifest_updates` probes for auto-detected files
using `get_file_content` (404 → skip), applies `update_manifest_content`, and
deduplicates against any explicitly configured paths.

The TOML updater supports one level of dot-separated key nesting (e.g.
`package.version`). Three-segment paths such as `tool.poetry.version` are
detected and skipped with a `warn!` log.

## Testing Evidence

- **Test Coverage:** Added 65+ new unit tests:
  - `apply_semver_bump_*` tests for all bump variants including pre-1.0 behaviour
  - `cross_calculator_consistency` module asserting all three paths agree on the
    pre-1.0 major-bump case
  - Full `manifest_tests.rs` covering TOML / JSON / PlainText update and
    auto-detection
  - Orchestrator tests updated to assert against `batch_commit_files` call
    recording rather than `upsert_file`
  - All test doubles across six inline test modules updated with the two new
    trait method stubs
- **Test Results:** 602 tests pass, 0 failures across the full workspace
- **Manual Testing:** Clippy (`-D warnings`) clean; `cargo fmt` applied

## Reviewer Guidance

- **`batch_commit_files` in `github_client/src/lib.rs`**: The six-step Git Trees
  API sequence is the most complex new code; verify the SHA threading between
  steps and the non-force ref patch
- **TOML key depth limit**: `update_toml` splits on the first `.` only, so
  `tool.poetry.version` will return an error and be skipped silently — confirm
  this is the intended behaviour for Poetry projects
- **Auto-detect probing**: Each candidate file makes one `get_file_content` API
  call at orchestration time; repositories with many manifests will see
  proportional extra calls — no batching is done at the probe stage
- **`ReleasePrConfig` serde defaults**: `auto_detect_manifests` defaults to
  `true`; existing configs that omit the field will start probing for manifests
  on next run — a behaviour change worth noting in release notes