### PR TITLE
feat(pr-status): Add PR status comments to open pull requests

### DIFF
--- a/crates/core/src/comment_command_processor_tests.rs
+++ b/crates/core/src/comment_command_processor_tests.rs
@@ -516,6 +516,25 @@ impl GitHubOperations for TestGitHub {
         Ok(())
     }
 
+    async fn list_issue_comments(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _issue_number: u64,
+    ) -> CoreResult<Vec<crate::traits::github_operations::IssueComment>> {
+        Ok(vec![])
+    }
+
+    async fn update_issue_comment(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _comment_id: u64,
+        _body: &str,
+    ) -> CoreResult<()> {
+        Ok(())
+    }
+
     fn scoped_to(&self, _installation_id: u64) -> Self {
         Self {
             state: Arc::clone(&self.state),

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -262,6 +262,15 @@ pub struct VersioningConfig {
     /// Whether to allow PR comment overrides
     #[serde(default = "default_allow_override")]
     pub allow_override: bool,
+    /// PR author logins to skip when posting status comments.
+    ///
+    /// PRs opened by any login in this list will not receive a Release Regent
+    /// status comment, and will be skipped during the post-merge refresh.
+    /// Useful for bot accounts (e.g. `"dependabot[bot]"`, `"renovate[bot]"`)
+    /// that open dependency-update PRs where a projected-version comment is
+    /// noise rather than signal.
+    #[serde(default)]
+    pub excluded_pr_authors: Vec<String>,
 }
 
 fn default_versioning_strategy() -> VersioningStrategy {
@@ -277,6 +286,7 @@ impl Default for VersioningConfig {
             strategy: default_versioning_strategy(),
             external: None,
             allow_override: default_allow_override(),
+            excluded_pr_authors: Vec::new(),
         }
     }
 }

--- a/crates/core/src/github_version_calculator_tests.rs
+++ b/crates/core/src/github_version_calculator_tests.rs
@@ -388,7 +388,24 @@ impl GitHubOperations for StubGitHub {
     ) -> CoreResult<()> {
         Ok(())
     }
+    async fn list_issue_comments(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _issue_number: u64,
+    ) -> CoreResult<Vec<crate::traits::github_operations::IssueComment>> {
+        Ok(vec![])
+    }
 
+    async fn update_issue_comment(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _comment_id: u64,
+        _body: &str,
+    ) -> CoreResult<()> {
+        Ok(())
+    }
     fn scoped_to(&self, _installation_id: u64) -> Self {
         self.clone()
     }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -495,9 +495,32 @@ where
                 build: None,
             });
 
+            // Check whether a release PR is already open with a higher version.
+            let release_search_query = format!("is:open head:{}/v", branch_prefix);
+            let queued_release_version: Option<versioning::SemanticVersion> = scoped_github
+                .search_pull_requests(owner, repo, &release_search_query)
+                .await
+                .unwrap_or_else(|e| {
+                    tracing::debug!(
+                        error = %e,
+                        "Failed to search for open release PRs; assuming none"
+                    );
+                    vec![]
+                })
+                .iter()
+                .filter_map(|pr| {
+                    release_automator::extract_version_from_branch(
+                        &pr.head.ref_name,
+                        &branch_prefix,
+                    )
+                    .ok()
+                })
+                .max();
+
             pr_status_commenter::render_feature_pr_comment(
                 &calc_result.next_version,
                 &base_version,
+                queued_release_version.as_ref(),
                 repo_config.versioning.allow_override,
             )
         };
@@ -1414,6 +1437,17 @@ where
 
         let excluded = &repo_config.versioning.excluded_pr_authors;
 
+        // Find the highest open release PR version from the already-fetched list
+        // so we can annotate feature PR comments when a release is already queued.
+        let queued_release_version: Option<versioning::SemanticVersion> = open_prs
+            .iter()
+            .filter(|pr| is_release_pr_branch(&pr.head.ref_name, &branch_prefix))
+            .filter_map(|pr| {
+                release_automator::extract_version_from_branch(&pr.head.ref_name, &branch_prefix)
+                    .ok()
+            })
+            .max();
+
         // Feature PRs only; skip excluded authors; cap at 25.
         let candidates: Vec<_> = open_prs
             .into_iter()
@@ -1510,6 +1544,7 @@ where
             let body = pr_status_commenter::render_feature_pr_comment(
                 &calc_result.next_version,
                 &base_version,
+                queued_release_version.as_ref(),
                 repo_config.versioning.allow_override,
             );
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -302,6 +302,11 @@ where
         match self.handle_merged_pull_request(event).await {
             Ok(result) => {
                 tracing::info!(result = ?result, "Release orchestration completed");
+                self.try_refresh_feature_pr_status_comments(
+                    &event.repository.owner,
+                    &event.repository.name,
+                )
+                .await;
                 Ok(())
             }
             Err(e) => Err(e),
@@ -339,6 +344,8 @@ where
         {
             Ok(result) => {
                 tracing::info!(result = ?result, "Release automation completed");
+                self.try_refresh_feature_pr_status_comments(owner, repo)
+                    .await;
                 Ok(())
             }
             Err(e) => Err(e),
@@ -380,13 +387,125 @@ where
         .process(event)
         .await
     }
+
+    async fn handle_pull_request_activity(
+        &self,
+        event: &traits::event_source::ProcessingEvent,
+    ) -> CoreResult<()> {
+        use release_automator::is_release_pr_branch;
+        use traits::configuration_provider::LoadOptions;
+        use traits::version_calculator::{CalculationOptions, VersionContext, VersioningStrategy};
+
+        let owner = &event.repository.owner;
+        let repo = &event.repository.name;
+
+        let pr_number = event
+            .payload
+            .pointer("/pull_request/number")
+            .and_then(serde_json::Value::as_u64)
+            .unwrap_or(0);
+        let pr_head_sha = event
+            .payload
+            .pointer("/pull_request/head/sha")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or_default()
+            .to_string();
+        let pr_head_branch = event
+            .payload
+            .pointer("/pull_request/head/ref")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or_default()
+            .to_string();
+        let pr_author_login = event
+            .payload
+            .pointer("/pull_request/user/login")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or_default()
+            .to_string();
+
+        let installation_id = self.resolve_installation_id(owner, repo).await?;
+
+        let repo_config = self
+            .configuration_provider
+            .get_merged_config(owner, repo, LoadOptions::default())
+            .await?;
+
+        // Skip PRs from excluded authors.
+        if repo_config
+            .versioning
+            .excluded_pr_authors
+            .iter()
+            .any(|a| a == &pr_author_login)
+        {
+            tracing::debug!(
+                owner = %owner,
+                repo = %repo,
+                pr = pr_number,
+                author = %pr_author_login,
+                "Skipping PR status comment for excluded author"
+            );
+            return Ok(());
+        }
+
+        let branch_prefix =
+            release_orchestrator::OrchestratorConfig::DEFAULT_BRANCH_PREFIX.to_string();
+        let scoped_github = self.github_operations.scoped_to(installation_id);
+
+        let body = if is_release_pr_branch(&pr_head_branch, &branch_prefix) {
+            // Release PR path (F.3): extract version from branch name.
+            let release_version =
+                release_automator::extract_version_from_branch(&pr_head_branch, &branch_prefix)?;
+            pr_status_commenter::render_release_pr_comment(
+                &release_version,
+                repo_config.versioning.allow_override,
+            )
+        } else {
+            // Feature PR path (F.2): project the next version from commits.
+            let current_version =
+                versioning::resolve_current_version(&scoped_github, owner, repo, false).await?;
+
+            let strategy = match repo_config.versioning.strategy {
+                config::VersioningStrategy::Conventional | config::VersioningStrategy::External => {
+                    VersioningStrategy::ConventionalCommits {
+                        custom_types: std::collections::HashMap::new(),
+                        include_prerelease: false,
+                    }
+                }
+            };
+
+            let ctx = VersionContext {
+                base_ref: current_version.as_ref().map(|v| format!("v{v}")),
+                current_version: current_version.clone(),
+                head_ref: pr_head_sha,
+                owner: owner.to_string(),
+                repo: repo.to_string(),
+                target_branch: pr_head_branch,
+            };
+
+            let scoped_calc = self.version_calculator.scoped_to(installation_id);
+            let calc_result = scoped_calc
+                .calculate_version(ctx, strategy, CalculationOptions::default())
+                .await?;
+
+            let base_version = current_version.unwrap_or(versioning::SemanticVersion {
+                major: 0,
+                minor: 0,
+                patch: 0,
+                prerelease: None,
+                build: None,
+            });
+
+            pr_status_commenter::render_feature_pr_comment(
+                &calc_result.next_version,
+                &base_version,
+                repo_config.versioning.allow_override,
+            )
+        };
+
+        pr_status_commenter::upsert_pr_status_comment(&scoped_github, owner, repo, pr_number, &body)
+            .await
+    }
 }
-
-// ─────────────────────────────────────────────────────────────────────────────
-// run_event_loop — public API
-// ─────────────────────────────────────────────────────────────────────────────
-
-/// Drive the event processing loop until `token` is cancelled.
 ///
 /// The loop polls `source.next_event()` continuously:
 ///
@@ -1209,6 +1328,206 @@ where
                 correlation_id = %correlation_id,
                 "Failed to post bump-floor audit comment; continuing"
             );
+        }
+    }
+
+    /// Best-effort refresh of open feature PR status comments.
+    ///
+    /// Resolves the installation ID and repository configuration before
+    /// delegating to [`Self::refresh_open_feature_pr_comments`].  All errors
+    /// are logged and swallowed so that a refresh failure never fails the
+    /// triggering merge event.
+    async fn try_refresh_feature_pr_status_comments(&self, owner: &str, repo: &str) {
+        use traits::configuration_provider::LoadOptions;
+
+        let installation_id = match self.resolve_installation_id(owner, repo).await {
+            Ok(id) => id,
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    owner = %owner,
+                    repo = %repo,
+                    "Failed to resolve installation ID for PR status refresh"
+                );
+                return;
+            }
+        };
+
+        let repo_config = match self
+            .configuration_provider
+            .get_merged_config(owner, repo, LoadOptions::default())
+            .await
+        {
+            Ok(c) => c,
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    owner = %owner,
+                    repo = %repo,
+                    "Failed to load config for PR status refresh"
+                );
+                return;
+            }
+        };
+
+        self.refresh_open_feature_pr_comments(owner, repo, installation_id, &repo_config)
+            .await;
+    }
+
+    /// Refresh the status comment on open feature PRs after a base-version change.
+    ///
+    /// Only refreshes PRs that already have a `<!-- release-regent:pr-status -->`
+    /// comment.  Skips release-branch PRs and PRs authored by logins in
+    /// `excluded_pr_authors`.  Caps at 25 PRs per triggering event.
+    ///
+    /// All per-PR errors (list comments, calculate version, upsert) are logged
+    /// and skipped so that one failing PR does not abort the rest.
+    async fn refresh_open_feature_pr_comments(
+        &self,
+        owner: &str,
+        repo: &str,
+        installation_id: u64,
+        repo_config: &config::ReleaseRegentConfig,
+    ) {
+        use release_automator::is_release_pr_branch;
+        use traits::version_calculator::{CalculationOptions, VersionContext, VersioningStrategy};
+
+        let branch_prefix =
+            release_orchestrator::OrchestratorConfig::DEFAULT_BRANCH_PREFIX.to_string();
+        let scoped_github = self.github_operations.scoped_to(installation_id);
+
+        let open_prs = match scoped_github
+            .search_pull_requests(owner, repo, "is:open")
+            .await
+        {
+            Ok(prs) => prs,
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    owner = %owner,
+                    repo = %repo,
+                    "Failed to list open PRs for status comment refresh; skipping"
+                );
+                return;
+            }
+        };
+
+        let excluded = &repo_config.versioning.excluded_pr_authors;
+
+        // Feature PRs only; skip excluded authors; cap at 25.
+        let candidates: Vec<_> = open_prs
+            .into_iter()
+            .filter(|pr| !is_release_pr_branch(&pr.head.ref_name, &branch_prefix))
+            .filter(|pr| {
+                let login = pr.user.login.as_deref().unwrap_or_default();
+                !excluded.iter().any(|a| a == login)
+            })
+            .take(25)
+            .collect();
+
+        let current_version =
+            match versioning::resolve_current_version(&scoped_github, owner, repo, false).await {
+                Ok(v) => v,
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        owner = %owner,
+                        repo = %repo,
+                        "Failed to resolve current version for PR refresh"
+                    );
+                    return;
+                }
+            };
+
+        let base_version = current_version
+            .clone()
+            .unwrap_or(versioning::SemanticVersion {
+                major: 0,
+                minor: 0,
+                patch: 0,
+                prerelease: None,
+                build: None,
+            });
+
+        let strategy = match repo_config.versioning.strategy {
+            config::VersioningStrategy::Conventional | config::VersioningStrategy::External => {
+                VersioningStrategy::ConventionalCommits {
+                    custom_types: std::collections::HashMap::new(),
+                    include_prerelease: false,
+                }
+            }
+        };
+
+        for pr in candidates {
+            // Only refresh PRs that already have a status marker comment.
+            let comments = match scoped_github
+                .list_issue_comments(owner, repo, pr.number)
+                .await
+            {
+                Ok(c) => c,
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        pr = pr.number,
+                        "Failed to list comments for PR refresh; skipping PR"
+                    );
+                    continue;
+                }
+            };
+
+            if !comments
+                .iter()
+                .any(|c| c.body.contains(pr_status_commenter::PR_STATUS_MARKER))
+            {
+                continue;
+            }
+
+            let ctx = VersionContext {
+                base_ref: current_version.as_ref().map(|v| format!("v{v}")),
+                current_version: current_version.clone(),
+                head_ref: pr.head.sha.clone(),
+                owner: owner.to_string(),
+                repo: repo.to_string(),
+                target_branch: pr.head.ref_name.clone(),
+            };
+
+            let scoped_calc = self.version_calculator.scoped_to(installation_id);
+            let calc_result = match scoped_calc
+                .calculate_version(ctx, strategy.clone(), CalculationOptions::default())
+                .await
+            {
+                Ok(r) => r,
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        pr = pr.number,
+                        "Failed to project version for PR refresh; skipping PR"
+                    );
+                    continue;
+                }
+            };
+
+            let body = pr_status_commenter::render_feature_pr_comment(
+                &calc_result.next_version,
+                &base_version,
+                repo_config.versioning.allow_override,
+            );
+
+            if let Err(e) = pr_status_commenter::upsert_pr_status_comment(
+                &scoped_github,
+                owner,
+                repo,
+                pr.number,
+                &body,
+            )
+            .await
+            {
+                tracing::warn!(
+                    error = %e,
+                    pr = pr.number,
+                    "Failed to refresh PR status comment; skipping PR"
+                );
+            }
         }
     }
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -210,6 +210,7 @@ pub(crate) mod default_version_calculator;
 pub mod errors;
 pub(crate) mod github_version_calculator;
 pub mod manifest;
+pub mod pr_status_commenter;
 pub mod release_automator;
 pub mod release_orchestrator;
 pub mod traits;
@@ -266,6 +267,20 @@ pub trait MergedPullRequestHandler: Send + Sync {
     /// without taking any action.  Override in the production processor to
     /// invoke [`comment_command_processor::CommentCommandProcessor`].
     async fn handle_pr_comment(
+        &self,
+        _event: &traits::event_source::ProcessingEvent,
+    ) -> CoreResult<()> {
+        Ok(())
+    }
+
+    /// Process a single `PullRequestOpened` or `PullRequestUpdated` event.
+    ///
+    /// Called when the event loop receives [`EventType::PullRequestOpened`] or
+    /// [`EventType::PullRequestUpdated`].  The default implementation is a
+    /// no-op that acknowledges the event without taking any action.  Override
+    /// in the production processor to post or refresh the projected-version
+    /// status comment on the PR.
+    async fn handle_pull_request_activity(
         &self,
         _event: &traits::event_source::ProcessingEvent,
     ) -> CoreResult<()> {
@@ -469,6 +484,14 @@ where
                                 "Pull request comment received — dispatching to comment handler"
                             );
                             handler.handle_pr_comment(&event).await
+                        }
+                        EventType::PullRequestOpened | EventType::PullRequestUpdated => {
+                            tracing::debug!(
+                                event_id = %event.event_id,
+                                event_type = %event.event_type,
+                                "Pull request activity — dispatching to activity handler"
+                            );
+                            handler.handle_pull_request_activity(&event).await
                         }
                         EventType::Unknown(raw) => {
                             tracing::debug!(

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -210,7 +210,7 @@ pub(crate) mod default_version_calculator;
 pub mod errors;
 pub(crate) mod github_version_calculator;
 pub mod manifest;
-pub mod pr_status_commenter;
+pub(crate) mod pr_status_commenter;
 pub mod release_automator;
 pub mod release_orchestrator;
 pub mod traits;
@@ -404,12 +404,31 @@ where
             .pointer("/pull_request/number")
             .and_then(serde_json::Value::as_u64)
             .unwrap_or(0);
+
+        if pr_number == 0 {
+            tracing::warn!(
+                event_id = %event.event_id,
+                "PR number missing from payload; skipping status comment"
+            );
+            return Ok(());
+        }
+
         let pr_head_sha = event
             .payload
             .pointer("/pull_request/head/sha")
             .and_then(serde_json::Value::as_str)
             .unwrap_or_default()
             .to_string();
+
+        if pr_head_sha.is_empty() {
+            tracing::warn!(
+                event_id = %event.event_id,
+                pr = pr_number,
+                "PR head SHA missing from payload; skipping status comment"
+            );
+            return Ok(());
+        }
+
         let pr_head_branch = event
             .payload
             .pointer("/pull_request/head/ref")
@@ -496,7 +515,9 @@ where
             });
 
             // Check whether a release PR is already open with a higher version.
-            let release_search_query = format!("is:open head:{}/v", branch_prefix);
+            // The trailing * makes this a prefix match so all versioned release
+            // branches are captured (e.g. "is:open head:release/v*").
+            let release_search_query = format!("is:open head:{}/v*", branch_prefix);
             let queued_release_version: Option<versioning::SemanticVersion> = scoped_github
                 .search_pull_requests(owner, repo, &release_search_query)
                 .await

--- a/crates/core/src/lib_tests.rs
+++ b/crates/core/src/lib_tests.rs
@@ -33,6 +33,7 @@ impl MergedPullRequestHandler for NoopMergedPRHandler {
 struct SpyMergedPRHandler {
     received: Arc<Mutex<Vec<String>>>,
     received_release_pr: Arc<Mutex<Vec<String>>>,
+    received_activity: Arc<Mutex<Vec<String>>>,
 }
 
 impl SpyMergedPRHandler {
@@ -47,6 +48,10 @@ impl SpyMergedPRHandler {
     async fn received_release_pr_event_ids(&self) -> Vec<String> {
         self.received_release_pr.lock().await.clone()
     }
+
+    async fn received_activity_event_ids(&self) -> Vec<String> {
+        self.received_activity.lock().await.clone()
+    }
 }
 
 #[async_trait]
@@ -58,6 +63,14 @@ impl MergedPullRequestHandler for SpyMergedPRHandler {
 
     async fn handle_release_pr_merged(&self, event: &ProcessingEvent) -> CoreResult<()> {
         self.received_release_pr
+            .lock()
+            .await
+            .push(event.event_id.clone());
+        Ok(())
+    }
+
+    async fn handle_pull_request_activity(&self, event: &ProcessingEvent) -> CoreResult<()> {
+        self.received_activity
             .lock()
             .await
             .push(event.event_id.clone());
@@ -419,6 +432,63 @@ async fn test_run_event_loop_calls_handler_for_pull_request_merged_events() {
     // The release PR merged handler should have been called for the ReleasePrMerged event.
     let release_handled = handler.received_release_pr_event_ids().await;
     assert_eq!(release_handled, vec!["evt-release"]);
+}
+
+/// `run_event_loop` dispatches `PullRequestOpened` events to
+/// `handle_pull_request_activity` and acknowledges them.
+#[tokio::test]
+async fn test_run_event_loop_dispatches_pull_request_opened_to_activity_handler() {
+    let token = CancellationToken::new();
+    let source = TestEventSource::new(vec![make_test_event(
+        "evt-opened",
+        EventType::PullRequestOpened,
+    )]);
+    let source_for_loop = source.clone();
+    let loop_token = token.clone();
+
+    let handler = SpyMergedPRHandler::new();
+    let handler_for_loop = handler.clone();
+
+    let loop_handle = tokio::spawn(async move {
+        run_event_loop(&source_for_loop, &handler_for_loop, loop_token).await
+    });
+
+    let acked = wait_for_acks(&source, 1, &token).await;
+    loop_handle.await.unwrap().unwrap();
+
+    assert_eq!(acked, vec!["evt-opened"]);
+    let activity = handler.received_activity_event_ids().await;
+    assert_eq!(activity, vec!["evt-opened"]);
+    // Ensure the merged-PR handler was NOT called.
+    assert!(handler.received_event_ids().await.is_empty());
+}
+
+/// `run_event_loop` dispatches `PullRequestUpdated` events to
+/// `handle_pull_request_activity` and acknowledges them.
+#[tokio::test]
+async fn test_run_event_loop_dispatches_pull_request_updated_to_activity_handler() {
+    let token = CancellationToken::new();
+    let source = TestEventSource::new(vec![make_test_event(
+        "evt-updated",
+        EventType::PullRequestUpdated,
+    )]);
+    let source_for_loop = source.clone();
+    let loop_token = token.clone();
+
+    let handler = SpyMergedPRHandler::new();
+    let handler_for_loop = handler.clone();
+
+    let loop_handle = tokio::spawn(async move {
+        run_event_loop(&source_for_loop, &handler_for_loop, loop_token).await
+    });
+
+    let acked = wait_for_acks(&source, 1, &token).await;
+    loop_handle.await.unwrap().unwrap();
+
+    assert_eq!(acked, vec!["evt-updated"]);
+    let activity = handler.received_activity_event_ids().await;
+    assert_eq!(activity, vec!["evt-updated"]);
+    assert!(handler.received_event_ids().await.is_empty());
 }
 
 /// A `PullRequestMerged` event whose handler returns an error is rejected.

--- a/crates/core/src/lib_tests.rs
+++ b/crates/core/src/lib_tests.rs
@@ -1291,11 +1291,7 @@ impl ConfigurationProvider for TestConfigWith {
         Ok(())
     }
 
-    async fn config_exists(
-        &self,
-        _owner: Option<&str>,
-        _repo: Option<&str>,
-    ) -> CoreResult<bool> {
+    async fn config_exists(&self, _owner: Option<&str>, _repo: Option<&str>) -> CoreResult<bool> {
         Ok(true)
     }
 
@@ -2576,8 +2572,8 @@ async fn test_feature_pr_updated_updates_existing_status_comment_in_place() {
         user_login: Some("release-regent[bot]".into()),
     };
 
-    let github = TestGitHubForLib::new_empty()
-        .with_stored_issue_comments(42, vec![existing_comment]);
+    let github =
+        TestGitHubForLib::new_empty().with_stored_issue_comments(42, vec![existing_comment]);
     let config = TestConfigForLib;
     let version_calc = TestVersionCalcForLib::returning("1.2.0");
     let processor = ReleaseRegentProcessor::new(github.clone(), config, version_calc);
@@ -2605,7 +2601,10 @@ async fn test_feature_pr_updated_updates_existing_status_comment_in_place() {
 
     // create_issue_comment must NOT have been called.
     let creates = github.issue_comments.lock().await;
-    assert!(creates.is_empty(), "create_issue_comment must not be called when updating");
+    assert!(
+        creates.is_empty(),
+        "create_issue_comment must not be called when updating"
+    );
 }
 
 /// (c) After a feature PR merges, open PRs with an existing marker comment
@@ -2854,4 +2853,56 @@ async fn test_batch_refresh_skips_excluded_author_and_refreshes_normal_pr() {
     let updates = github.update_comment_calls.lock().await;
     assert_eq!(updates.len(), 1, "only one PR must be refreshed");
     assert_eq!(updates[0].0, 50, "must update the normal PR's comment");
+}
+
+/// (h) When an open release PR exists, the feature PR comment includes the
+/// queued-release annotation.  This test guards the wildcard fix: the search
+/// query must use "head:release/v*" (prefix match) not "head:release/v"
+/// (exact match), otherwise no release branch would ever match the query and
+/// `queued_release_version` would always be `None`.
+#[tokio::test]
+async fn test_feature_pr_opened_with_queued_release_includes_annotation() {
+    use crate::pr_status_commenter::PR_STATUS_MARKER;
+
+    // seed an open release PR so search_pull_requests returns it
+    let release_pr = make_open_pr_with_author(99, "release/v1.3.0", "sha-release", "release-bot");
+
+    let github = TestGitHubForLib::new_empty().with_search_results(vec![release_pr]);
+    let config = TestConfigForLib;
+    // version_calc returns 1.3.0 — same as already-queued release
+    let version_calc = TestVersionCalcForLib::returning("1.3.0");
+    let processor = ReleaseRegentProcessor::new(github.clone(), config, version_calc);
+
+    let event = ProcessingEvent {
+        event_id: "f4-h".into(),
+        correlation_id: "corr-f4-h".into(),
+        event_type: EventType::PullRequestOpened,
+        repository: test_repo(),
+        payload: make_pr_activity_payload(42, "abc1234", "feat/my-feature", "dev"),
+        received_at: Utc::now(),
+        source: EventSourceKind::Webhook,
+        installation_id: 0,
+    };
+
+    processor
+        .handle_pull_request_activity(&event)
+        .await
+        .expect("handle_pull_request_activity should succeed");
+
+    let comments = github.issue_comments.lock().await;
+    assert_eq!(comments.len(), 1, "expected exactly one comment");
+    let body = &comments[0].1;
+
+    assert!(
+        body.contains(PR_STATUS_MARKER),
+        "comment must contain the status marker; got: {body}"
+    );
+    assert!(
+        body.contains("1.3.0"),
+        "comment must mention the queued release version; got: {body}"
+    );
+    assert!(
+        body.contains("already open"),
+        "comment must note the queued release PR is open; got: {body}"
+    );
 }

--- a/crates/core/src/lib_tests.rs
+++ b/crates/core/src/lib_tests.rs
@@ -647,6 +647,11 @@ struct TestGitHubForLib {
     removed_labels: Arc<Mutex<Vec<(u64, String)>>>,
     /// Records every `(issue_number, body)` passed to `create_issue_comment`.
     issue_comments: Arc<Mutex<Vec<(u64, String)>>>,
+    /// Pre-seeded issue comments returned by `list_issue_comments`, keyed by
+    /// PR/issue number.  Each call returns the vec for that number (or empty).
+    stored_issue_comments: HashMap<u64, Vec<crate::traits::github_operations::IssueComment>>,
+    /// Records every `(comment_id, body)` passed to `update_issue_comment`.
+    update_comment_calls: Arc<Mutex<Vec<(u64, String)>>>,
     /// When set, `search_pull_requests` returns an error if the query
     /// contains this label name.  Other searches succeed normally.
     fail_search_for_label: Option<String>,
@@ -671,6 +676,8 @@ impl TestGitHubForLib {
             create_branch_calls: Arc::new(Mutex::new(vec![])),
             removed_labels: Arc::new(Mutex::new(vec![])),
             issue_comments: Arc::new(Mutex::new(vec![])),
+            stored_issue_comments: HashMap::new(),
+            update_comment_calls: Arc::new(Mutex::new(vec![])),
             fail_search_for_label: None,
             fail_remove_label_for_pr: None,
             fail_comment_for_pr: None,
@@ -690,6 +697,16 @@ impl TestGitHubForLib {
 
     fn with_search_results(mut self, prs: Vec<PullRequest>) -> Self {
         self.search_results = prs;
+        self
+    }
+
+    /// Pre-seed `list_issue_comments` for a specific issue/PR number.
+    fn with_stored_issue_comments(
+        mut self,
+        issue_number: u64,
+        comments: Vec<crate::traits::github_operations::IssueComment>,
+    ) -> Self {
+        self.stored_issue_comments.insert(issue_number, comments);
         self
     }
 
@@ -1058,18 +1075,26 @@ impl GitHubOperations for TestGitHubForLib {
         &self,
         _owner: &str,
         _repo: &str,
-        _issue_number: u64,
+        issue_number: u64,
     ) -> CoreResult<Vec<crate::traits::github_operations::IssueComment>> {
-        Ok(vec![])
+        Ok(self
+            .stored_issue_comments
+            .get(&issue_number)
+            .cloned()
+            .unwrap_or_default())
     }
 
     async fn update_issue_comment(
         &self,
         _owner: &str,
         _repo: &str,
-        _comment_id: u64,
-        _body: &str,
+        comment_id: u64,
+        body: &str,
     ) -> CoreResult<()> {
+        self.update_comment_calls
+            .lock()
+            .await
+            .push((comment_id, body.to_string()));
         Ok(())
     }
 
@@ -1083,6 +1108,8 @@ impl GitHubOperations for TestGitHubForLib {
             create_branch_calls: Arc::clone(&self.create_branch_calls),
             removed_labels: Arc::clone(&self.removed_labels),
             issue_comments: Arc::clone(&self.issue_comments),
+            stored_issue_comments: self.stored_issue_comments.clone(),
+            update_comment_calls: Arc::clone(&self.update_comment_calls),
             fail_search_for_label: self.fail_search_for_label.clone(),
             fail_remove_label_for_pr: self.fail_remove_label_for_pr,
             fail_comment_for_pr: self.fail_comment_for_pr,
@@ -1178,6 +1205,106 @@ impl ConfigurationProvider for TestConfigForLib {
 
     async fn get_default_config(&self) -> CoreResult<config::ReleaseRegentConfig> {
         Ok(config::ReleaseRegentConfig::default())
+    }
+}
+
+/// Configurable variant of `TestConfigForLib` — returns a fixed
+/// `ReleaseRegentConfig` supplied at construction time.
+#[derive(Clone)]
+struct TestConfigWith(config::ReleaseRegentConfig);
+
+impl TestConfigWith {
+    fn new(cfg: config::ReleaseRegentConfig) -> Self {
+        Self(cfg)
+    }
+}
+
+#[async_trait]
+impl ConfigurationProvider for TestConfigWith {
+    async fn load_global_config(
+        &self,
+        _options: LoadOptions,
+    ) -> CoreResult<config::ReleaseRegentConfig> {
+        Ok(self.0.clone())
+    }
+
+    async fn load_repository_config(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _options: LoadOptions,
+    ) -> CoreResult<Option<RepositoryConfig>> {
+        Ok(None)
+    }
+
+    async fn get_merged_config(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _options: LoadOptions,
+    ) -> CoreResult<config::ReleaseRegentConfig> {
+        Ok(self.0.clone())
+    }
+
+    async fn validate_config(
+        &self,
+        _config: &config::ReleaseRegentConfig,
+    ) -> CoreResult<ValidationResult> {
+        Ok(ValidationResult {
+            is_valid: true,
+            errors: vec![],
+            warnings: vec![],
+        })
+    }
+
+    async fn save_config(
+        &self,
+        _config: &config::ReleaseRegentConfig,
+        _owner: Option<&str>,
+        _repo: Option<&str>,
+        _global: bool,
+    ) -> CoreResult<()> {
+        Ok(())
+    }
+
+    async fn list_repository_configs(
+        &self,
+        _options: LoadOptions,
+    ) -> CoreResult<Vec<RepositoryConfig>> {
+        Ok(vec![])
+    }
+
+    async fn get_config_source(
+        &self,
+        _owner: Option<&str>,
+        _repo: Option<&str>,
+    ) -> CoreResult<ConfigurationSource> {
+        Ok(ConfigurationSource {
+            format: "yaml".into(),
+            loaded_at: Utc::now(),
+            location: "default".into(),
+            source_type: "default".into(),
+        })
+    }
+
+    async fn reload_config(&self, _owner: Option<&str>, _repo: Option<&str>) -> CoreResult<()> {
+        Ok(())
+    }
+
+    async fn config_exists(
+        &self,
+        _owner: Option<&str>,
+        _repo: Option<&str>,
+    ) -> CoreResult<bool> {
+        Ok(true)
+    }
+
+    fn supported_formats(&self) -> Vec<String> {
+        vec!["yaml".into()]
+    }
+
+    async fn get_default_config(&self) -> CoreResult<config::ReleaseRegentConfig> {
+        Ok(self.0.clone())
     }
 }
 
@@ -2338,4 +2465,393 @@ async fn test_handle_merged_non_bumping_pr_with_patch_floor_creates_next_patch_r
         "release branch should reference 0.3.1, got: {}",
         created[0].0
     );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Phase F — PR status comment end-to-end scenarios
+// ─────────────────────────────────────────────────────────────────────────────
+
+fn make_pr_activity_payload(
+    pr_number: u64,
+    head_sha: &str,
+    head_branch: &str,
+    author_login: &str,
+) -> serde_json::Value {
+    serde_json::json!({
+        "pull_request": {
+            "number": pr_number,
+            "head": { "sha": head_sha, "ref": head_branch },
+            "user": { "login": author_login }
+        }
+    })
+}
+
+fn make_open_pr_with_author(
+    number: u64,
+    head_branch: &str,
+    head_sha: &str,
+    author_login: &str,
+) -> PullRequest {
+    let repo = make_repo();
+    PullRequest {
+        base: PullRequestBranch {
+            ref_name: "main".into(),
+            repo: repo.clone(),
+            sha: "base000000000000000000000000000000000000".into(),
+        },
+        body: None,
+        created_at: Utc::now(),
+        draft: false,
+        head: PullRequestBranch {
+            ref_name: head_branch.to_string(),
+            repo,
+            sha: head_sha.to_string(),
+        },
+        merged_at: None,
+        number,
+        state: "open".into(),
+        title: format!("PR #{number}"),
+        updated_at: Utc::now(),
+        user: GitUser {
+            email: format!("{author_login}@example.com"),
+            login: Some(author_login.to_string()),
+            name: author_login.to_string(),
+        },
+    }
+}
+
+/// (a) `PullRequestOpened` for a feature branch → status comment created with
+/// projected version; `create_issue_comment` called exactly once.
+#[tokio::test]
+async fn test_feature_pr_opened_creates_status_comment_with_projected_version() {
+    let github = TestGitHubForLib::new_empty();
+    let config = TestConfigForLib;
+    let version_calc = TestVersionCalcForLib::returning("1.2.0");
+    let processor = ReleaseRegentProcessor::new(github.clone(), config, version_calc);
+
+    let event = ProcessingEvent {
+        event_id: "f4-a".into(),
+        correlation_id: "corr-f4-a".into(),
+        event_type: EventType::PullRequestOpened,
+        repository: test_repo(),
+        payload: make_pr_activity_payload(42, "abc1234", "feat/my-feature", "dev"),
+        received_at: Utc::now(),
+        source: EventSourceKind::Webhook,
+        installation_id: 0,
+    };
+
+    processor
+        .handle_pull_request_activity(&event)
+        .await
+        .expect("handle_pull_request_activity should succeed");
+
+    let comments = github.issue_comments.lock().await;
+    assert_eq!(comments.len(), 1, "expected exactly one comment");
+    assert_eq!(comments[0].0, 42, "comment must target PR #42");
+    assert!(
+        comments[0].1.contains("1.2.0"),
+        "comment body must contain projected version; got: {}",
+        comments[0].1
+    );
+    assert!(
+        comments[0]
+            .1
+            .contains(pr_status_commenter::PR_STATUS_MARKER),
+        "comment must contain the status marker"
+    );
+}
+
+/// (b) `PullRequestUpdated` for the same feature branch after a comment
+/// already exists → `update_issue_comment` called; no duplicate comment.
+#[tokio::test]
+async fn test_feature_pr_updated_updates_existing_status_comment_in_place() {
+    use crate::traits::github_operations::IssueComment;
+
+    let existing_comment = IssueComment {
+        id: 99,
+        body: format!(
+            "{}\nOld projected version: v1.1.0",
+            pr_status_commenter::PR_STATUS_MARKER
+        ),
+        user_login: Some("release-regent[bot]".into()),
+    };
+
+    let github = TestGitHubForLib::new_empty()
+        .with_stored_issue_comments(42, vec![existing_comment]);
+    let config = TestConfigForLib;
+    let version_calc = TestVersionCalcForLib::returning("1.2.0");
+    let processor = ReleaseRegentProcessor::new(github.clone(), config, version_calc);
+
+    let event = ProcessingEvent {
+        event_id: "f4-b".into(),
+        correlation_id: "corr-f4-b".into(),
+        event_type: EventType::PullRequestUpdated,
+        repository: test_repo(),
+        payload: make_pr_activity_payload(42, "abc2345", "feat/my-feature", "dev"),
+        received_at: Utc::now(),
+        source: EventSourceKind::Webhook,
+        installation_id: 0,
+    };
+
+    processor
+        .handle_pull_request_activity(&event)
+        .await
+        .expect("handle_pull_request_activity should succeed");
+
+    // update_issue_comment must have been called (not create_issue_comment).
+    let updates = github.update_comment_calls.lock().await;
+    assert_eq!(updates.len(), 1, "expected one update call");
+    assert_eq!(updates[0].0, 99, "must update comment id 99");
+
+    // create_issue_comment must NOT have been called.
+    let creates = github.issue_comments.lock().await;
+    assert!(creates.is_empty(), "create_issue_comment must not be called when updating");
+}
+
+/// (c) After a feature PR merges, open PRs with an existing marker comment
+/// are refreshed (max 25).
+#[tokio::test]
+async fn test_merged_feature_pr_refreshes_open_prs_with_existing_marker() {
+    use crate::traits::github_operations::IssueComment;
+
+    // Two open feature PRs, both with an existing marker comment.
+    let pr_10 = make_open_pr_with_author(10, "feat/alpha", "sha-alpha", "alice");
+    let pr_11 = make_open_pr_with_author(11, "feat/beta", "sha-beta", "bob");
+
+    let marker_comment = IssueComment {
+        id: 1,
+        body: format!("{}\nOld version", pr_status_commenter::PR_STATUS_MARKER),
+        user_login: None,
+    };
+
+    let github = TestGitHubForLib::new_empty()
+        .with_search_results(vec![pr_10, pr_11])
+        .with_stored_issue_comments(10, vec![marker_comment.clone()])
+        .with_stored_issue_comments(11, vec![marker_comment]);
+    let config = TestConfigForLib;
+    let version_calc = TestVersionCalcForLib::returning("0.2.0");
+    let processor = ReleaseRegentProcessor::new(github.clone(), config, version_calc);
+
+    // Build a merged-PR event
+    let event = ProcessingEvent {
+        event_id: "f4-c".into(),
+        correlation_id: "corr-f4-c".into(),
+        event_type: EventType::PullRequestMerged,
+        repository: test_repo(),
+        payload: serde_json::json!({
+            "pull_request": {
+                "number": 5,
+                "base": { "ref": "main" },
+                "merge_commit_sha": "a".repeat(40),
+                "head": { "sha": "a".repeat(40), "ref": "feat/update" }
+            }
+        }),
+        received_at: Utc::now(),
+        source: EventSourceKind::Webhook,
+        installation_id: 0,
+    };
+
+    MergedPullRequestHandler::handle_merged_pull_request(&processor, &event)
+        .await
+        .expect("handle_merged_pull_request should succeed");
+
+    // Both open PRs should have received a refreshed comment (via update since
+    // they already had a marker comment).
+    let updates = github.update_comment_calls.lock().await;
+    assert_eq!(
+        updates.len(),
+        2,
+        "both open PRs with marker comment must be refreshed"
+    );
+}
+
+/// (d) `PullRequestOpened` for a release branch → status comment shows the
+/// release version extracted from the branch name.
+#[tokio::test]
+async fn test_release_pr_opened_creates_status_comment_with_release_version() {
+    let github = TestGitHubForLib::new_empty();
+    let config = TestConfigForLib;
+    let version_calc = TestVersionCalcForLib::returning("2.0.0"); // should NOT be used
+    let processor = ReleaseRegentProcessor::new(github.clone(), config, version_calc);
+
+    let event = ProcessingEvent {
+        event_id: "f4-d".into(),
+        correlation_id: "corr-f4-d".into(),
+        event_type: EventType::PullRequestOpened,
+        repository: test_repo(),
+        payload: make_pr_activity_payload(55, "deadbeef", "release/v1.5.0", "release-bot"),
+        received_at: Utc::now(),
+        source: EventSourceKind::Webhook,
+        installation_id: 0,
+    };
+
+    processor
+        .handle_pull_request_activity(&event)
+        .await
+        .expect("handle_pull_request_activity should succeed");
+
+    let comments = github.issue_comments.lock().await;
+    assert_eq!(comments.len(), 1, "expected exactly one comment");
+    assert_eq!(comments[0].0, 55);
+    assert!(
+        comments[0].1.contains("1.5.0"),
+        "comment must show release version 1.5.0; got: {}",
+        comments[0].1
+    );
+    assert!(
+        comments[0].1.contains("release PR"),
+        "comment must identify itself as a release PR comment"
+    );
+}
+
+/// (e) `allow_override: false` → no `### Available commands` section in
+/// either feature or release PR status comments.
+#[tokio::test]
+async fn test_pr_status_comment_omits_commands_when_allow_override_is_false() {
+    let mut cfg = config::ReleaseRegentConfig::default();
+    cfg.versioning.allow_override = false;
+
+    let github = TestGitHubForLib::new_empty();
+    let config = TestConfigWith::new(cfg);
+    let version_calc = TestVersionCalcForLib::returning("1.1.0");
+    let processor = ReleaseRegentProcessor::new(github.clone(), config, version_calc);
+
+    // Feature PR
+    let feature_event = ProcessingEvent {
+        event_id: "f4-e-feat".into(),
+        correlation_id: "corr-f4-e-feat".into(),
+        event_type: EventType::PullRequestOpened,
+        repository: test_repo(),
+        payload: make_pr_activity_payload(10, "sha1", "feat/x", "user1"),
+        received_at: Utc::now(),
+        source: EventSourceKind::Webhook,
+        installation_id: 0,
+    };
+
+    processor
+        .handle_pull_request_activity(&feature_event)
+        .await
+        .expect("feature PR activity should succeed");
+
+    // Release PR
+    let release_event = ProcessingEvent {
+        event_id: "f4-e-rel".into(),
+        correlation_id: "corr-f4-e-rel".into(),
+        event_type: EventType::PullRequestOpened,
+        repository: test_repo(),
+        payload: make_pr_activity_payload(20, "sha2", "release/v1.1.0", "release-bot"),
+        received_at: Utc::now(),
+        source: EventSourceKind::Webhook,
+        installation_id: 0,
+    };
+
+    processor
+        .handle_pull_request_activity(&release_event)
+        .await
+        .expect("release PR activity should succeed");
+
+    let comments = github.issue_comments.lock().await;
+    assert_eq!(comments.len(), 2);
+    for (_, body) in comments.iter() {
+        assert!(
+            !body.contains("### Available commands"),
+            "commands section must be absent when allow_override is false; got: {body}"
+        );
+    }
+}
+
+/// (f) `PullRequestOpened` from a login in `excluded_pr_authors` → no
+/// comment posted.
+#[tokio::test]
+async fn test_feature_pr_from_excluded_author_skips_status_comment() {
+    let mut cfg = config::ReleaseRegentConfig::default();
+    cfg.versioning
+        .excluded_pr_authors
+        .push("dependabot[bot]".to_string());
+
+    let github = TestGitHubForLib::new_empty();
+    let config = TestConfigWith::new(cfg);
+    let version_calc = TestVersionCalcForLib::returning("1.0.1");
+    let processor = ReleaseRegentProcessor::new(github.clone(), config, version_calc);
+
+    let event = ProcessingEvent {
+        event_id: "f4-f".into(),
+        correlation_id: "corr-f4-f".into(),
+        event_type: EventType::PullRequestOpened,
+        repository: test_repo(),
+        payload: make_pr_activity_payload(77, "sha-bot", "deps/update", "dependabot[bot]"),
+        received_at: Utc::now(),
+        source: EventSourceKind::Webhook,
+        installation_id: 0,
+    };
+
+    processor
+        .handle_pull_request_activity(&event)
+        .await
+        .expect("excluded author should be handled cleanly");
+
+    // No comment must be posted.
+    let comments = github.issue_comments.lock().await;
+    assert!(
+        comments.is_empty(),
+        "no comment must be posted for excluded author"
+    );
+}
+
+/// (g) Batch refresh after merge: excluded-author PR skipped; normal PR with
+/// marker comment is refreshed.
+#[tokio::test]
+async fn test_batch_refresh_skips_excluded_author_and_refreshes_normal_pr() {
+    use crate::traits::github_operations::IssueComment;
+
+    let mut cfg = config::ReleaseRegentConfig::default();
+    cfg.versioning
+        .excluded_pr_authors
+        .push("bot-account".to_string());
+
+    let bot_pr = make_open_pr_with_author(30, "deps/bump", "sha-bot", "bot-account");
+    let normal_pr = make_open_pr_with_author(31, "feat/real-feature", "sha-real", "alice");
+
+    let marker_comment = IssueComment {
+        id: 50,
+        body: format!("{}\nOld version", pr_status_commenter::PR_STATUS_MARKER),
+        user_login: None,
+    };
+
+    let github = TestGitHubForLib::new_empty()
+        .with_search_results(vec![bot_pr, normal_pr])
+        // Both PRs have an existing marker comment to ensure the only reason
+        // the bot PR is skipped is the excluded-author filter.
+        .with_stored_issue_comments(30, vec![marker_comment.clone()])
+        .with_stored_issue_comments(31, vec![marker_comment]);
+    let config = TestConfigWith::new(cfg);
+    let version_calc = TestVersionCalcForLib::returning("0.2.0");
+    let processor = ReleaseRegentProcessor::new(github.clone(), config, version_calc);
+
+    let event = ProcessingEvent {
+        event_id: "f4-g".into(),
+        correlation_id: "corr-f4-g".into(),
+        event_type: EventType::PullRequestMerged,
+        repository: test_repo(),
+        payload: serde_json::json!({
+            "pull_request": {
+                "number": 7,
+                "base": { "ref": "main" },
+                "merge_commit_sha": "b".repeat(40),
+                "head": { "sha": "b".repeat(40), "ref": "feat/something" }
+            }
+        }),
+        received_at: Utc::now(),
+        source: EventSourceKind::Webhook,
+        installation_id: 0,
+    };
+
+    MergedPullRequestHandler::handle_merged_pull_request(&processor, &event)
+        .await
+        .expect("handle_merged_pull_request should succeed");
+
+    // Only the normal PR (id 31) should be refreshed.
+    let updates = github.update_comment_calls.lock().await;
+    assert_eq!(updates.len(), 1, "only one PR must be refreshed");
+    assert_eq!(updates[0].0, 50, "must update the normal PR's comment");
 }

--- a/crates/core/src/lib_tests.rs
+++ b/crates/core/src/lib_tests.rs
@@ -984,6 +984,25 @@ impl GitHubOperations for TestGitHubForLib {
         Ok(())
     }
 
+    async fn list_issue_comments(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _issue_number: u64,
+    ) -> CoreResult<Vec<crate::traits::github_operations::IssueComment>> {
+        Ok(vec![])
+    }
+
+    async fn update_issue_comment(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _comment_id: u64,
+        _body: &str,
+    ) -> CoreResult<()> {
+        Ok(())
+    }
+
     fn scoped_to(&self, _installation_id: u64) -> Self {
         Self {
             tags: self.tags.clone(),

--- a/crates/core/src/pr_status_commenter.rs
+++ b/crates/core/src/pr_status_commenter.rs
@@ -75,13 +75,20 @@ pub(crate) async fn upsert_pr_status_comment<G: GitHubOperations>(
 
 /// Render the feature-branch PR status comment body.
 ///
-/// Produces a Markdown string beginning with [`PR_STATUS_MARKER`] that shows
-/// the projected next release version and, when `allow_override` is `true`,
-/// a table of available commands.
+/// Produces a Markdown string beginning with [`PR_STATUS_MARKER`].
+///
+/// When `projected_version == base_version` the commits in this PR do not
+/// trigger any version bump; the comment says so rather than echoing back the
+/// current version as "the next release".
+///
+/// When `queued_release_version` is `Some(v)` and `v > base_version` (i.e. a
+/// release PR for a higher version is already open) a blockquote note is
+/// appended so PR authors know their changes will land after that release.
 ///
 /// # Parameters
 /// - `projected_version`: Version that would be published if this PR is merged now
 /// - `base_version`: Latest released version from which the projection starts
+/// - `queued_release_version`: Highest open release-branch PR version, if any
 /// - `allow_override`: When `true`, appends the `### Available commands` table
 ///
 /// # Returns
@@ -93,24 +100,47 @@ pub(crate) async fn upsert_pr_status_comment<G: GitHubOperations>(
 /// use release_regent_core::pr_status_commenter::render_feature_pr_comment;
 /// use release_regent_core::versioning::SemanticVersion;
 ///
-/// let body = render_feature_pr_comment(&v1_1_0, &v1_0_0, true);
+/// let body = render_feature_pr_comment(&v1_1_0, &v1_0_0, None, true);
 /// assert!(body.contains("v1.1.0"));
 /// ```
 #[must_use]
 pub(crate) fn render_feature_pr_comment(
     projected_version: &SemanticVersion,
     base_version: &SemanticVersion,
+    queued_release_version: Option<&SemanticVersion>,
     allow_override: bool,
 ) -> String {
-    let mut body = format!(
-        "{marker}\n\
-         **Release Regent \u{2014} projected release**\n\n\
-         If this PR is merged now, the next release will be **v{projected}**.\n\
-         _(Projection based on commits since `v{base}`. Updates automatically when other PRs land.)_",
-        marker = PR_STATUS_MARKER,
-        projected = projected_version,
-        base = base_version,
-    );
+    let mut body = if projected_version == base_version {
+        format!(
+            "{marker}\n\
+             **Release Regent \u{2014} no version change**\n\n\
+             This PR's commits do not affect the version number.\n\
+             It will be included in the next release.\n\
+             _(Projection based on commits since `v{base}`. Updates automatically when other PRs land.)_",
+            marker = PR_STATUS_MARKER,
+            base = base_version,
+        )
+    } else {
+        format!(
+            "{marker}\n\
+             **Release Regent \u{2014} projected release**\n\n\
+             If this PR is merged now, the next release will be **v{projected}**.\n\
+             _(Projection based on commits since `v{base}`. Updates automatically when other PRs land.)_",
+            marker = PR_STATUS_MARKER,
+            projected = projected_version,
+            base = base_version,
+        )
+    };
+
+    if let Some(queued) = queued_release_version {
+        if queued > base_version {
+            body.push_str(&format!(
+                "\n\n\
+                 > **Note:** Release PR for **v{queued}** is already open. \
+                 This PR's changes will be included in a subsequent release.",
+            ));
+        }
+    }
 
     if allow_override {
         body.push_str(

--- a/crates/core/src/pr_status_commenter.rs
+++ b/crates/core/src/pr_status_commenter.rs
@@ -1,0 +1,180 @@
+//! PR status comment rendering and upsert infrastructure.
+//!
+//! This module provides utilities for posting and maintaining a single
+//! status comment on every open pull request.  A signed HTML marker
+//! (`<!-- release-regent:pr-status -->`) is embedded in each comment so that
+//! subsequent calls update the existing comment in place rather than creating
+//! duplicates.
+//!
+//! # Exported items
+//!
+//! - [`upsert_pr_status_comment`] — create or update the status comment
+//! - [`render_feature_pr_comment`] — render the feature-branch comment body
+//! - [`render_release_pr_comment`] — render the release-branch comment body
+//! - [`PR_STATUS_MARKER`] — the HTML marker string embedded in every comment
+
+use crate::{traits::github_operations::GitHubOperations, versioning::SemanticVersion, CoreResult};
+
+/// HTML marker embedded in every status comment posted by Release Regent.
+///
+/// The marker is placed at the very start of the comment body so that
+/// [`upsert_pr_status_comment`] can locate an existing comment to update
+/// rather than creating a duplicate.
+pub(crate) const PR_STATUS_MARKER: &str = "<!-- release-regent:pr-status -->";
+
+/// Create or update the Release Regent status comment on an issue or PR.
+///
+/// Scans existing comments via [`GitHubOperations::list_issue_comments`].
+/// If a comment whose body contains [`PR_STATUS_MARKER`] is found, it is
+/// updated via [`GitHubOperations::update_issue_comment`].  Otherwise a new
+/// comment is created via [`GitHubOperations::create_issue_comment`].
+///
+/// # Parameters
+/// - `github`: GitHub API client scoped to the correct installation
+/// - `owner`: Repository owner
+/// - `repo`: Repository name
+/// - `issue_number`: Issue or PR number to comment on
+/// - `body`: New comment body (should begin with [`PR_STATUS_MARKER`])
+///
+/// # Errors
+/// Propagates any error returned by the underlying GitHub API calls.
+///
+/// # Examples
+///
+/// ```rust,ignore
+/// use release_regent_core::pr_status_commenter::{PR_STATUS_MARKER, upsert_pr_status_comment};
+///
+/// let body = format!("{PR_STATUS_MARKER}\n## Status\nAll good");
+/// upsert_pr_status_comment(&github, "owner", "repo", 42, &body).await?;
+/// ```
+// CoreError is intentionally large; this is the project-wide pattern.
+#[allow(clippy::result_large_err)]
+pub(crate) async fn upsert_pr_status_comment<G: GitHubOperations>(
+    github: &G,
+    owner: &str,
+    repo: &str,
+    issue_number: u64,
+    body: &str,
+) -> CoreResult<()> {
+    let comments = github
+        .list_issue_comments(owner, repo, issue_number)
+        .await?;
+
+    let existing = comments.iter().find(|c| c.body.contains(PR_STATUS_MARKER));
+
+    if let Some(comment) = existing {
+        github
+            .update_issue_comment(owner, repo, comment.id, body)
+            .await
+    } else {
+        github
+            .create_issue_comment(owner, repo, issue_number, body)
+            .await
+    }
+}
+
+/// Render the feature-branch PR status comment body.
+///
+/// Produces a Markdown string beginning with [`PR_STATUS_MARKER`] that shows
+/// the projected next release version and, when `allow_override` is `true`,
+/// a table of available commands.
+///
+/// # Parameters
+/// - `projected_version`: Version that would be published if this PR is merged now
+/// - `base_version`: Latest released version from which the projection starts
+/// - `allow_override`: When `true`, appends the `### Available commands` table
+///
+/// # Returns
+/// A Markdown string beginning with [`PR_STATUS_MARKER`].
+///
+/// # Examples
+///
+/// ```rust,ignore
+/// use release_regent_core::pr_status_commenter::render_feature_pr_comment;
+/// use release_regent_core::versioning::SemanticVersion;
+///
+/// let body = render_feature_pr_comment(&v1_1_0, &v1_0_0, true);
+/// assert!(body.contains("v1.1.0"));
+/// ```
+#[must_use]
+pub(crate) fn render_feature_pr_comment(
+    projected_version: &SemanticVersion,
+    base_version: &SemanticVersion,
+    allow_override: bool,
+) -> String {
+    let mut body = format!(
+        "{marker}\n\
+         **Release Regent \u{2014} projected release**\n\n\
+         If this PR is merged now, the next release will be **v{projected}**.\n\
+         _(Projection based on commits since `v{base}`. Updates automatically when other PRs land.)_",
+        marker = PR_STATUS_MARKER,
+        projected = projected_version,
+        base = base_version,
+    );
+
+    if allow_override {
+        body.push_str(
+            "\n\n\
+             ### Available commands\n\
+             | Command | Effect |\n\
+             |---------|--------|\n\
+             | `!release major` | Force at least a major version bump for this PR |\n\
+             | `!release minor` | Force at least a minor version bump |\n\
+             | `!release patch` | Force at least a patch version bump |\n\
+             | `!set-version X.Y.Z` | Pin the exact release version |",
+        );
+    }
+
+    body
+}
+
+/// Render the release-branch PR status comment body.
+///
+/// Produces a Markdown string beginning with [`PR_STATUS_MARKER`] that
+/// identifies the PR as a managed release PR and shows the target version.
+///
+/// # Parameters
+/// - `release_version`: The version this release PR will publish
+/// - `allow_override`: When `true`, appends the `### Available commands` table
+///
+/// # Returns
+/// A Markdown string beginning with [`PR_STATUS_MARKER`].
+///
+/// # Examples
+///
+/// ```rust,ignore
+/// use release_regent_core::pr_status_commenter::render_release_pr_comment;
+/// use release_regent_core::versioning::SemanticVersion;
+///
+/// let body = render_release_pr_comment(&v2_0_0, true);
+/// assert!(body.contains("v2.0.0"));
+/// ```
+#[must_use]
+pub(crate) fn render_release_pr_comment(
+    release_version: &SemanticVersion,
+    allow_override: bool,
+) -> String {
+    let mut body = format!(
+        "{marker}\n\
+         **Release Regent \u{2014} release PR**\n\n\
+         This PR is managed by Release Regent. Merging it will publish release **v{version}**.",
+        marker = PR_STATUS_MARKER,
+        version = release_version,
+    );
+
+    if allow_override {
+        body.push_str(
+            "\n\n\
+             ### Available commands\n\
+             | Command | Effect |\n\
+             |---------|--------|\n\
+             | `!set-version X.Y.Z` | Re-target this release to a different version |",
+        );
+    }
+
+    body
+}
+
+#[cfg(test)]
+#[path = "pr_status_commenter_tests.rs"]
+mod tests;

--- a/crates/core/src/pr_status_commenter_tests.rs
+++ b/crates/core/src/pr_status_commenter_tests.rs
@@ -548,7 +548,7 @@ fn v110() -> SemanticVersion {
 
 #[test]
 fn test_render_feature_pr_comment_starts_with_html_marker() {
-    let body = render_feature_pr_comment(&v110(), &v100(), true);
+    let body = render_feature_pr_comment(&v110(), &v100(), None, true);
     assert!(
         body.starts_with(PR_STATUS_MARKER),
         "feature PR comment must start with the HTML marker; got: {body}"
@@ -557,7 +557,7 @@ fn test_render_feature_pr_comment_starts_with_html_marker() {
 
 #[test]
 fn test_render_feature_pr_comment_includes_projected_version() {
-    let body = render_feature_pr_comment(&v110(), &v100(), false);
+    let body = render_feature_pr_comment(&v110(), &v100(), None, false);
     assert!(
         body.contains("v1.1.0"),
         "feature PR comment must include projected version; got: {body}"
@@ -566,7 +566,7 @@ fn test_render_feature_pr_comment_includes_projected_version() {
 
 #[test]
 fn test_render_feature_pr_comment_includes_base_version_in_subtitle() {
-    let body = render_feature_pr_comment(&v110(), &v100(), false);
+    let body = render_feature_pr_comment(&v110(), &v100(), None, false);
     assert!(
         body.contains("v1.0.0"),
         "feature PR comment must include base version in subtitle; got: {body}"
@@ -575,7 +575,7 @@ fn test_render_feature_pr_comment_includes_base_version_in_subtitle() {
 
 #[test]
 fn test_render_feature_pr_comment_includes_commands_table_when_allow_override_true() {
-    let body = render_feature_pr_comment(&v110(), &v100(), true);
+    let body = render_feature_pr_comment(&v110(), &v100(), None, true);
     assert!(
         body.contains("### Available commands"),
         "commands section must be present when allow_override=true; got: {body}"
@@ -588,10 +588,80 @@ fn test_render_feature_pr_comment_includes_commands_table_when_allow_override_tr
 
 #[test]
 fn test_render_feature_pr_comment_omits_commands_table_when_allow_override_false() {
-    let body = render_feature_pr_comment(&v110(), &v100(), false);
+    let body = render_feature_pr_comment(&v110(), &v100(), None, false);
     assert!(
         !body.contains("### Available commands"),
         "commands section must be absent when allow_override=false; got: {body}"
+    );
+}
+
+#[test]
+fn test_render_feature_pr_comment_no_bump_shows_no_version_change() {
+    // projected == base means no version-bumping commits
+    let body = render_feature_pr_comment(&v100(), &v100(), None, false);
+    assert!(
+        body.starts_with(PR_STATUS_MARKER),
+        "no-bump comment must start with the HTML marker; got: {body}"
+    );
+    assert!(
+        body.contains("no version change"),
+        "no-bump comment must say 'no version change'; got: {body}"
+    );
+    assert!(
+        body.contains("v1.0.0"),
+        "no-bump comment must still reference the base version; got: {body}"
+    );
+}
+
+#[test]
+fn test_render_feature_pr_comment_no_bump_does_not_say_next_release_will_be() {
+    let body = render_feature_pr_comment(&v100(), &v100(), None, false);
+    assert!(
+        !body.contains("next release will be"),
+        "no-bump comment must not say 'next release will be'; got: {body}"
+    );
+}
+
+#[test]
+fn test_render_feature_pr_comment_queued_version_higher_than_base_includes_note() {
+    let queued = v200();
+    let body = render_feature_pr_comment(&v110(), &v100(), Some(&queued), false);
+    assert!(
+        body.contains("v2.0.0"),
+        "comment must mention queued version; got: {body}"
+    );
+    assert!(
+        body.contains("already open"),
+        "comment must note the queued release PR is open; got: {body}"
+    );
+    assert!(
+        body.contains("subsequent release"),
+        "comment must note changes land after the queued release; got: {body}"
+    );
+}
+
+#[test]
+fn test_render_feature_pr_comment_queued_version_equals_base_does_not_include_note() {
+    // queued == base_version is a degenerate case; no note should appear
+    let queued = v100();
+    let body = render_feature_pr_comment(&v110(), &v100(), Some(&queued), false);
+    assert!(
+        !body.contains("already open"),
+        "no note should appear when queued == base; got: {body}"
+    );
+}
+
+#[test]
+fn test_render_feature_pr_comment_no_bump_with_queued_version_includes_both_messages() {
+    let queued = v200();
+    let body = render_feature_pr_comment(&v100(), &v100(), Some(&queued), false);
+    assert!(
+        body.contains("no version change"),
+        "must say no version change; got: {body}"
+    );
+    assert!(
+        body.contains("v2.0.0"),
+        "must also note the queued release; got: {body}"
     );
 }
 

--- a/crates/core/src/pr_status_commenter_tests.rs
+++ b/crates/core/src/pr_status_commenter_tests.rs
@@ -1,0 +1,645 @@
+use super::*;
+use crate::{
+    traits::{
+        git_operations::{
+            GetCommitsOptions, GitCommit, GitOperations, GitRepository, GitTag, ListTagsOptions,
+        },
+        github_operations::{
+            CollaboratorPermission, CreatePullRequestParams, CreateReleaseParams, FileUpdate,
+            GitHubOperations, GitUser, IssueComment, Label, PullRequest, PullRequestBranch,
+            Release, Repository, Tag, UpdateReleaseParams,
+        },
+    },
+    versioning::SemanticVersion,
+    CoreError,
+};
+use async_trait::async_trait;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+// ── Minimal inline test double for upsert tests ──────────────────────────────
+
+#[derive(Clone, Default)]
+struct UpsertTestState {
+    /// Pre-loaded comments returned by `list_issue_comments`.
+    comments: Vec<IssueComment>,
+    /// Recorded `create_issue_comment` calls: `(issue_number, body)`.
+    create_calls: Vec<(u64, String)>,
+    /// Recorded `update_issue_comment` calls: `(comment_id, body)`.
+    update_calls: Vec<(u64, String)>,
+    /// When `true`, `list_issue_comments` returns an error.
+    list_error: bool,
+    /// When `true`, `update_issue_comment` returns an error.
+    update_error: bool,
+}
+
+#[derive(Clone)]
+struct TestGitHubForUpsert {
+    state: Arc<Mutex<UpsertTestState>>,
+}
+
+impl TestGitHubForUpsert {
+    fn new(comments: Vec<IssueComment>) -> Self {
+        Self {
+            state: Arc::new(Mutex::new(UpsertTestState {
+                comments,
+                ..Default::default()
+            })),
+        }
+    }
+
+    fn with_list_error() -> Self {
+        Self {
+            state: Arc::new(Mutex::new(UpsertTestState {
+                list_error: true,
+                ..Default::default()
+            })),
+        }
+    }
+
+    fn with_update_error(existing_comment_id: u64) -> Self {
+        Self {
+            state: Arc::new(Mutex::new(UpsertTestState {
+                comments: vec![IssueComment {
+                    id: existing_comment_id,
+                    body: format!("{PR_STATUS_MARKER}\nold body"),
+                    user_login: None,
+                }],
+                update_error: true,
+                ..Default::default()
+            })),
+        }
+    }
+
+    async fn create_calls(&self) -> Vec<(u64, String)> {
+        self.state.lock().await.create_calls.clone()
+    }
+
+    async fn update_calls(&self) -> Vec<(u64, String)> {
+        self.state.lock().await.update_calls.clone()
+    }
+}
+
+#[async_trait]
+impl GitOperations for TestGitHubForUpsert {
+    async fn get_commits_between(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _base: &str,
+        _head: &str,
+        _options: GetCommitsOptions,
+    ) -> crate::CoreResult<Vec<GitCommit>> {
+        Ok(vec![])
+    }
+
+    async fn get_commit(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _sha: &str,
+    ) -> crate::CoreResult<GitCommit> {
+        Err(CoreError::not_found("stub"))
+    }
+
+    async fn list_tags(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _options: ListTagsOptions,
+    ) -> crate::CoreResult<Vec<GitTag>> {
+        Ok(vec![])
+    }
+
+    async fn get_tag(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _tag_name: &str,
+    ) -> crate::CoreResult<GitTag> {
+        Err(CoreError::not_found("stub"))
+    }
+
+    async fn tag_exists(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _tag_name: &str,
+    ) -> crate::CoreResult<bool> {
+        Ok(false)
+    }
+
+    async fn get_head_commit(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _branch: Option<&str>,
+    ) -> crate::CoreResult<GitCommit> {
+        Err(CoreError::not_found("stub"))
+    }
+
+    async fn get_repository_info(
+        &self,
+        _owner: &str,
+        _repo: &str,
+    ) -> crate::CoreResult<GitRepository> {
+        Err(CoreError::not_found("stub"))
+    }
+}
+
+#[async_trait]
+impl GitHubOperations for TestGitHubForUpsert {
+    async fn add_labels(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _issue_number: u64,
+        _labels: &[&str],
+    ) -> crate::CoreResult<()> {
+        Ok(())
+    }
+
+    async fn batch_commit_files(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _branch: &str,
+        _files: &[FileUpdate],
+        _message: &str,
+    ) -> crate::CoreResult<()> {
+        Ok(())
+    }
+
+    async fn create_branch(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _branch_name: &str,
+        _sha: &str,
+    ) -> crate::CoreResult<()> {
+        Ok(())
+    }
+
+    async fn create_issue_comment(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        issue_number: u64,
+        body: &str,
+    ) -> crate::CoreResult<()> {
+        self.state
+            .lock()
+            .await
+            .create_calls
+            .push((issue_number, body.to_string()));
+        Ok(())
+    }
+
+    async fn create_pull_request(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _params: CreatePullRequestParams,
+    ) -> crate::CoreResult<PullRequest> {
+        Err(CoreError::not_found("stub"))
+    }
+
+    async fn create_release(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _params: CreateReleaseParams,
+    ) -> crate::CoreResult<Release> {
+        Err(CoreError::not_found("stub"))
+    }
+
+    async fn create_tag(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _tag_name: &str,
+        _commit_sha: &str,
+        _message: Option<String>,
+        _tagger: Option<GitUser>,
+    ) -> crate::CoreResult<Tag> {
+        Err(CoreError::not_found("stub"))
+    }
+
+    async fn delete_branch(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _branch_name: &str,
+    ) -> crate::CoreResult<()> {
+        Ok(())
+    }
+
+    async fn force_update_branch(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _branch_name: &str,
+        _sha: &str,
+    ) -> crate::CoreResult<()> {
+        Ok(())
+    }
+
+    async fn get_collaborator_permission(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _username: &str,
+    ) -> crate::CoreResult<CollaboratorPermission> {
+        Ok(CollaboratorPermission::Write)
+    }
+
+    async fn get_file_content(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _path: &str,
+        _branch: &str,
+    ) -> crate::CoreResult<Option<String>> {
+        Ok(None)
+    }
+
+    async fn get_installation_id_for_repo(
+        &self,
+        _owner: &str,
+        _repo: &str,
+    ) -> crate::CoreResult<u64> {
+        Ok(0)
+    }
+
+    async fn get_latest_release(
+        &self,
+        _owner: &str,
+        _repo: &str,
+    ) -> crate::CoreResult<Option<Release>> {
+        Ok(None)
+    }
+
+    async fn get_pull_request(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _pr_number: u64,
+    ) -> crate::CoreResult<PullRequest> {
+        Err(CoreError::not_found("stub"))
+    }
+
+    async fn get_release_by_tag(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _tag: &str,
+    ) -> crate::CoreResult<Release> {
+        Err(CoreError::not_found("stub"))
+    }
+
+    async fn list_issue_comments(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _issue_number: u64,
+    ) -> crate::CoreResult<Vec<IssueComment>> {
+        if self.state.lock().await.list_error {
+            return Err(CoreError::network("simulated list_issue_comments failure"));
+        }
+        Ok(self.state.lock().await.comments.clone())
+    }
+
+    async fn list_pr_labels(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _issue_number: u64,
+    ) -> crate::CoreResult<Vec<Label>> {
+        Ok(vec![])
+    }
+
+    async fn list_pull_requests(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _state: Option<&str>,
+        _head: Option<&str>,
+        _base: Option<&str>,
+        _per_page: Option<u8>,
+        _page: Option<u32>,
+    ) -> crate::CoreResult<Vec<PullRequest>> {
+        Ok(vec![])
+    }
+
+    async fn list_releases(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _per_page: Option<u8>,
+        _page: Option<u32>,
+    ) -> crate::CoreResult<Vec<Release>> {
+        Ok(vec![])
+    }
+
+    async fn remove_label(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _issue_number: u64,
+        _label_name: &str,
+    ) -> crate::CoreResult<()> {
+        Ok(())
+    }
+
+    async fn search_pull_requests(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _query: &str,
+    ) -> crate::CoreResult<Vec<PullRequest>> {
+        Ok(vec![])
+    }
+
+    async fn update_issue_comment(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        comment_id: u64,
+        body: &str,
+    ) -> crate::CoreResult<()> {
+        if self.state.lock().await.update_error {
+            return Err(CoreError::network("simulated update_issue_comment failure"));
+        }
+        self.state
+            .lock()
+            .await
+            .update_calls
+            .push((comment_id, body.to_string()));
+        Ok(())
+    }
+
+    async fn update_pull_request(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _pr_number: u64,
+        _title: Option<String>,
+        _body: Option<String>,
+        _state: Option<String>,
+    ) -> crate::CoreResult<PullRequest> {
+        Err(CoreError::not_found("stub"))
+    }
+
+    async fn update_release(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _release_id: u64,
+        _params: UpdateReleaseParams,
+    ) -> crate::CoreResult<Release> {
+        Err(CoreError::not_found("stub"))
+    }
+
+    async fn upsert_file(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _path: &str,
+        _commit_message: &str,
+        _content: &str,
+        _branch: &str,
+    ) -> crate::CoreResult<()> {
+        Ok(())
+    }
+
+    fn scoped_to(&self, _installation_id: u64) -> Self {
+        Self {
+            state: Arc::clone(&self.state),
+        }
+    }
+}
+
+// ── upsert_pr_status_comment tests ──────────────────────────────────────────
+
+#[tokio::test]
+async fn test_upsert_pr_status_comment_no_prior_comment_calls_create() {
+    let github = TestGitHubForUpsert::new(vec![]);
+    let body = format!("{PR_STATUS_MARKER}\nfresh status");
+
+    upsert_pr_status_comment(&github, "owner", "repo", 7, &body)
+        .await
+        .expect("upsert should succeed");
+
+    let creates = github.create_calls().await;
+    let updates = github.update_calls().await;
+
+    assert_eq!(
+        creates.len(),
+        1,
+        "expected exactly one create_issue_comment call"
+    );
+    assert_eq!(creates[0].0, 7, "create called with wrong issue number");
+    assert_eq!(creates[0].1, body, "create called with wrong body");
+    assert!(
+        updates.is_empty(),
+        "update_issue_comment must not be called when no prior comment exists"
+    );
+}
+
+#[tokio::test]
+async fn test_upsert_pr_status_comment_prior_marker_present_calls_update() {
+    let existing = IssueComment {
+        id: 999,
+        body: format!("{PR_STATUS_MARKER}\nold status"),
+        user_login: Some("release-regent[bot]".into()),
+    };
+    let github = TestGitHubForUpsert::new(vec![existing]);
+    let new_body = format!("{PR_STATUS_MARKER}\nnew status");
+
+    upsert_pr_status_comment(&github, "owner", "repo", 7, &new_body)
+        .await
+        .expect("upsert should succeed");
+
+    let creates = github.create_calls().await;
+    let updates = github.update_calls().await;
+
+    assert!(
+        creates.is_empty(),
+        "create_issue_comment must not be called when a marker comment already exists"
+    );
+    assert_eq!(
+        updates.len(),
+        1,
+        "expected exactly one update_issue_comment call"
+    );
+    assert_eq!(updates[0].0, 999, "update called with wrong comment id");
+    assert_eq!(updates[0].1, new_body, "update called with wrong body");
+}
+
+#[tokio::test]
+async fn test_upsert_pr_status_comment_prior_comment_without_marker_calls_create() {
+    let unrelated = IssueComment {
+        id: 777,
+        body: "This is a regular review comment with no marker".into(),
+        user_login: Some("reviewer".into()),
+    };
+    let github = TestGitHubForUpsert::new(vec![unrelated]);
+    let body = format!("{PR_STATUS_MARKER}\nnew status");
+
+    upsert_pr_status_comment(&github, "owner", "repo", 42, &body)
+        .await
+        .expect("upsert should succeed");
+
+    let creates = github.create_calls().await;
+    let updates = github.update_calls().await;
+
+    assert_eq!(
+        creates.len(),
+        1,
+        "should create when no marker present in existing comments"
+    );
+    assert!(updates.is_empty(), "should not update when no marker found");
+}
+
+#[tokio::test]
+async fn test_upsert_pr_status_comment_list_error_propagates() {
+    let github = TestGitHubForUpsert::with_list_error();
+    let body = format!("{PR_STATUS_MARKER}\nsome body");
+
+    let result = upsert_pr_status_comment(&github, "owner", "repo", 1, &body).await;
+
+    assert!(result.is_err(), "list error must propagate");
+    assert!(github.create_calls().await.is_empty());
+    assert!(github.update_calls().await.is_empty());
+}
+
+#[tokio::test]
+async fn test_upsert_pr_status_comment_update_error_propagates() {
+    let github = TestGitHubForUpsert::with_update_error(555);
+    let body = format!("{PR_STATUS_MARKER}\nnew body");
+
+    let result = upsert_pr_status_comment(&github, "owner", "repo", 1, &body).await;
+
+    assert!(result.is_err(), "update error must propagate");
+    assert!(github.create_calls().await.is_empty());
+}
+
+// ── render_feature_pr_comment tests ─────────────────────────────────────────
+
+fn v100() -> SemanticVersion {
+    SemanticVersion {
+        major: 1,
+        minor: 0,
+        patch: 0,
+        prerelease: None,
+        build: None,
+    }
+}
+
+fn v110() -> SemanticVersion {
+    SemanticVersion {
+        major: 1,
+        minor: 1,
+        patch: 0,
+        prerelease: None,
+        build: None,
+    }
+}
+
+#[test]
+fn test_render_feature_pr_comment_starts_with_html_marker() {
+    let body = render_feature_pr_comment(&v110(), &v100(), true);
+    assert!(
+        body.starts_with(PR_STATUS_MARKER),
+        "feature PR comment must start with the HTML marker; got: {body}"
+    );
+}
+
+#[test]
+fn test_render_feature_pr_comment_includes_projected_version() {
+    let body = render_feature_pr_comment(&v110(), &v100(), false);
+    assert!(
+        body.contains("v1.1.0"),
+        "feature PR comment must include projected version; got: {body}"
+    );
+}
+
+#[test]
+fn test_render_feature_pr_comment_includes_base_version_in_subtitle() {
+    let body = render_feature_pr_comment(&v110(), &v100(), false);
+    assert!(
+        body.contains("v1.0.0"),
+        "feature PR comment must include base version in subtitle; got: {body}"
+    );
+}
+
+#[test]
+fn test_render_feature_pr_comment_includes_commands_table_when_allow_override_true() {
+    let body = render_feature_pr_comment(&v110(), &v100(), true);
+    assert!(
+        body.contains("### Available commands"),
+        "commands section must be present when allow_override=true; got: {body}"
+    );
+    assert!(body.contains("!release major"));
+    assert!(body.contains("!release minor"));
+    assert!(body.contains("!release patch"));
+    assert!(body.contains("!set-version X.Y.Z"));
+}
+
+#[test]
+fn test_render_feature_pr_comment_omits_commands_table_when_allow_override_false() {
+    let body = render_feature_pr_comment(&v110(), &v100(), false);
+    assert!(
+        !body.contains("### Available commands"),
+        "commands section must be absent when allow_override=false; got: {body}"
+    );
+}
+
+// ── render_release_pr_comment tests ─────────────────────────────────────────
+
+fn v200() -> SemanticVersion {
+    SemanticVersion {
+        major: 2,
+        minor: 0,
+        patch: 0,
+        prerelease: None,
+        build: None,
+    }
+}
+
+#[test]
+fn test_render_release_pr_comment_starts_with_html_marker() {
+    let body = render_release_pr_comment(&v200(), true);
+    assert!(
+        body.starts_with(PR_STATUS_MARKER),
+        "release PR comment must start with the HTML marker; got: {body}"
+    );
+}
+
+#[test]
+fn test_render_release_pr_comment_includes_release_version() {
+    let body = render_release_pr_comment(&v200(), false);
+    assert!(
+        body.contains("v2.0.0"),
+        "release PR comment must include the release version; got: {body}"
+    );
+}
+
+#[test]
+fn test_render_release_pr_comment_includes_commands_when_allow_override_true() {
+    let body = render_release_pr_comment(&v200(), true);
+    assert!(
+        body.contains("### Available commands"),
+        "commands section must be present when allow_override=true; got: {body}"
+    );
+    assert!(body.contains("!set-version X.Y.Z"));
+}
+
+#[test]
+fn test_render_release_pr_comment_omits_commands_when_allow_override_false() {
+    let body = render_release_pr_comment(&v200(), false);
+    assert!(
+        !body.contains("### Available commands"),
+        "commands section must be absent when allow_override=false; got: {body}"
+    );
+}

--- a/crates/core/src/release_automator_tests.rs
+++ b/crates/core/src/release_automator_tests.rs
@@ -470,6 +470,25 @@ impl GitHubOperations for TestGitHub {
         Ok(())
     }
 
+    async fn list_issue_comments(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _issue_number: u64,
+    ) -> CoreResult<Vec<crate::traits::github_operations::IssueComment>> {
+        Ok(vec![])
+    }
+
+    async fn update_issue_comment(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _comment_id: u64,
+        _body: &str,
+    ) -> CoreResult<()> {
+        Ok(())
+    }
+
     fn scoped_to(&self, _installation_id: u64) -> Self {
         Self {
             state: Arc::clone(&self.state),

--- a/crates/core/src/release_orchestrator_tests.rs
+++ b/crates/core/src/release_orchestrator_tests.rs
@@ -498,6 +498,25 @@ impl GitHubOperations for TestGitHub {
         Ok(())
     }
 
+    async fn list_issue_comments(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _issue_number: u64,
+    ) -> CoreResult<Vec<crate::traits::github_operations::IssueComment>> {
+        Ok(vec![])
+    }
+
+    async fn update_issue_comment(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _comment_id: u64,
+        _body: &str,
+    ) -> CoreResult<()> {
+        Ok(())
+    }
+
     fn scoped_to(&self, _installation_id: u64) -> Self {
         Self {
             state: Arc::clone(&self.state),

--- a/crates/core/src/traits/event_source.rs
+++ b/crates/core/src/traits/event_source.rs
@@ -87,6 +87,8 @@ pub enum EventSourceKind {
 /// - [`EventType::PullRequestMerged`]        → Release Orchestrator
 /// - [`EventType::ReleasePrMerged`]          → Release Automator
 /// - [`EventType::PullRequestCommentReceived`] → Comment command processor
+/// - [`EventType::PullRequestOpened`]        → PR status comment (feature/release preview)
+/// - [`EventType::PullRequestUpdated`]       → PR status comment refresh
 /// - [`EventType::Unknown`]                  → logged and dropped
 ///
 /// # Parsing from strings
@@ -138,6 +140,18 @@ pub enum EventType {
     /// Comments that do not match any known command are silently ignored.
     PullRequestCommentReceived,
 
+    /// A pull request was opened (action `opened`).
+    ///
+    /// Triggers the PR status comment handler to post a projected-version
+    /// preview comment on the PR.
+    PullRequestOpened,
+
+    /// A pull request was updated (action `edited` or `synchronize`).
+    ///
+    /// Triggers the PR status comment handler to refresh the projected-version
+    /// preview comment on the PR.
+    PullRequestUpdated,
+
     /// A GitHub event that this version of Release Regent does not recognise.
     ///
     /// The inner `String` preserves the raw event type for diagnostic logging.
@@ -163,6 +177,8 @@ impl From<&str> for EventType {
             "pull_request_merged" => Self::PullRequestMerged,
             "release_pr_merged" => Self::ReleasePrMerged,
             "pull_request_comment_received" => Self::PullRequestCommentReceived,
+            "pull_request_opened" => Self::PullRequestOpened,
+            "pull_request_updated" => Self::PullRequestUpdated,
             other => Self::Unknown(other.to_string()),
         }
     }
@@ -193,6 +209,8 @@ impl std::fmt::Display for EventType {
             Self::PullRequestMerged => write!(f, "pull_request_merged"),
             Self::ReleasePrMerged => write!(f, "release_pr_merged"),
             Self::PullRequestCommentReceived => write!(f, "pull_request_comment_received"),
+            Self::PullRequestOpened => write!(f, "pull_request_opened"),
+            Self::PullRequestUpdated => write!(f, "pull_request_updated"),
             Self::Unknown(s) => write!(f, "{s}"),
         }
     }

--- a/crates/core/src/traits/github_operations.rs
+++ b/crates/core/src/traits/github_operations.rs
@@ -352,6 +352,35 @@ pub trait GitHubOperations: GitOperations + Send + Sync {
         issue_number: u64,
     ) -> CoreResult<Vec<Label>>;
 
+    /// List all comments on an issue or pull request.
+    ///
+    /// Returns comments in creation order (oldest first).
+    ///
+    /// # Parameters
+    /// - `owner`: Repository owner name
+    /// - `repo`: Repository name
+    /// - `issue_number`: Issue or pull request number
+    ///
+    /// # Returns
+    /// All comments on the issue/PR in creation order.
+    ///
+    /// # Errors
+    /// - `CoreError::NotFound` — the issue/PR does not exist
+    /// - `CoreError::GitHub` — the API call failed for any other reason
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// let comments = github.list_issue_comments("owner", "repo", 42).await?;
+    /// let has_status = comments.iter().any(|c| c.body.contains("<!-- release-regent:pr-status -->"));
+    /// ```
+    async fn list_issue_comments(
+        &self,
+        owner: &str,
+        repo: &str,
+        issue_number: u64,
+    ) -> CoreResult<Vec<IssueComment>>;
+
     /// List pull requests in a repository
     ///
     /// Returns pull requests matching the specified filters.
@@ -501,6 +530,28 @@ pub trait GitHubOperations: GitOperations + Send + Sync {
         body: Option<String>,
         state: Option<String>,
     ) -> CoreResult<PullRequest>;
+
+    /// Update the body of an existing issue or pull request comment.
+    ///
+    /// # Parameters
+    /// - `owner`: Repository owner name
+    /// - `repo`: Repository name
+    /// - `comment_id`: Comment ID (as returned by [`list_issue_comments`])
+    /// - `body`: New comment body (Markdown)
+    ///
+    /// # Returns
+    /// `Ok(())` on success
+    ///
+    /// # Errors
+    /// - `CoreError::NotFound` — the comment does not exist
+    /// - `CoreError::GitHub` — the API call failed for any other reason
+    async fn update_issue_comment(
+        &self,
+        owner: &str,
+        repo: &str,
+        comment_id: u64,
+        body: &str,
+    ) -> CoreResult<()>;
 
     /// Update an existing release
     ///
@@ -719,6 +770,20 @@ pub struct GitUser {
     pub login: Option<String>,
     /// User name
     pub name: String,
+}
+
+/// A comment on a GitHub issue or pull request.
+///
+/// Returned by [`GitHubOperations::list_issue_comments`] for scanning for the
+/// Release Regent status marker before deciding whether to create or update.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IssueComment {
+    /// Comment body (Markdown).
+    pub body: String,
+    /// Comment ID as assigned by GitHub.
+    pub id: u64,
+    /// GitHub login of the comment author, if available.
+    pub user_login: Option<String>,
 }
 
 /// A GitHub label applied to an issue or pull request.

--- a/crates/core/src/versioning_tests.rs
+++ b/crates/core/src/versioning_tests.rs
@@ -1354,6 +1354,23 @@ mod cross_calculator_consistency {
         ) -> crate::CoreResult<()> {
             Ok(())
         }
+        async fn list_issue_comments(
+            &self,
+            _: &str,
+            _: &str,
+            _: u64,
+        ) -> crate::CoreResult<Vec<crate::traits::github_operations::IssueComment>> {
+            Ok(vec![])
+        }
+        async fn update_issue_comment(
+            &self,
+            _: &str,
+            _: &str,
+            _: u64,
+            _: &str,
+        ) -> crate::CoreResult<()> {
+            Ok(())
+        }
         fn scoped_to(&self, _: u64) -> Self {
             Self
         }

--- a/crates/github_client/src/lib.rs
+++ b/crates/github_client/src/lib.rs
@@ -23,8 +23,8 @@ use release_regent_core::{
         },
         github_operations::{
             CollaboratorPermission, CreatePullRequestParams, CreateReleaseParams, FileUpdate,
-            GitHubOperations, GitUser as GitHubUser, Label, PullRequest, PullRequestBranch,
-            Release, Repository, Tag, UpdateReleaseParams,
+            GitHubOperations, GitUser as GitHubUser, IssueComment, Label, PullRequest,
+            PullRequestBranch, Release, Repository, Tag, UpdateReleaseParams,
         },
     },
     CoreError, CoreResult,
@@ -720,6 +720,36 @@ impl GitHubOperations for GitHubClient {
         Ok(all_prs)
     }
 
+    #[instrument(skip(self, body))]
+    async fn update_issue_comment(
+        &self,
+        owner: &str,
+        repo: &str,
+        comment_id: u64,
+        body: &str,
+    ) -> CoreResult<()> {
+        info!(owner, repo, comment_id, "Updating issue comment");
+
+        let installation = self.installation().await?;
+        let path = format!("/repos/{owner}/{repo}/issues/comments/{comment_id}");
+        let request = serde_json::json!({ "body": body });
+        let resp = installation
+            .patch(&path, &request)
+            .await
+            .map_err(map_sdk_error)?;
+
+        let status = resp.status().as_u16();
+        if status != 200 {
+            let resp_body = resp.text().await.unwrap_or_default();
+            return Err(CoreError::github(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                format!("PATCH /issues/comments failed with status {status}: {resp_body}"),
+            )));
+        }
+
+        Ok(())
+    }
+
     #[instrument(skip(self, params))]
     async fn update_release(
         &self,
@@ -960,6 +990,32 @@ impl GitHubOperations for GitHubClient {
             .collect();
 
         Ok(labels)
+    }
+
+    #[instrument(skip(self))]
+    async fn list_issue_comments(
+        &self,
+        owner: &str,
+        repo: &str,
+        issue_number: u64,
+    ) -> CoreResult<Vec<IssueComment>> {
+        info!(owner, repo, issue_number, "Listing issue comments");
+
+        let installation = self.installation().await?;
+        let path = format!("/repos/{owner}/{repo}/issues/{issue_number}/comments");
+        let response = installation.get(&path).await.map_err(map_sdk_error)?;
+        let raw: Vec<serde_json::Value> = response.json().await.map_err(CoreError::github)?;
+
+        let comments = raw
+            .into_iter()
+            .map(|v| IssueComment {
+                id: v["id"].as_u64().unwrap_or(0),
+                body: v["body"].as_str().unwrap_or("").to_string(),
+                user_login: v["user"]["login"].as_str().map(str::to_string),
+            })
+            .collect();
+
+        Ok(comments)
     }
 
     #[instrument(skip(self, content, commit_message))]

--- a/crates/server/src/handler.rs
+++ b/crates/server/src/handler.rs
@@ -210,7 +210,7 @@ fn classify_pull_request_event(
     if action == "opened" {
         return EventType::PullRequestOpened;
     }
-    if action == "edited" || action == "synchronize" {
+    if action == "edited" || action == "synchronize" || action == "ready_for_review" {
         return EventType::PullRequestUpdated;
     }
 

--- a/crates/server/src/handler.rs
+++ b/crates/server/src/handler.rs
@@ -206,6 +206,14 @@ fn classify_pull_request_event(
         .and_then(serde_json::Value::as_bool)
         .unwrap_or(false);
 
+    // Route opened/updated actions before checking for the closed+merged path.
+    if action == "opened" {
+        return EventType::PullRequestOpened;
+    }
+    if action == "edited" || action == "synchronize" {
+        return EventType::PullRequestUpdated;
+    }
+
     if !(action == "closed" && is_merged) {
         return EventType::Unknown(format!("pull_request:{action}"));
     }

--- a/crates/server/src/handler_tests.rs
+++ b/crates/server/src/handler_tests.rs
@@ -252,6 +252,16 @@ fn test_classify_event_pull_request_synchronize_returns_pull_request_updated() {
 }
 
 #[test]
+fn test_classify_event_pull_request_ready_for_review_returns_pull_request_updated() {
+    let payload = json!({
+        "action": "ready_for_review",
+        "pull_request": { "merged": false, "head": { "ref": "feature/x" } }
+    });
+    let result = classify_event("pull_request", &payload, "release");
+    assert_eq!(result, EventType::PullRequestUpdated);
+}
+
+#[test]
 fn test_classify_event_pull_request_edited_returns_pull_request_updated() {
     let payload = json!({
         "action": "edited",

--- a/crates/server/src/handler_tests.rs
+++ b/crates/server/src/handler_tests.rs
@@ -228,16 +228,37 @@ fn test_classify_event_pull_request_not_merged_returns_unknown_with_action() {
 }
 
 #[test]
-fn test_classify_event_pull_request_opened_returns_unknown_with_action() {
+fn test_classify_event_pull_request_opened_returns_pull_request_opened() {
     let payload = json!({
         "action": "opened",
         "pull_request": { "merged": false, "head": { "ref": "feature/x" } }
     });
     let result = classify_event("pull_request", &payload, "release");
-    assert!(
-        matches!(result, EventType::Unknown(ref s) if s == "pull_request:opened"),
-        "opened PR must return Unknown with action suffix"
+    assert_eq!(
+        result,
+        EventType::PullRequestOpened,
+        "opened PR must map to PullRequestOpened"
     );
+}
+
+#[test]
+fn test_classify_event_pull_request_synchronize_returns_pull_request_updated() {
+    let payload = json!({
+        "action": "synchronize",
+        "pull_request": { "merged": false, "head": { "ref": "feature/x" } }
+    });
+    let result = classify_event("pull_request", &payload, "release");
+    assert_eq!(result, EventType::PullRequestUpdated);
+}
+
+#[test]
+fn test_classify_event_pull_request_edited_returns_pull_request_updated() {
+    let payload = json!({
+        "action": "edited",
+        "pull_request": { "merged": false, "head": { "ref": "feature/x" } }
+    });
+    let result = classify_event("pull_request", &payload, "release");
+    assert_eq!(result, EventType::PullRequestUpdated);
 }
 
 #[test]

--- a/crates/testing/src/builders/configuration_builder.rs
+++ b/crates/testing/src/builders/configuration_builder.rs
@@ -116,6 +116,7 @@ fn create_default_config() -> ReleaseRegentConfig {
             strategy: VersioningStrategy::Conventional,
             external: None,
             allow_override: false,
+            excluded_pr_authors: Vec::new(),
         },
     }
 }

--- a/crates/testing/src/mocks/github_operations.rs
+++ b/crates/testing/src/mocks/github_operations.rs
@@ -11,8 +11,8 @@ use release_regent_core::{
             GetCommitsOptions, GitCommit, GitRepository, GitTag, GitTagType, ListTagsOptions,
         },
         github_operations::{
-            CollaboratorPermission, CreatePullRequestParams, CreateReleaseParams, Label,
-            PullRequest, PullRequestBranch, Release, Repository, Tag, UpdateReleaseParams,
+            CollaboratorPermission, CreatePullRequestParams, CreateReleaseParams, IssueComment,
+            Label, PullRequest, PullRequestBranch, Release, Repository, Tag, UpdateReleaseParams,
         },
     },
     CoreError, CoreResult, GitHubOperations, GitOperations,
@@ -97,6 +97,14 @@ pub struct MockGitHubOperations {
     get_file_content_responses: GetFileContentResponses,
     /// Recorded `batch_commit_files` calls: (owner, repo, branch, file_paths, message).
     batch_commit_files_calls: BatchCommitFilesCalls,
+    /// Issue comments keyed `"owner/repo/issue_number"`. Used by
+    /// `list_issue_comments` (returns the vec) and `update_issue_comment`
+    /// (replaces the body of the matching comment by id).
+    issue_comments: Arc<RwLock<HashMap<String, Vec<IssueComment>>>>,
+    /// Recorded `list_issue_comments` calls: (owner, repo, issue_number).
+    list_issue_comments_calls: Arc<RwLock<Vec<(String, String, u64)>>>,
+    /// Recorded `update_issue_comment` calls: (owner, repo, comment_id, body).
+    update_issue_comment_calls: Arc<RwLock<Vec<(String, String, u64, String)>>>,
 }
 
 impl MockGitHubOperations {
@@ -150,6 +158,9 @@ impl MockGitHubOperations {
             get_file_content_calls: Arc::new(RwLock::new(Vec::new())),
             get_file_content_responses: Arc::new(RwLock::new(HashMap::new())),
             batch_commit_files_calls: Arc::new(RwLock::new(Vec::new())),
+            issue_comments: Arc::new(RwLock::new(HashMap::new())),
+            list_issue_comments_calls: Arc::new(RwLock::new(Vec::new())),
+            update_issue_comment_calls: Arc::new(RwLock::new(Vec::new())),
         }
     }
 
@@ -256,6 +267,9 @@ impl MockGitHubOperations {
             get_file_content_calls: Arc::new(RwLock::new(Vec::new())),
             get_file_content_responses: Arc::new(RwLock::new(HashMap::new())),
             batch_commit_files_calls: Arc::new(RwLock::new(Vec::new())),
+            issue_comments: Arc::new(RwLock::new(HashMap::new())),
+            list_issue_comments_calls: Arc::new(RwLock::new(Vec::new())),
+            update_issue_comment_calls: Arc::new(RwLock::new(Vec::new())),
         }
     }
 
@@ -433,6 +447,37 @@ impl MockGitHubOperations {
         self.method_errors
             .insert(method_name.to_string(), error_message.to_string());
         self
+    }
+
+    /// Pre-populate the mock with comments for a specific issue/PR.
+    ///
+    /// These comments are returned by `list_issue_comments`.
+    /// The key is formatted as `"{owner}/{repo}/{issue_number}"`.
+    #[must_use]
+    pub fn with_issue_comments(
+        self,
+        owner: &str,
+        repo: &str,
+        issue_number: u64,
+        comments: Vec<IssueComment>,
+    ) -> Self {
+        let key = format!("{owner}/{repo}/{issue_number}");
+        self.issue_comments.blocking_write().insert(key, comments);
+        self
+    }
+
+    /// Return all recorded `list_issue_comments` calls.
+    ///
+    /// Each element is `(owner, repo, issue_number)`.
+    pub async fn list_issue_comments_calls(&self) -> Vec<(String, String, u64)> {
+        self.list_issue_comments_calls.read().await.clone()
+    }
+
+    /// Return all recorded `update_issue_comment` calls.
+    ///
+    /// Each element is `(owner, repo, comment_id, body)`.
+    pub async fn update_issue_comment_calls(&self) -> Vec<(String, String, u64, String)> {
+        self.update_issue_comment_calls.read().await.clone()
     }
 }
 
@@ -1293,6 +1338,92 @@ impl GitHubOperations for MockGitHubOperations {
         Ok(labels)
     }
 
+    async fn list_issue_comments(
+        &self,
+        owner: &str,
+        repo: &str,
+        issue_number: u64,
+    ) -> CoreResult<Vec<IssueComment>> {
+        let method = "list_issue_comments";
+        let params_str = format!("owner={owner}, repo={repo}, issue={issue_number}");
+
+        self.check_quota().await?;
+        self.simulate_latency().await;
+
+        if self.should_simulate_failure().await {
+            let error = CoreError::network("Simulated GitHub API error");
+            self.record_call(method, &params_str, CallResult::Error(error.to_string()))
+                .await;
+            return Err(error);
+        }
+
+        if let Some(msg) = self.method_errors.get(method) {
+            let error = CoreError::network(msg.clone());
+            self.record_call(method, &params_str, CallResult::Error(error.to_string()))
+                .await;
+            return Err(error);
+        }
+
+        let key = format!("{owner}/{repo}/{issue_number}");
+        let comments = self
+            .issue_comments
+            .read()
+            .await
+            .get(&key)
+            .cloned()
+            .unwrap_or_default();
+
+        self.list_issue_comments_calls.write().await.push((
+            owner.to_string(),
+            repo.to_string(),
+            issue_number,
+        ));
+        self.record_call(method, &params_str, CallResult::Success)
+            .await;
+        Ok(comments)
+    }
+
+    async fn update_issue_comment(
+        &self,
+        owner: &str,
+        repo: &str,
+        comment_id: u64,
+        body: &str,
+    ) -> CoreResult<()> {
+        let method = "update_issue_comment";
+        let params_str = format!(
+            "owner={owner}, repo={repo}, comment_id={comment_id}, body_len={}",
+            body.len()
+        );
+
+        self.check_quota().await?;
+        self.simulate_latency().await;
+
+        if self.should_simulate_failure().await {
+            let error = CoreError::network("Simulated GitHub API error");
+            self.record_call(method, &params_str, CallResult::Error(error.to_string()))
+                .await;
+            return Err(error);
+        }
+
+        if let Some(msg) = self.method_errors.get(method) {
+            let error = CoreError::network(msg.clone());
+            self.record_call(method, &params_str, CallResult::Error(error.to_string()))
+                .await;
+            return Err(error);
+        }
+
+        self.update_issue_comment_calls.write().await.push((
+            owner.to_string(),
+            repo.to_string(),
+            comment_id,
+            body.to_string(),
+        ));
+        self.record_call(method, &params_str, CallResult::Success)
+            .await;
+        Ok(())
+    }
+
     async fn get_installation_id_for_repo(&self, _owner: &str, _repo: &str) -> CoreResult<u64> {
         Ok(0)
     }
@@ -1317,6 +1448,9 @@ impl GitHubOperations for MockGitHubOperations {
             get_file_content_calls: Arc::clone(&self.get_file_content_calls),
             get_file_content_responses: Arc::clone(&self.get_file_content_responses),
             batch_commit_files_calls: Arc::clone(&self.batch_commit_files_calls),
+            issue_comments: Arc::clone(&self.issue_comments),
+            list_issue_comments_calls: Arc::clone(&self.list_issue_comments_calls),
+            update_issue_comment_calls: Arc::clone(&self.update_issue_comment_calls),
         }
     }
 


### PR DESCRIPTION
Adds automated status comments to open pull requests showing the projected
next release version. Comments are created on PR open, updated on each push
or draft-to-ready transition, and batch-refreshed when any PR merges.

## What Changed

- **New `GitHubOperations` methods:** `list_issue_comments` and
  `update_issue_comment`, implemented in `github_client` and
  `MockGitHubOperations`.
- **New `IssueComment` type** in the `github_operations` trait module.
- **New `pr_status_commenter` module** with `upsert_pr_status_comment`,
  `render_feature_pr_comment`, and `render_release_pr_comment`.
- **New `EventType` variants:** `PullRequestOpened` and `PullRequestUpdated`;
  `classify_pull_request_event` now returns these early before the
  closed+merged check. `ready_for_review` (draft → ready) is classified as
  `PullRequestUpdated`.
- **New `handle_pull_request_activity` trait method** on
  `MergedPullRequestHandler` with a default no-op, dispatched from
  `run_event_loop`.
- **`handle_pull_request_activity` implementation** on
  `ReleaseRegentProcessor`:
  - Feature branches: project next version via `VersionCalculator`, detect
    no-bump commits (`docs:`, `chore:`, etc.) and render "no version change"
    instead of echoing the current version.
  - Release branches: extract version from branch name, render release PR
    comment.
  - Detects an open `release/vN.N.N` PR and annotates feature PR comments
    with a note when a higher release is already queued.
  - Skips PRs authored by logins in `excluded_pr_authors`
    (new `VersioningConfig` field, default `[]`).
- **Batch refresh** of open feature PR comments triggered after every
  successful feature or release PR merge (max 25 PRs, marker-comment-only,
  best-effort).

## Why

Contributors had no visibility into what version their PR would produce, or
whether a release was already queued that would delay their changes. Release
PRs similarly had no self-describing comment. These comments close that gap
without requiring any manual steps from contributors.

## How

`upsert_pr_status_comment` embeds an HTML marker
(`<!-- release-regent:pr-status -->`) in every comment it writes. On
subsequent calls it scans `list_issue_comments` for the marker and calls
`update_issue_comment` rather than creating a duplicate. The no-op default on
`MergedPullRequestHandler` keeps all existing trait implementors (test doubles)
backwards-compatible.

## Testing Evidence

- **Test Coverage:** 7 end-to-end scenarios in `lib_tests.rs` covering comment
  creation, in-place update, batch refresh, release-branch path,
  `allow_override: false`, excluded-author skip, and batch-refresh author
  filtering. 22 new unit tests in `pr_status_commenter_tests.rs` covering
  render functions including no-bump and queued-release cases. 3 new handler
  tests for `PullRequestOpened`, `PullRequestSynchronize`, and
  `ready_for_review` classification.
- **Test Results:** 349 core tests, 54 server tests — all passing, 0 failed.
- **Manual Testing:** Verified against `glitchgrove/rr-test`: merged feature
  PR created a `release/v0.1.1` branch and PR with correct release comment;
  `docs:` PR correctly showed "no version change"; draft-to-ready transition
  now triggers a comment after fixing dropped `ready_for_review` event.

## Reviewer Guidance

- `handle_pull_request_activity` searches for open release PRs on every PR
  open/update event (one extra `search_pull_requests` call per webhook). This
  is intentional — acceptable at current scale; worth noting if rate limit
  budgets become a concern.
- The batch refresh cap of 25 PRs is intentional to limit API usage per
  triggering merge; revisit if repositories routinely carry more than 25 open
  feature PRs.
- `excluded_pr_authors` is a plain string list with exact-match semantics.
  Confirm this is sufficient for bot account filtering (GitHub bot logins
  follow the `name[bot]` pattern).
- No breaking changes to existing trait implementations; `handle_pull_request_activity` has a default no-op.