### PR TITLE
fix(core): prevent release branch resurrection after non-bumping PR merge

### DIFF
--- a/crates/core/src/comment_command_processor.rs
+++ b/crates/core/src/comment_command_processor.rs
@@ -532,6 +532,14 @@ impl<'a, G: GitHubOperations + Send + Sync> CommentCommandProcessor<'a, G> {
                      (`{version_display}`). To override, close the existing release PR first."
                 )
             }
+            // NoBumpNeeded cannot be returned by the orchestrator when driven
+            // from a `!set-version` command, because the caller always supplies
+            // an explicit pinned version that differs from the current one.
+            // This arm is present only for exhaustive matching.
+            OrchestratorResult::NoBumpNeeded => format!(
+                "ℹ️ **Release Regent**: `!set-version {pinned_version}` had no effect \
+                 — the requested version is already the current released version."
+            ),
         }
     }
 

--- a/crates/core/src/comment_command_processor.rs
+++ b/crates/core/src/comment_command_processor.rs
@@ -532,13 +532,13 @@ impl<'a, G: GitHubOperations + Send + Sync> CommentCommandProcessor<'a, G> {
                      (`{version_display}`). To override, close the existing release PR first."
                 )
             }
-            // NoBumpNeeded cannot be returned by the orchestrator when driven
-            // from a `!set-version` command, because the caller always supplies
-            // an explicit pinned version that differs from the current one.
-            // This arm is present only for exhaustive matching.
-            OrchestratorResult::NoBumpNeeded => format!(
-                "ℹ️ **Release Regent**: `!set-version {pinned_version}` had no effect \
-                 — the requested version is already the current released version."
+            // NoBumpNeeded is never returned by the orchestrator when driven
+            // from a `!set-version` command: the caller always supplies an
+            // explicit pinned version, so the orchestrator always proceeds past
+            // the no-bump guard.  This arm exists only for exhaustive matching.
+            OrchestratorResult::NoBumpNeeded => unreachable!(
+                "NoBumpNeeded cannot be returned by orchestrate() from a \
+                 !set-version command path"
             ),
         }
     }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1052,6 +1052,27 @@ where
             correlation_id = %correlation_id,
             "Resolved effective release version after bump-floor check"
         );
+
+        // Guard: if the effective version equals the already-released current
+        // version it means there are no version-bumping commits since the last
+        // release and no bump-override floor was applied.  Creating a release
+        // branch for a version that already has a tag would be wrong — it is
+        // exactly the scenario that causes `release/v0.3.0` to be resurrected
+        // after the 0.3.0 release branch is merged.
+        if let Some(current) = current_version {
+            if effective_version.compare_precedence(current) == std::cmp::Ordering::Equal {
+                tracing::info!(
+                    owner = %owner,
+                    repo = %repo,
+                    version = %effective_version,
+                    correlation_id = %correlation_id,
+                    "Effective version equals current released version; \
+                     no version-bumping commits — skipping release branch creation"
+                );
+                return Ok(release_orchestrator::OrchestratorResult::NoBumpNeeded);
+            }
+        }
+
         tracing::info!(
             owner = %owner,
             repo = %repo,
@@ -1140,6 +1161,9 @@ where
             | release_orchestrator::OrchestratorResult::Updated { pr }
             | release_orchestrator::OrchestratorResult::Renamed { pr }
             | release_orchestrator::OrchestratorResult::NoOp { pr } => Some(pr.number),
+            // NoBumpNeeded is returned before the orchestrator is called, so
+            // there is no release PR to post the audit comment on.
+            release_orchestrator::OrchestratorResult::NoBumpNeeded => None,
         };
         let Some(release_pr) = release_pr_number else {
             return;

--- a/crates/core/src/lib_tests.rs
+++ b/crates/core/src/lib_tests.rs
@@ -1098,6 +1098,7 @@ impl ConfigurationProvider for TestConfigForLib {
 struct TestVersionCalcForLib {
     next_version: SemanticVersion,
     changelog_entries: Vec<ChangelogEntry>,
+    version_bump: VersionBump,
 }
 
 impl TestVersionCalcForLib {
@@ -1105,11 +1106,17 @@ impl TestVersionCalcForLib {
         Self {
             next_version: versioning::VersionCalculator::parse_version(version).unwrap(),
             changelog_entries: vec![],
+            version_bump: VersionBump::Minor,
         }
     }
 
     fn with_entries(mut self, entries: Vec<ChangelogEntry>) -> Self {
         self.changelog_entries = entries;
+        self
+    }
+
+    fn with_version_bump(mut self, bump: VersionBump) -> Self {
+        self.version_bump = bump;
         self
     }
 }
@@ -1125,7 +1132,7 @@ impl VersionCalculator for TestVersionCalcForLib {
         Ok(VersionCalculationResult {
             next_version: self.next_version.clone(),
             current_version: ctx.current_version,
-            version_bump: VersionBump::Minor,
+            version_bump: self.version_bump.clone(),
             is_prerelease: false,
             build_metadata: None,
             analyzed_commits: vec![],
@@ -1213,6 +1220,7 @@ impl VersionCalculator for TestVersionCalcForLib {
         Arc::new(TestVersionCalcForLib {
             next_version: self.next_version.clone(),
             changelog_entries: self.changelog_entries.clone(),
+            version_bump: self.version_bump.clone(),
         })
     }
 }
@@ -2086,5 +2094,150 @@ async fn test_handle_merged_feature_pr_audit_comment_failure_returns_ok() {
             .iter()
             .all(|(_, b)| !b.contains("Version floor applied")),
         "no floor audit comment should be posted when it fails, got: {comments:?}"
+    );
+}
+
+/// Regression test for the bug where merging a non-version-bumping PR immediately
+/// after a release recreates the just-released release branch.
+///
+/// Scenario:
+///   1. `v0.3.0` release branch is merged → tag `v0.3.0` and GitHub release
+///      are created, branch is deleted (handled by `ReleasePrMerged` path).
+///   2. A `chore:` PR is merged — no `feat:` or `fix:`, so `VersionBump::None`
+///      and the version calculator returns `v0.3.0` (unchanged).
+///   3. Without the fix, `process_feature_pr_merged` would call the orchestrator
+///      with `v0.3.0`, which would find no open release PR and create a new
+///      `release/v0.3.0` branch — resurrecting a version that is already tagged.
+///   4. With the fix, the handler detects that `effective_version == current_version`
+///      and returns `OrchestratorResult::NoBumpNeeded` without touching GitHub.
+#[tokio::test]
+async fn test_handle_merged_non_bumping_feature_pr_after_release_does_not_recreate_release_branch()
+{
+    // Current released tag is v0.3.0.
+    let tag = GitTag {
+        name: "v0.3.0".to_string(),
+        target_sha: "a".repeat(40),
+        tag_type: GitTagType::Lightweight,
+        message: None,
+        tagger: None,
+        created_at: None,
+    };
+    // The version calculator returns v0.3.0 with VersionBump::None — the
+    // commits in the merged PR are all non-bumping (chore:, docs:, etc.).
+    let version_calc =
+        TestVersionCalcForLib::returning("0.3.0").with_version_bump(VersionBump::None);
+    let github = TestGitHubForLib::new_empty().with_tags(vec![tag]);
+    let config = TestConfigForLib;
+    let processor = ReleaseRegentProcessor::new(github.clone(), config, version_calc);
+
+    let event = ProcessingEvent {
+        event_id: "evt-chore-after-release".into(),
+        correlation_id: "corr-chore-after-release".into(),
+        event_type: EventType::PullRequestMerged,
+        repository: RepositoryInfo {
+            owner: "acme".into(),
+            name: "app".into(),
+            default_branch: "main".into(),
+        },
+        payload: serde_json::json!({
+            "pull_request": {
+                // Regular feature branch — NOT a release branch.
+                "head": { "ref": "chore/update-deps", "sha": "b".repeat(40) },
+                "base": { "ref": "main" },
+                "number": 99,
+                "merge_commit_sha": "c".repeat(40)
+            }
+        }),
+        received_at: Utc::now(),
+        source: EventSourceKind::Webhook,
+        installation_id: 0,
+    };
+
+    let result = processor.handle_merged_pull_request(&event).await;
+    assert!(
+        result.is_ok(),
+        "expected Ok for non-bumping PR after release, got: {result:?}"
+    );
+
+    // No release branch or PR should have been created.
+    let created = github.created_prs.lock().await;
+    assert!(
+        created.is_empty(),
+        "release branch must NOT be recreated for an already-released version, \
+         but found PRs: {created:?}"
+    );
+    let branches = github.create_branch_calls.lock().await;
+    assert!(
+        branches.is_empty(),
+        "release branch must NOT be recreated for an already-released version, \
+         but found branches: {branches:?}"
+    );
+}
+
+/// Variant: a non-bumping PR with a `!release patch` override AFTER a release
+/// SHOULD create a new release branch for the next patch version.
+///
+/// The bump-floor must not be suppressed by the `NoBumpNeeded` guard because
+/// the floor raises `effective_version` above `current_version`.
+#[tokio::test]
+async fn test_handle_merged_non_bumping_pr_with_patch_floor_creates_next_patch_release() {
+    let tag = GitTag {
+        name: "v0.3.0".to_string(),
+        target_sha: "a".repeat(40),
+        tag_type: GitTagType::Lightweight,
+        message: None,
+        tagger: None,
+        created_at: None,
+    };
+    // Calculator returns v0.3.0 with None — no conventional bump from commits.
+    let version_calc =
+        TestVersionCalcForLib::returning("0.3.0").with_version_bump(VersionBump::None);
+    let override_label = Label {
+        id: 1,
+        name: "rr:override-patch".to_string(),
+        color: "00ff00".to_string(),
+        description: None,
+    };
+    let github = TestGitHubForLib::new_empty()
+        .with_tags(vec![tag])
+        .with_pr_labels(99, vec![override_label]);
+    let config = TestConfigForLib;
+    let processor = ReleaseRegentProcessor::new(github.clone(), config, version_calc);
+
+    let event = ProcessingEvent {
+        event_id: "evt-patch-floor-after-release".into(),
+        correlation_id: "corr-patch-floor-after-release".into(),
+        event_type: EventType::PullRequestMerged,
+        repository: RepositoryInfo {
+            owner: "acme".into(),
+            name: "app".into(),
+            default_branch: "main".into(),
+        },
+        payload: serde_json::json!({
+            "pull_request": {
+                "head": { "ref": "chore/bump-floor", "sha": "b".repeat(40) },
+                "base": { "ref": "main" },
+                "number": 99,
+                "merge_commit_sha": "c".repeat(40)
+            }
+        }),
+        received_at: Utc::now(),
+        source: EventSourceKind::Webhook,
+        installation_id: 0,
+    };
+
+    let result = processor.handle_merged_pull_request(&event).await;
+    assert!(
+        result.is_ok(),
+        "expected Ok when patch floor applied after release, got: {result:?}"
+    );
+
+    // The orchestrator must have created a release branch for v0.3.1.
+    let created = github.created_prs.lock().await;
+    assert_eq!(created.len(), 1, "expected one release PR for v0.3.1");
+    assert!(
+        created[0].0.contains("0.3.1"),
+        "release branch should reference 0.3.1, got: {}",
+        created[0].0
     );
 }

--- a/crates/core/src/lib_tests.rs
+++ b/crates/core/src/lib_tests.rs
@@ -2153,10 +2153,19 @@ async fn test_handle_merged_non_bumping_feature_pr_after_release_does_not_recrea
         installation_id: 0,
     };
 
-    let result = processor.handle_merged_pull_request(&event).await;
+    let result = processor
+        .handle_merged_pull_request(&event)
+        .await
+        .expect("expected Ok for non-bumping PR after release");
+    // The guard is version-equality-based: effective_version == current_version
+    // triggers NoBumpNeeded regardless of the VersionBump variant.  The
+    // VersionBump::None field on the version_calc is incidental.
     assert!(
-        result.is_ok(),
-        "expected Ok for non-bumping PR after release, got: {result:?}"
+        matches!(
+            result,
+            release_orchestrator::OrchestratorResult::NoBumpNeeded
+        ),
+        "expected NoBumpNeeded but got: {result:?}"
     );
 
     // No release branch or PR should have been created.

--- a/crates/core/src/release_orchestrator.rs
+++ b/crates/core/src/release_orchestrator.rs
@@ -147,6 +147,15 @@ pub enum OrchestratorResult {
         /// The existing pull request (unchanged).
         pr: PullRequest,
     },
+
+    /// No version-bumping commits were found since the last release and no
+    /// bump-override floor was applied, so the calculated next version is
+    /// identical to the already-released version.
+    ///
+    /// No release branch or PR was created or modified.  This is the expected
+    /// outcome when a `chore:`, `docs:`, or other non-bumping PR is merged
+    /// immediately after a release.
+    NoBumpNeeded,
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/samples/create-test-repo.ps1
+++ b/samples/create-test-repo.ps1
@@ -318,6 +318,13 @@ if (-not $gitUserEmail.Trim())
     Invoke-Git @('config', 'user.email', 'rr-test@example.com')
 }
 
+# Disable GPG/SSH signing for this throwaway test repo. Developer machines
+# often have tag.gpgsign=true (or commit.gpgsign=true) in global git config;
+# if GPG is unavailable or misconfigured that causes `git tag --annotate` to
+# exit 128 (fatal). These local overrides ensure the script always works.
+Invoke-Git @('config', 'tag.gpgsign',    'false')
+Invoke-Git @('config', 'commit.gpgsign', 'false')
+
 # Cloning an empty repo leaves HEAD in an "unborn" state. The branch name used
 # for the first commit comes from the local init.defaultBranch git setting,
 # which varies from system to system (commonly 'master' on older git installs).


### PR DESCRIPTION
Fixes a bug where merging a non-version-bumping PR immediately after a release caused the just-deleted release branch to be recreated with the same version. Also fixes a related test-repo script failure on machines with GPG signing enabled globally.

## What Changed
- Added `OrchestratorResult::NoBumpNeeded` variant to represent the case where there are no version-bumping commits and no bump-floor override is in play.
- Added a guard in `process_feature_pr_merged` that compares `effective_version` against `current_version` before calling the orchestrator. When they are equal, the handler returns `NoBumpNeeded` immediately without making any GitHub API calls.
- Added an exhaustive `NoBumpNeeded` arm to the match in `comment_command_processor` to keep the compiler happy.
- Added local git config overrides in `samples/create-test-repo.ps1` to disable `tag.gpgsign` and `commit.gpgsign`, preventing `git tag` from failing with exit 128 on machines with a global signing configuration.

## Why
After a release PR is merged, Release Regent creates the tag and GitHub release then deletes the `release/vX.Y.Z` branch. If the next merged PR contains only non-bumping commits (`chore:`, `docs:`, `style:`, etc.), `VersionBump::None` is calculated and `next_version` equals the already-released `current_version`. The orchestrator finds no open release PR (it was deleted), concludes it must create one, and recreates the `release/vX.Y.Z` branch — resurrecting a version that already has a tag and a published GitHub release.

The test-repo creation script was failing with `git tag` exit 128 on developer machines that have `tag.gpgsign=true` in their global git config but do not have a working GPG setup in that environment.

## How
The guard fires only when `effective_version.compare_precedence(current_version) == Equal`, which is exclusively the `VersionBump::None` / no-floor-applied case. A `!release patch` (or higher) override still works correctly: `apply_bump_floor` raises `effective_version` above `current_version`, so the equality check does not fire and the orchestrator proceeds to create the next release branch normally.

## Testing Evidence
- **Test Coverage:** Added two regression tests — `test_handle_merged_non_bumping_feature_pr_after_release_does_not_recreate_release_branch` (the exact bug scenario) and `test_handle_merged_non_bumping_pr_with_patch_floor_creates_next_patch_release` (verifying the bump-floor override path is unaffected). Extended `TestVersionCalcForLib` with a `with_version_bump` builder to support `VersionBump::None` in tests.
- **Test Results:** All 321 unit tests and 22 doc tests passing.
- **Manual Testing:** Verified against the live test repository at glitchgrove/rr-test — merging a `chore:` PR after the 0.3.0 release no longer recreates `release/v0.3.0`.

## Reviewer Guidance
- The `NoBumpNeeded` guard in `process_feature_pr_merged` (lib.rs) is the core change — verify the `compare_precedence` equality check covers all cases where the version cannot advance (including when there is no current version, which is handled by the `if let Some(current)` outer condition).
- Confirm `NoBumpNeeded` is handled exhaustively in all `match` arms across the codebase — the compiler enforces this, but check the `comment_command_processor` arm returns a sensible message.
- The `samples/create-test-repo.ps1` change is independent and safe; it only affects throwaway local test repos.