### PR TITLE
feat(manifest): add Cargo workspace version detection

### DIFF
--- a/crates/core/src/manifest.rs
+++ b/crates/core/src/manifest.rs
@@ -210,8 +210,7 @@ pub fn detect_standard_manifests(existing_paths: &[&str]) -> Vec<ManifestFileCon
     // update will fail with a clear error that the orchestrator logs and skips;
     // the workspace root entry above is the single source of truth for those crates.
     for &path in existing_paths {
-        if path != "Cargo.toml"
-            && (path.ends_with("/Cargo.toml") || path.ends_with("\\Cargo.toml"))
+        if path != "Cargo.toml" && (path.ends_with("/Cargo.toml") || path.ends_with("\\Cargo.toml"))
         {
             result.push(ManifestFileConfig {
                 path: path.to_string(),
@@ -322,7 +321,9 @@ fn update_toml(content: &str, key: &str, version: &str) -> CoreResult<String> {
     })?;
 
     if !item.is_str() {
-        // Detect Cargo workspace version inheritance: `version.workspace = true`.
+        // Detect Cargo workspace version inheritance in two syntactic forms:
+        // - dotted-key:   `version.workspace = true`           (Item::Table)
+        // - inline-table: `version = { workspace = true }`     (Item::Value::InlineTable)
         // When present, the version is controlled by `workspace.package.version`
         // in the root Cargo.toml, so updating this field individually is wrong.
         let is_workspace_inherited = item
@@ -330,13 +331,20 @@ fn update_toml(content: &str, key: &str, version: &str) -> CoreResult<String> {
             .and_then(|t| t.get("workspace"))
             .and_then(|v| v.as_value())
             .and_then(|v| v.as_bool())
-            .unwrap_or(false);
+            .unwrap_or(false)
+            || item
+                .as_value()
+                .and_then(|v| v.as_inline_table())
+                .and_then(|t| t.get("workspace"))
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
         if is_workspace_inherited {
             return Err(CoreError::invalid_input(
                 "manifest",
                 format!(
                     "TOML key '{key}' uses workspace inheritance \
-                     (version.workspace = true); update \
+                     (`version.workspace = true` or \
+                     `version = {{ workspace = true }}`); update \
                      workspace.package.version in the root Cargo.toml instead"
                 ),
             ));

--- a/crates/core/src/manifest.rs
+++ b/crates/core/src/manifest.rs
@@ -25,9 +25,11 @@
 //! | PHP / Composer | `composer.json`           | JSON        | `version`                        |
 //!
 //! For the root `Cargo.toml`, **two** entries are returned — one for the
-//! workspace key (`workspace.package.version`) and one for the plain-package
-//! key (`package.version`).  The orchestrator tries both; the one whose key
-//! is absent fails with [`CoreError::InvalidInput`] and is skipped.
+//! plain-package key (`package.version`) and one for the workspace key
+//! (`workspace.package.version`).  The workspace key is emitted **last** so
+//! that `dedup_file_updates_by_path` keeps it when both keys resolve to the
+//! same path (mixed workspace + package root).  The key that is absent in the
+//! actual file fails with [`CoreError::InvalidInput`] and is skipped.
 //!
 //! When a member-crate `Cargo.toml` uses `version.workspace = true` (inheriting
 //! the version from the workspace root), `update_manifest_content` returns
@@ -191,16 +193,20 @@ pub fn detect_standard_manifests(existing_paths: &[&str]) -> Vec<ManifestFileCon
     // Rust — root Cargo.toml.  Both a workspace root (`workspace.package.version`)
     // and a plain package (`package.version`) are tried; the one whose key is
     // absent produces a `CoreError::InvalidInput` that the orchestrator skips.
+    //
+    // ORDER MATTERS: `dedup_file_updates_by_path` keeps the **last** entry for
+    // each path, so `workspace.package.version` is emitted second so that it
+    // takes precedence over `package.version` for mixed workspace+package roots.
     if path_set.contains("Cargo.toml") {
         result.push(ManifestFileConfig {
             path: "Cargo.toml".to_string(),
             format: ManifestFormat::Toml,
-            version_key: "workspace.package.version".to_string(),
+            version_key: "package.version".to_string(),
         });
         result.push(ManifestFileConfig {
             path: "Cargo.toml".to_string(),
             format: ManifestFormat::Toml,
-            version_key: "package.version".to_string(),
+            version_key: "workspace.package.version".to_string(),
         });
     }
 

--- a/crates/core/src/manifest.rs
+++ b/crates/core/src/manifest.rs
@@ -14,13 +14,26 @@
 //!
 //! Auto-detection recognises the following files out of the box:
 //!
-//! | Language       | File              | Format      | Key                     |
-//! |----------------|-------------------|-------------|-------------------------|
-//! | Rust           | `Cargo.toml`      | TOML        | `package.version`       |
-//! | Node.js / npm  | `package.json`    | JSON        | `version`               |
-//! | Python PEP 517 | `pyproject.toml`  | TOML        | `project.version`       |
-//! | Python / Poetry| `pyproject.toml`  | TOML        | `tool.poetry.version`   |
-//! | PHP / Composer | `composer.json`   | JSON        | `version`               |
+//! | Language       | File                      | Format      | Key                              |
+//! |----------------|---------------------------|-------------|----------------------------------|
+//! | Rust workspace | `Cargo.toml` (root)       | TOML        | `workspace.package.version`      |
+//! | Rust package   | `Cargo.toml` (root)       | TOML        | `package.version`                |
+//! | Rust member    | `<member>/Cargo.toml`     | TOML        | `package.version`                |
+//! | Node.js / npm  | `package.json`            | JSON        | `version`                        |
+//! | Python PEP 517 | `pyproject.toml`          | TOML        | `project.version`                |
+//! | Python / Poetry| `pyproject.toml`          | TOML        | `tool.poetry.version`            |
+//! | PHP / Composer | `composer.json`           | JSON        | `version`                        |
+//!
+//! For the root `Cargo.toml`, **two** entries are returned — one for the
+//! workspace key (`workspace.package.version`) and one for the plain-package
+//! key (`package.version`).  The orchestrator tries both; the one whose key
+//! is absent fails with [`CoreError::InvalidInput`] and is skipped.
+//!
+//! When a member-crate `Cargo.toml` uses `version.workspace = true` (inheriting
+//! the version from the workspace root), `update_manifest_content` returns
+//! [`CoreError::InvalidInput`] with a message that explains the situation.
+//! The version for that crate is already set by updating `workspace.package.version`
+//! in the root `Cargo.toml`.
 //!
 //! The [`ManifestFormat::PlainText`] variant serves as an escape hatch for any
 //! other language (e.g. .NET `.csproj`, Ruby gemspec) via a user-supplied regex
@@ -175,13 +188,37 @@ pub fn detect_standard_manifests(existing_paths: &[&str]) -> Vec<ManifestFileCon
     let path_set: std::collections::HashSet<&str> = existing_paths.iter().copied().collect();
     let mut result = Vec::new();
 
-    // Rust
+    // Rust — root Cargo.toml.  Both a workspace root (`workspace.package.version`)
+    // and a plain package (`package.version`) are tried; the one whose key is
+    // absent produces a `CoreError::InvalidInput` that the orchestrator skips.
     if path_set.contains("Cargo.toml") {
+        result.push(ManifestFileConfig {
+            path: "Cargo.toml".to_string(),
+            format: ManifestFormat::Toml,
+            version_key: "workspace.package.version".to_string(),
+        });
         result.push(ManifestFileConfig {
             path: "Cargo.toml".to_string(),
             format: ManifestFormat::Toml,
             version_key: "package.version".to_string(),
         });
+    }
+
+    // Rust — workspace member crates.  Any path that ends with `/Cargo.toml`
+    // (or `\Cargo.toml` on Windows) and is not the repository root is treated
+    // as a member crate.  If the member uses `version.workspace = true` the
+    // update will fail with a clear error that the orchestrator logs and skips;
+    // the workspace root entry above is the single source of truth for those crates.
+    for &path in existing_paths {
+        if path != "Cargo.toml"
+            && (path.ends_with("/Cargo.toml") || path.ends_with("\\Cargo.toml"))
+        {
+            result.push(ManifestFileConfig {
+                path: path.to_string(),
+                format: ManifestFormat::Toml,
+                version_key: "package.version".to_string(),
+            });
+        }
     }
 
     // Node.js / npm
@@ -285,6 +322,25 @@ fn update_toml(content: &str, key: &str, version: &str) -> CoreResult<String> {
     })?;
 
     if !item.is_str() {
+        // Detect Cargo workspace version inheritance: `version.workspace = true`.
+        // When present, the version is controlled by `workspace.package.version`
+        // in the root Cargo.toml, so updating this field individually is wrong.
+        let is_workspace_inherited = item
+            .as_table()
+            .and_then(|t| t.get("workspace"))
+            .and_then(|v| v.as_value())
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        if is_workspace_inherited {
+            return Err(CoreError::invalid_input(
+                "manifest",
+                format!(
+                    "TOML key '{key}' uses workspace inheritance \
+                     (version.workspace = true); update \
+                     workspace.package.version in the root Cargo.toml instead"
+                ),
+            ));
+        }
         return Err(CoreError::invalid_input(
             "manifest",
             format!("TOML key '{key}' is not a string value"),

--- a/crates/core/src/manifest_tests.rs
+++ b/crates/core/src/manifest_tests.rs
@@ -192,14 +192,14 @@ fn detect_standard_manifests_cargo_toml_detected() {
         2,
         "root Cargo.toml should produce two entries (workspace + package)"
     );
-    // First entry: workspace root key
+    // First entry: plain-package key (emitted first so workspace key wins deduplication)
     assert_eq!(result[0].path, "Cargo.toml");
     assert_eq!(result[0].format, ManifestFormat::Toml);
-    assert_eq!(result[0].version_key, "workspace.package.version");
-    // Second entry: plain package key
+    assert_eq!(result[0].version_key, "package.version");
+    // Second entry: workspace root key (emitted last so it wins deduplication)
     assert_eq!(result[1].path, "Cargo.toml");
     assert_eq!(result[1].format, ManifestFormat::Toml);
-    assert_eq!(result[1].version_key, "package.version");
+    assert_eq!(result[1].version_key, "workspace.package.version");
 }
 
 #[test]
@@ -254,7 +254,9 @@ fn detect_standard_manifests_member_cargo_toml_detected() {
 }
 
 /// Verify that the root `Cargo.toml` (two entries) and each workspace member
-/// `Cargo.toml` (one entry each) are all detected correctly when passed together.
+/// `Cargo.toml` (one entry each) are all detected correctly when passed together,
+/// and that `workspace.package.version` is the second (last-emitted) root entry
+/// so that `dedup_file_updates_by_path` keeps it when both root keys collide.
 #[test]
 fn detect_standard_manifests_root_and_member_cargo_tomls() {
     let result = detect_standard_manifests(&[
@@ -330,6 +332,10 @@ fn update_manifest_content_toml_workspace_inherited_returns_error() {
     );
 }
 
+/// Verify that all well-known manifests present in the same repository are
+/// detected in one call: root `Cargo.toml` produces two entries (package key
+/// first, workspace key last), `package.json` and `composer.json` one each
+/// — four entries in total.
 #[test]
 fn detect_standard_manifests_multiple_files_all_detected() {
     let result = detect_standard_manifests(&["Cargo.toml", "package.json", "composer.json"]);

--- a/crates/core/src/manifest_tests.rs
+++ b/crates/core/src/manifest_tests.rs
@@ -242,6 +242,8 @@ fn detect_standard_manifests_unknown_file_not_detected() {
     assert!(result.is_empty(), "unrecognised files must not be detected");
 }
 
+/// Verify that a workspace member `Cargo.toml` (non-root path ending in
+/// `/Cargo.toml`) is detected with the `package.version` key.
 #[test]
 fn detect_standard_manifests_member_cargo_toml_detected() {
     let result = detect_standard_manifests(&["crates/my-crate/Cargo.toml"]);
@@ -251,6 +253,8 @@ fn detect_standard_manifests_member_cargo_toml_detected() {
     assert_eq!(result[0].version_key, "package.version");
 }
 
+/// Verify that the root `Cargo.toml` (two entries) and each workspace member
+/// `Cargo.toml` (one entry each) are all detected correctly when passed together.
 #[test]
 fn detect_standard_manifests_root_and_member_cargo_tomls() {
     let result = detect_standard_manifests(&[
@@ -281,6 +285,8 @@ fn detect_standard_manifests_root_and_member_cargo_tomls() {
 // update_manifest_content — TOML workspace support
 // ─────────────────────────────────────────────────────────────────────────────
 
+/// Verify that `workspace.package.version` (the workspace-level version key
+/// used by Cargo workspace roots) is updated correctly.
 #[test]
 fn update_manifest_content_toml_replaces_workspace_package_version() {
     let content = "[workspace.package]\nversion = \"0.1.0\"\n";
@@ -306,6 +312,8 @@ fn update_manifest_content_toml_replaces_workspace_package_version() {
     );
 }
 
+/// Verify that `version.workspace = true` (dotted-key form of workspace
+/// inheritance) returns a clear error rather than a generic "not a string" error.
 #[test]
 fn update_manifest_content_toml_workspace_inherited_returns_error() {
     let content = "[package]\nname = \"my-crate\"\nversion.workspace = true\n";
@@ -331,4 +339,26 @@ fn detect_standard_manifests_multiple_files_all_detected() {
     assert!(paths.contains(&"Cargo.toml"));
     assert!(paths.contains(&"package.json"));
     assert!(paths.contains(&"composer.json"));
+}
+
+/// Verify that `version = { workspace = true }` (inline-table form) is
+/// recognised as workspace inheritance and returns a clear error rather
+/// than the generic "not a string value" error.
+///
+/// Regression guard for the inline-table detection gap: `item.as_table()`
+/// returns `None` for inline tables, so this form was previously undetected.
+#[test]
+fn update_manifest_content_toml_workspace_inherited_inline_table_returns_error() {
+    let content = "[package]\nname = \"my-crate\"\nversion = { workspace = true }\n";
+    let result =
+        update_manifest_content(content, &ManifestFormat::Toml, "package.version", "1.0.0");
+    assert!(
+        result.is_err(),
+        "inline-table workspace-inherited version should return an error"
+    );
+    let msg = format!("{:?}", result.unwrap_err());
+    assert!(
+        msg.contains("workspace inheritance"),
+        "error message should mention workspace inheritance, got: {msg}"
+    );
 }

--- a/crates/core/src/manifest_tests.rs
+++ b/crates/core/src/manifest_tests.rs
@@ -187,10 +187,19 @@ fn detect_standard_manifests_empty_list_returns_empty() {
 #[test]
 fn detect_standard_manifests_cargo_toml_detected() {
     let result = detect_standard_manifests(&["Cargo.toml"]);
-    assert_eq!(result.len(), 1);
+    assert_eq!(
+        result.len(),
+        2,
+        "root Cargo.toml should produce two entries (workspace + package)"
+    );
+    // First entry: workspace root key
     assert_eq!(result[0].path, "Cargo.toml");
     assert_eq!(result[0].format, ManifestFormat::Toml);
-    assert_eq!(result[0].version_key, "package.version");
+    assert_eq!(result[0].version_key, "workspace.package.version");
+    // Second entry: plain package key
+    assert_eq!(result[1].path, "Cargo.toml");
+    assert_eq!(result[1].format, ManifestFormat::Toml);
+    assert_eq!(result[1].version_key, "package.version");
 }
 
 #[test]
@@ -234,10 +243,90 @@ fn detect_standard_manifests_unknown_file_not_detected() {
 }
 
 #[test]
+fn detect_standard_manifests_member_cargo_toml_detected() {
+    let result = detect_standard_manifests(&["crates/my-crate/Cargo.toml"]);
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0].path, "crates/my-crate/Cargo.toml");
+    assert_eq!(result[0].format, ManifestFormat::Toml);
+    assert_eq!(result[0].version_key, "package.version");
+}
+
+#[test]
+fn detect_standard_manifests_root_and_member_cargo_tomls() {
+    let result = detect_standard_manifests(&[
+        "Cargo.toml",
+        "crates/foo/Cargo.toml",
+        "crates/bar/Cargo.toml",
+    ]);
+    // root → 2, foo → 1, bar → 1 = 4 total
+    assert_eq!(result.len(), 4);
+    let root: Vec<&ManifestFileConfig> = result.iter().filter(|m| m.path == "Cargo.toml").collect();
+    assert_eq!(root.len(), 2);
+    let root_keys: Vec<&str> = root.iter().map(|m| m.version_key.as_str()).collect();
+    assert!(
+        root_keys.contains(&"workspace.package.version"),
+        "workspace key must be present for root"
+    );
+    assert!(
+        root_keys.contains(&"package.version"),
+        "package key must be present for root"
+    );
+    let members: Vec<&ManifestFileConfig> =
+        result.iter().filter(|m| m.path != "Cargo.toml").collect();
+    assert_eq!(members.len(), 2);
+    assert!(members.iter().all(|m| m.version_key == "package.version"));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// update_manifest_content — TOML workspace support
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn update_manifest_content_toml_replaces_workspace_package_version() {
+    let content = "[workspace.package]\nversion = \"0.1.0\"\n";
+    let result = update_manifest_content(
+        content,
+        &ManifestFormat::Toml,
+        "workspace.package.version",
+        "2.0.0",
+    );
+    assert!(
+        result.is_ok(),
+        "workspace.package.version update should succeed: {:?}",
+        result
+    );
+    let updated = result.unwrap();
+    assert!(
+        updated.contains("2.0.0"),
+        "updated content should contain the new version"
+    );
+    assert!(
+        !updated.contains("0.1.0"),
+        "updated content should not contain the old version"
+    );
+}
+
+#[test]
+fn update_manifest_content_toml_workspace_inherited_returns_error() {
+    let content = "[package]\nname = \"my-crate\"\nversion.workspace = true\n";
+    let result =
+        update_manifest_content(content, &ManifestFormat::Toml, "package.version", "1.0.0");
+    assert!(
+        result.is_err(),
+        "workspace-inherited version should return an error"
+    );
+    let msg = format!("{:?}", result.unwrap_err());
+    assert!(
+        msg.contains("workspace inheritance"),
+        "error message should mention workspace inheritance, got: {msg}"
+    );
+}
+
+#[test]
 fn detect_standard_manifests_multiple_files_all_detected() {
     let result = detect_standard_manifests(&["Cargo.toml", "package.json", "composer.json"]);
-    // Cargo.toml → 1, package.json → 1, composer.json → 1 = 3 total
-    assert_eq!(result.len(), 3);
+    // Cargo.toml → 2 (workspace + package), package.json → 1, composer.json → 1 = 4 total
+    assert_eq!(result.len(), 4);
     let paths: Vec<&str> = result.iter().map(|m| m.path.as_str()).collect();
     assert!(paths.contains(&"Cargo.toml"));
     assert!(paths.contains(&"package.json"));

--- a/crates/core/src/release_orchestrator.rs
+++ b/crates/core/src/release_orchestrator.rs
@@ -958,7 +958,8 @@ fn dedup_file_updates_by_path(updates: Vec<FileUpdate>) -> Vec<FileUpdate> {
             paths = ?duplicates,
             "Duplicate manifest paths detected; keeping last entry for each. \
              For a mixed workspace+package root Cargo.toml, \
-             workspace.package.version takes precedence over package.version"
+             workspace.package.version is kept because detect_standard_manifests \
+             emits it last (after package.version)"
         );
     }
     deduped

--- a/crates/core/src/release_orchestrator.rs
+++ b/crates/core/src/release_orchestrator.rs
@@ -889,9 +889,6 @@ impl<'a, G: GitHubOperations> ReleaseOrchestrator<'a, G> {
 // Private helpers
 // ─────────────────────────────────────────────────────────────────────────────
 
-/// Deduplicate a [`FileUpdate`] list by path, keeping the **last** entry for
-/// each unique path.
-///
 /// Parse a root `Cargo.toml` and return a `Cargo.toml` path for each
 /// workspace member that is listed as an **explicit path** (no glob characters).
 ///
@@ -927,19 +924,43 @@ fn cargo_workspace_member_cargo_tomls(workspace_cargo_toml: &str) -> Vec<String>
         .collect()
 }
 
+/// Deduplicate a [`FileUpdate`] list by path, keeping the **last** entry for
+/// each unique path.
+///
 /// `detect_standard_manifests` may produce two configs for the same file (e.g.
 /// both `project.version` and `tool.poetry.version` for `pyproject.toml`).
 /// Passing duplicate paths to the Git Trees API results in silent data loss — the
 /// last blob silently wins.  This helper makes the last-writer-wins semantics
 /// explicit and predictable.
+///
+/// Emits a `warn!` log when duplicates are detected, because a mixed
+/// workspace+package root `Cargo.toml` (containing both `[workspace.package]`
+/// and `[package]`) will produce two entries for the same path; the warning
+/// helps operators distinguish an expected deduplication from an accidental one.
 fn dedup_file_updates_by_path(updates: Vec<FileUpdate>) -> Vec<FileUpdate> {
     let mut seen = std::collections::HashSet::new();
+    let mut duplicates: Vec<String> = Vec::new();
     let mut deduped: Vec<FileUpdate> = updates
         .into_iter()
         .rev()
-        .filter(|u| seen.insert(u.path.clone()))
+        .filter(|u| {
+            if seen.insert(u.path.clone()) {
+                true
+            } else {
+                duplicates.push(u.path.clone());
+                false
+            }
+        })
         .collect();
     deduped.reverse();
+    if !duplicates.is_empty() {
+        warn!(
+            paths = ?duplicates,
+            "Duplicate manifest paths detected; keeping last entry for each. \
+             For a mixed workspace+package root Cargo.toml, \
+             workspace.package.version takes precedence over package.version"
+        );
+    }
     deduped
 }
 

--- a/crates/core/src/release_orchestrator.rs
+++ b/crates/core/src/release_orchestrator.rs
@@ -637,7 +637,7 @@ impl<'a, G: GitHubOperations> ReleaseOrchestrator<'a, G> {
                 "pyproject.toml",
                 "composer.json",
             ];
-            let mut probe_cache: std::collections::HashMap<&str, String> =
+            let mut probe_cache: std::collections::HashMap<String, String> =
                 std::collections::HashMap::new();
             for &candidate in &candidates {
                 if explicit_paths.contains(candidate) {
@@ -649,7 +649,7 @@ impl<'a, G: GitHubOperations> ReleaseOrchestrator<'a, G> {
                     .await
                 {
                     Ok(Some(content)) => {
-                        probe_cache.insert(candidate, content);
+                        probe_cache.insert(candidate.to_string(), content);
                     }
                     Ok(None) => {} // file not present — skip silently
                     Err(e) => {
@@ -661,7 +661,42 @@ impl<'a, G: GitHubOperations> ReleaseOrchestrator<'a, G> {
                     }
                 }
             }
-            let existing: Vec<&str> = probe_cache.keys().copied().collect();
+            // Discover Cargo workspace member crates from the root Cargo.toml.
+            // Glob-pattern entries (e.g. "crates/*") are skipped because they
+            // require filesystem enumeration; list those paths explicitly in
+            // `manifest_files` config if they need to be updated individually.
+            if let Some(root_cargo) = probe_cache.get("Cargo.toml") {
+                for member_path in cargo_workspace_member_cargo_tomls(root_cargo) {
+                    if explicit_paths.contains(member_path.as_str()) {
+                        continue;
+                    }
+                    if probe_cache.contains_key(&member_path) {
+                        continue;
+                    }
+                    match self
+                        .github
+                        .get_file_content(owner, repo, &member_path, branch)
+                        .await
+                    {
+                        Ok(Some(content)) => {
+                            debug!(
+                                path = %member_path,
+                                "Found Cargo workspace member manifest"
+                            );
+                            probe_cache.insert(member_path, content);
+                        }
+                        Ok(None) => {} // member's Cargo.toml absent on this branch — skip
+                        Err(e) => {
+                            warn!(
+                                path = %member_path,
+                                error = %e,
+                                "Failed to probe Cargo workspace member manifest; skipping"
+                            );
+                        }
+                    }
+                }
+            }
+            let existing: Vec<&str> = probe_cache.keys().map(|s| s.as_str()).collect();
             for cfg in detect_standard_manifests(&existing) {
                 manifests.push(std::borrow::Cow::Owned(cfg));
             }
@@ -857,6 +892,41 @@ impl<'a, G: GitHubOperations> ReleaseOrchestrator<'a, G> {
 /// Deduplicate a [`FileUpdate`] list by path, keeping the **last** entry for
 /// each unique path.
 ///
+/// Parse a root `Cargo.toml` and return a `Cargo.toml` path for each
+/// workspace member that is listed as an **explicit path** (no glob characters).
+///
+/// Glob entries such as `"crates/*"` are silently skipped because enumerating
+/// them requires a directory listing that is not available here.  Users should
+/// add those member paths explicitly to `manifest_files` in the config when
+/// they need per-crate version updates.
+///
+/// Returns an empty `Vec` when the content cannot be parsed or the file
+/// contains no `[workspace] members` array.
+fn cargo_workspace_member_cargo_tomls(workspace_cargo_toml: &str) -> Vec<String> {
+    let doc: toml_edit::DocumentMut = match workspace_cargo_toml.parse() {
+        Ok(d) => d,
+        Err(_) => return Vec::new(),
+    };
+
+    let members = match doc
+        .get("workspace")
+        .and_then(|w| w.as_table())
+        .and_then(|t| t.get("members"))
+        .and_then(|m| m.as_array())
+    {
+        Some(a) => a,
+        None => return Vec::new(),
+    };
+
+    members
+        .iter()
+        .filter_map(|v| v.as_str())
+        // Skip glob patterns — they require filesystem enumeration.
+        .filter(|s| !s.contains('*') && !s.contains('?') && !s.contains('[') && !s.contains('{'))
+        .map(|s| format!("{s}/Cargo.toml"))
+        .collect()
+}
+
 /// `detect_standard_manifests` may produce two configs for the same file (e.g.
 /// both `project.version` and `tool.poetry.version` for `pyproject.toml`).
 /// Passing duplicate paths to the Git Trees API results in silent data loss — the

--- a/crates/core/src/release_orchestrator_tests.rs
+++ b/crates/core/src/release_orchestrator_tests.rs
@@ -1352,3 +1352,96 @@ fn test_cargo_workspace_member_cargo_tomls_explicit_paths_returned() {
         "missing crates/bar/Cargo.toml in {result:?}"
     );
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// dedup_file_updates_by_path — private helper unit tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Verify that an empty input list is returned unchanged with no panic.
+#[test]
+fn test_dedup_file_updates_by_path_empty_input_returns_empty() {
+    let result = dedup_file_updates_by_path(vec![]);
+    assert!(result.is_empty(), "empty input should return empty vec");
+}
+
+/// Verify that a list with no duplicate paths is returned unchanged (same
+/// length and same order).
+#[test]
+fn test_dedup_file_updates_by_path_no_duplicates_returns_input_unchanged() {
+    let updates = vec![
+        FileUpdate {
+            path: "Cargo.toml".to_string(),
+            content: "version1".to_string(),
+        },
+        FileUpdate {
+            path: "package.json".to_string(),
+            content: "version2".to_string(),
+        },
+    ];
+    let result = dedup_file_updates_by_path(updates);
+    assert_eq!(result.len(), 2, "no duplicates should not drop any entries");
+    assert_eq!(result[0].path, "Cargo.toml");
+    assert_eq!(result[1].path, "package.json");
+}
+
+/// Verify that when two entries share the same path the **last** one is kept.
+///
+/// `detect_standard_manifests` emits `package.version` first and
+/// `workspace.package.version` last for the root `Cargo.toml`, so after
+/// deduplication the workspace key must win.
+#[test]
+fn test_dedup_file_updates_by_path_last_entry_wins_for_duplicates() {
+    let updates = vec![
+        FileUpdate {
+            path: "Cargo.toml".to_string(),
+            content: "package.version update".to_string(),
+        },
+        FileUpdate {
+            path: "Cargo.toml".to_string(),
+            content: "workspace.package.version update".to_string(),
+        },
+    ];
+    let result = dedup_file_updates_by_path(updates);
+    assert_eq!(
+        result.len(),
+        1,
+        "duplicate path should be collapsed to one entry"
+    );
+    assert_eq!(
+        result[0].content, "workspace.package.version update",
+        "last entry must win; got content: {:?}",
+        result[0].content
+    );
+}
+
+/// Verify that mixed duplicate and unique paths produce the correct selection:
+/// unique paths are kept as-is; duplicate paths keep only the last occurrence.
+/// Relative order in the output follows the position of the last (surviving)
+/// occurrence of each path in the original list.
+#[test]
+fn test_dedup_file_updates_by_path_mixed_keeps_correct_entries() {
+    // Cargo.toml twice (index 0 and 2), package.json once (index 1).
+    // After dedup: package.json (last-seen at index 1) comes before Cargo.toml
+    // (last-seen at index 2), preserving the relative order of last occurrences.
+    let updates = vec![
+        FileUpdate {
+            path: "Cargo.toml".to_string(),
+            content: "first".to_string(),
+        },
+        FileUpdate {
+            path: "package.json".to_string(),
+            content: "unique".to_string(),
+        },
+        FileUpdate {
+            path: "Cargo.toml".to_string(),
+            content: "last".to_string(),
+        },
+    ];
+    let result = dedup_file_updates_by_path(updates);
+    assert_eq!(result.len(), 2, "should collapse Cargo.toml to one entry");
+    // package.json (last-seen at original index 1) precedes Cargo.toml (last-seen at index 2).
+    assert_eq!(result[0].path, "package.json");
+    assert_eq!(result[0].content, "unique");
+    assert_eq!(result[1].path, "Cargo.toml");
+    assert_eq!(result[1].content, "last", "last Cargo.toml entry must win");
+}

--- a/crates/core/src/release_orchestrator_tests.rs
+++ b/crates/core/src/release_orchestrator_tests.rs
@@ -1279,3 +1279,76 @@ fn test_extract_changelog_from_pr_body_empty_body_returns_empty() {
     let result = extract_changelog_from_pr_body("", "## Changelog");
     assert_eq!(result, "");
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// cargo_workspace_member_cargo_tomls — private helper unit tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Verify that malformed TOML input returns an empty vec without panicking.
+#[test]
+fn test_cargo_workspace_member_cargo_tomls_malformed_toml_returns_empty() {
+    let result = cargo_workspace_member_cargo_tomls("this is not toml @@@ {{{");
+    assert!(
+        result.is_empty(),
+        "malformed TOML should return empty vec, got {result:?}"
+    );
+}
+
+/// Verify that a `Cargo.toml` with no `[workspace]` table returns an empty vec.
+#[test]
+fn test_cargo_workspace_member_cargo_tomls_no_workspace_table_returns_empty() {
+    let content = "[package]\nname = \"myapp\"\nversion = \"0.1.0\"\n";
+    let result = cargo_workspace_member_cargo_tomls(content);
+    assert!(
+        result.is_empty(),
+        "no [workspace] table should return empty vec, got {result:?}"
+    );
+}
+
+/// Verify that a workspace without a `members` array returns an empty vec.
+#[test]
+fn test_cargo_workspace_member_cargo_tomls_no_members_returns_empty() {
+    let content = "[workspace]\nresolver = \"2\"\n";
+    let result = cargo_workspace_member_cargo_tomls(content);
+    assert!(
+        result.is_empty(),
+        "workspace without members should return empty vec, got {result:?}"
+    );
+}
+
+/// Verify that glob patterns in the workspace `members` array are filtered out.
+///
+/// Glob characters `*`, `?`, `[`, and `{` all disqualify an entry from being
+/// returned because filesystem enumeration is not available here.
+#[test]
+fn test_cargo_workspace_member_cargo_tomls_globs_are_filtered() {
+    let content =
+        "[workspace]\nmembers = [\"crates/*\", \"tools/?\", \"lib/[a-z]*\", \"ext/{a,b}\"]\n";
+    let result = cargo_workspace_member_cargo_tomls(content);
+    assert!(
+        result.is_empty(),
+        "all glob patterns should be filtered, got {result:?}"
+    );
+}
+
+/// Verify that explicit (non-glob) workspace member paths are returned as
+/// `<member>/Cargo.toml` strings, while glob entries in the same list are
+/// silently skipped.
+#[test]
+fn test_cargo_workspace_member_cargo_tomls_explicit_paths_returned() {
+    let content = "[workspace]\nmembers = [\"crates/foo\", \"crates/bar\", \"crates/*\"]\n";
+    let result = cargo_workspace_member_cargo_tomls(content);
+    assert_eq!(
+        result.len(),
+        2,
+        "should return exactly two explicit members (glob skipped), got {result:?}"
+    );
+    assert!(
+        result.contains(&"crates/foo/Cargo.toml".to_string()),
+        "missing crates/foo/Cargo.toml in {result:?}"
+    );
+    assert!(
+        result.contains(&"crates/bar/Cargo.toml".to_string()),
+        "missing crates/bar/Cargo.toml in {result:?}"
+    );
+}


### PR DESCRIPTION
Extends manifest auto-detection and update logic to handle Cargo workspace layouts.

Changes in manifest.rs:
- detect_standard_manifests emits two entries for the root Cargo.toml: workspace.package.version and package.version. The orchestrator tries both; the missing key fails gracefully.
- Any path ending in /Cargo.toml (non-root) is detected as a workspace member crate with key package.version.
- update_toml detects version.workspace = true and returns a clear error pointing to workspace.package.version instead of a generic type error.

Changes in release_orchestrator.rs:
- After probing the root Cargo.toml, the orchestrator parses its workspace members array and probes each explicit member Cargo.toml automatically. Glob patterns are skipped.
- Added private helper cargo_workspace_member_cargo_tomls to extract member paths from a root Cargo.toml.
- probe_cache type changed from HashMap<&str, String> to HashMap<String, String> for dynamically discovered member paths.