### PR TITLE
docs(config): specify enterprise 5-level configuration hierarchy (ADR-007)

### DIFF
--- a/docs/adr/ADR-007-enterprise-config-hierarchy.md
+++ b/docs/adr/ADR-007-enterprise-config-hierarchy.md
@@ -1,0 +1,327 @@
+# ADR-007: Enterprise Configuration Hierarchy with Metadata Repository
+
+Status: Accepted
+Date: 2026-05-09
+Owners: ReleaseRegent team
+
+## Context
+
+Release Regent needs a flexible configuration system that supports both simple single-repo
+deployments and large enterprise deployments. A naive two-level model (app-level local
+config → repo dotfile) is insufficient for enterprise deployments where:
+
+- A platform team needs to enforce organisation-wide policies (e.g. versioning strategy,
+  release controls) that individual repository owners cannot override.
+- Policies need to apply to **groups** of related repositories (e.g. all backend services,
+  all mobile apps) without requiring each repository to duplicate the same configuration.
+- Configuration governance must follow the same git-based audit trail as code changes,
+  not live in a deployment container.
+- A single Release Regent instance serves hundreds of repositories across an organisation,
+  requiring centralised policy management with selective override permissions.
+
+A two-level model (app-level local config → repo dotfile) does not support policy
+enforcement or group-level defaults.
+
+## Decision
+
+Extend the configuration hierarchy to five levels, resolved in this order (each level
+merges over the previous for unlocked fields only):
+
+```
+Built-in defaults
+      ↓
+App-level config     CONFIG_DIR/release-regent.yml  (local disk — bootstrap + fallback)
+      ↓
+Global policy        {org}/.release-regent/global.toml  (metadata repo)
+      ↓
+Group policy         {org}/.release-regent/groups/{group}.toml  (metadata repo)
+      ↓
+Repository config    {repo-root}/.release-regent.yml  (target repository)
+```
+
+### Metadata repository
+
+All server-side levels above the repository dotfile are stored in a **metadata
+repository** named `.release-regent` within the same GitHub organisation (or user
+account). This repository is auto-discovered: for an event from `myorg/some-repo`, the
+metadata repository is `myorg/.release-regent`.
+
+```
+myorg/.release-regent/
+  global.toml          ← org-wide policy defaults and field locks
+  groups/
+    platform.toml      ← policy for repos that declare group = "platform"
+    mobile.toml
+    data.toml
+```
+
+The GitHub App must be installed on the metadata repository for global and group levels
+to be active. If the App is not installed (or the repository does not exist), the system
+silently falls back to the app-level config as the top of the hierarchy.
+
+### Group membership
+
+Repositories self-declare their group in the repo dotfile via a top-level `group` field:
+
+```toml
+# .release-regent.yml in myorg/platform-api
+group = "platform"
+
+[release_pr]
+title_template = "chore(release): ${version} [platform-api]"
+```
+
+The `group` field is added to `ReleaseRegentConfig`. It is only meaningful in repository
+dotfiles; if present in global or group config files it is ignored with a `warn!`.
+
+### Per-field locks
+
+Global and group config files may include a `locked_fields` array. Each entry is a
+dotted field path. Lower levels cannot override locked fields.
+
+```toml
+# global.toml
+[versioning]
+strategy = "conventional"
+allow_override = false
+
+locked_fields = ["versioning.strategy", "versioning.allow_override"]
+```
+
+```toml
+# groups/platform.toml
+[releases]
+draft = true
+
+# Adds to global's locks; cannot remove globally-locked fields
+locked_fields = ["releases.draft"]
+```
+
+**Lockable fields** (only these are valid in `locked_fields`):
+
+| Path | Description |
+|---|---|
+| `versioning.strategy` | Versioning algorithm (conventional / external) |
+| `versioning.allow_override` | Whether PR comment override commands are permitted |
+| `releases.draft` | Whether GitHub releases are created as drafts |
+| `releases.prerelease` | Whether GitHub releases are marked pre-release |
+| `releases.generate_notes` | Whether GitHub auto-generates release notes |
+| `core.branches.main` | Name of the default/main branch |
+| `core.version_prefix` | Prefix prepended to version tags |
+| `error_handling.max_retries` | Maximum retry count |
+| `error_handling.backoff_multiplier` | Exponential backoff multiplier |
+| `error_handling.initial_delay_ms` | Initial retry delay |
+
+**Never lockable** — if listed in `locked_fields`, silently ignored with `warn!`:
+
+- All `release_pr.*` fields (title template, body template, manifest files, auto-detect)
+- All `notifications.*` fields
+
+`locked_fields` in repository dotfiles is silently ignored with `warn!`.
+
+### Lock accumulation rule
+
+Locks accumulate downward through the hierarchy; they can never be removed by a lower
+level. If a group config attempts to include in its `locked_fields` a field that global
+already locked, the entry is a no-op (the field stays locked) and a `warn!` is emitted.
+Repository dotfiles cannot modify locks in any way.
+
+### Lock conflict handling
+
+When a lower-level config specifies a value for a field that is locked by a higher level,
+the provider **silently uses the locked value** and emits a `warn!`. The event is **not**
+failed. This prevents immediate workflow disruption for repositories that have a
+pre-existing dotfile when a new lock is added centrally — they can clean up the dotfile
+at their own pace.
+
+### Fallback behaviour
+
+| Condition | Behaviour |
+|---|---|
+| App not installed on metadata repo / metadata repo absent | Fall back: skip global and group levels; emit `warn!`; app-level is the effective top |
+| Metadata repo accessible but `global.toml` absent | Skip global level; continue |
+| Metadata repo accessible, `global.toml` present but invalid | **Hard fail** all events for this org |
+| Group declared in repo dotfile, group file absent in metadata repo | Skip group level; emit `warn!`; continue |
+| Group file present but invalid | **Hard fail** events for repos in that group |
+| Repository dotfile absent | Skip repo level; use merged result so far |
+| Repository dotfile present but invalid | **Hard fail** that event only |
+
+The asymmetry between "absent = skip silently" and "present but invalid = hard fail" is
+intentional: absence is a valid operational state (not yet configured), while an invalid
+file is a configuration error that must be explicitly corrected.
+
+### Caching
+
+Three independent in-memory caches with different TTLs:
+
+| Level | Cache key | TTL |
+|---|---|---|
+| Global policy | `{org}` | 600 seconds (10 min) |
+| Group policy | `{org}/{group}` | 300 seconds (5 min) |
+| Repository config | `{owner}/{repo}` | 300 seconds (5 min) |
+
+The metadata repo installation ID is cached permanently for the process lifetime
+(installation IDs are stable for the lifetime of a GitHub App installation).
+
+A parse or validation error at any level evicts the cache entry for that level so that a
+corrected file is picked up on the next event.
+
+## Consequences
+
+**Enables:**
+
+- Platform teams enforce non-overridable policies (versioning strategy, release controls)
+  centrally, without touching individual repository config files.
+- Group-level defaults eliminate per-repository boilerplate for common settings (draft
+  releases for incubation services, specific branch naming, etc.).
+- All configuration changes at every level are under git-based change management and
+  audit within the metadata repository.
+- Compatible with single-repository or simple deployments — metadata repository is
+  optional; app-level config is the fallback.
+- Backwards compatible: existing deployments with only a local `CONFIG_DIR/release-regent.yml`
+  continue to work unchanged.
+
+**Forbids:**
+
+- Lower configuration levels from overriding locked policy fields.
+- Locking template and notification fields (always user-customisable at repo level).
+- Repository dotfiles from specifying `locked_fields` (ignored with `warn!`).
+- Release Regent from validating the authorship of changes to the metadata repository —
+  this is delegated to branch protection rules and CODEOWNERS on the metadata repository.
+
+**Trade-offs:**
+
+- Webhook events that trigger config loading may now make up to three additional GitHub
+  API calls (global, group, repo dotfile) before the main operation begins. Caching
+  reduces this to zero for the common case within a TTL window.
+- An invalid `global.toml` in the metadata repository fails **all** events for that
+  organisation — high blast radius but deliberate, as policy errors must be fixed promptly.
+- The metadata repository naming convention (`{org}/.release-regent`) is fixed; custom
+  names are not supported.
+
+## Alternatives considered
+
+### Option A: Mapping file in metadata repo for group membership
+
+A `teams/members.toml` would centrally map repositories to groups. **Why not**: Requires
+a central update for every new repository; doesn't scale and violates the self-describing
+repository principle.
+
+### Option B: GitHub Teams API for group membership
+
+Map GitHub Team membership to config groups. **Why not**: GitHub Teams are designed for
+access control, not config inheritance. One repo can belong to multiple teams (ambiguous
+group resolution). Requires additional `teams:read` scope. Fragile.
+
+### Option C: Separate metadata repository per group
+
+Each group operates its own metadata repository. **Why not**: No single authoritative place
+for org-wide policy. Installation management complexity grows with the number of groups.
+
+### Option D: Environment variable injection per group or org
+
+Pass group/org policy via env vars at server startup. **Why not**: Doesn't scale past a
+handful of settings. Not auditable. Requires a server restart for every policy change.
+
+## Implementation notes
+
+### New fields on `ReleaseRegentConfig`
+
+```rust
+/// Repository group name. Only meaningful in repository dotfiles.
+/// If present in global or group config files, ignored with warn!.
+/// When set, the provider fetches {org}/.release-regent/groups/{group}.toml.
+#[serde(default)]
+pub group: Option<String>,
+
+/// Fields that cannot be overridden at lower configuration levels.
+/// Only valid in global policy and group policy files.
+/// If present in repository dotfiles, ignored with warn!.
+///
+/// Valid lockable paths: see [ADR-007] for the complete list.
+#[serde(default)]
+pub locked_fields: Vec<String>,
+```
+
+### Merge algorithm (pseudocode inside `get_merged_config`)
+
+```
+result ← ReleaseRegentConfig::default()
+locks  ← HashSet::new()
+
+// 1. App-level (local disk, always required)
+app_config ← FileConfigurationProvider::load_global_config()
+result ← merge(result, app_config)   // no locks applied yet
+
+// 2. Metadata repo levels
+metadata_installation ← resolve_metadata_installation(org)
+if metadata_installation is Some(id):
+    scoped ← github.scoped_to(id)
+
+    // 2a. Global policy
+    global_raw ← fetch_file(scoped, org, ".release-regent", "global.toml")
+    if global_raw is Ok(Some(content)):
+        global_config ← parse_and_validate(content)   // Err → hard fail
+        locks.extend(validate_lockable(global_config.locked_fields))
+        result ← merge_with_locks(result, global_config, locks)
+    // if Ok(None): skip; if Err(API): fall through with warning
+
+    // 2b. Group policy (need group name from repo dotfile peek)
+    group_name ← peek_group_field(owner, repo, branch, scoped)  // may return None
+    if group_name is Some(name):
+        group_raw ← fetch_file(scoped, org, ".release-regent", "groups/{name}.toml")
+        if group_raw is Ok(Some(content)):
+            group_config ← parse_and_validate(content)  // Err → hard fail
+            new_locks ← validate_lockable(group_config.locked_fields)
+            // Locks already in `locks` remain; new_locks adds more
+            locks.extend(new_locks)
+            result ← merge_with_locks(result, group_config, locks)
+        if group_raw is Ok(None):
+            warn!("Group '{name}' declared in {owner}/{repo} but no group config found")
+            // skip group level, continue
+
+else:
+    warn!("Metadata repo {org}/.release-regent not accessible; using app-level as baseline")
+
+// 3. Repository dotfile
+repo_config ← fetch_repo_dotfile(owner, repo, branch)
+if repo_config is Ok(Some(config)):
+    if config.locked_fields is not empty: warn! and clear locked_fields
+    result ← merge_with_locks(result, config, locks)
+if repo_config is Ok(None): skip
+if repo_config is Err: hard fail
+
+return result
+```
+
+### `merge_with_locks` semantics
+
+For each field in `incoming`:
+
+- If the field's dotted path is in `locks` and `incoming.field ≠ result.field`:
+  emit `warn!("Field {path} is locked by higher-level policy; ignoring override from {level}")`;
+  keep `result.field` (the locked value).
+- Otherwise: `result.field ← incoming.field`.
+
+### Group field peek
+
+To resolve the group name before applying the group policy, the provider fetches the repo
+dotfile once early in the merge pipeline, extracts only the `group` field, then applies
+the full repo dotfile last. The fetched content is cached so it is not downloaded twice.
+
+### Server environment variable changes
+
+No new environment variables are required. The metadata repository is auto-discovered
+from each webhook event's `repository.owner` field.
+
+### Lockable field validation
+
+Non-lockable fields (templates, notifications) found in `locked_fields` are silently
+dropped after a `warn!`. The provider must maintain a static allowlist of lockable paths
+and filter `locked_fields` against it before adding to the accumulated lock set.
+
+## References
+
+- [FR-6: Configuration Management](../specs/requirements/functional-requirements.md)
+- [US-6, US-9: Configuration Management](../specs/requirements/user-stories.md)
+- [Interface spec — GitHubConfigurationProvider](../specs/interfaces/github_operations_additions.md)

--- a/docs/adr/ADR-007-enterprise-config-hierarchy.md
+++ b/docs/adr/ADR-007-enterprise-config-hierarchy.md
@@ -64,12 +64,16 @@ silently falls back to the app-level config as the top of the hierarchy.
 Repositories self-declare their group in the repo dotfile via a top-level `group` field:
 
 ```toml
-# .release-regent.yml in myorg/platform-api
+# .release-regent.toml in myorg/platform-api
 group = "platform"
 
 [release_pr]
 title_template = "chore(release): ${version} [platform-api]"
 ```
+
+> **Note**: The `group` field and section-based config both use TOML syntax here. Use
+> `.release-regent.toml` for TOML content and `.release-regent.yml` / `.release-regent.yaml`
+> for YAML content — the parser is selected by file extension.
 
 The `group` field is added to `ReleaseRegentConfig`. It is only meaningful in repository
 dotfiles; if present in global or group config files it is ignored with a `warn!`.
@@ -81,20 +85,20 @@ dotted field path. Lower levels cannot override locked fields.
 
 ```toml
 # global.toml
+locked_fields = ["versioning.strategy", "versioning.allow_override"]
+
 [versioning]
 strategy = "conventional"
 allow_override = false
-
-locked_fields = ["versioning.strategy", "versioning.allow_override"]
 ```
 
 ```toml
 # groups/platform.toml
-[releases]
-draft = true
-
 # Adds to global's locks; cannot remove globally-locked fields
 locked_fields = ["releases.draft"]
+
+[releases]
+draft = true
 ```
 
 **Lockable fields** (only these are valid in `locked_fields`):
@@ -145,6 +149,7 @@ at their own pace.
 | Group file present but invalid | **Hard fail** events for repos in that group |
 | Repository dotfile absent | Skip repo level; use merged result so far |
 | Repository dotfile present but invalid | **Hard fail** that event only |
+| Repository dotfile API error (503, network timeout) | **Hard fail** that event only — unlike a transient error on the metadata repo, the repo dotfile is the primary per-repository config source; transient failures are not silently skipped |
 
 The asymmetry between "absent = skip silently" and "present but invalid = hard fail" is
 intentional: absence is a valid operational state (not yet configured), while an invalid
@@ -259,26 +264,32 @@ if metadata_installation is Some(id):
     scoped ← github.scoped_to(id)
 
     // 2a. Global policy
+    metadata_reachable ← true
     global_raw ← fetch_file(scoped, org, ".release-regent", "global.toml")
     if global_raw is Ok(Some(content)):
         global_config ← parse_and_validate(content)   // Err → hard fail
         locks.extend(validate_lockable(global_config.locked_fields))
         result ← merge_with_locks(result, global_config, locks)
-    // if Ok(None): skip; if Err(API): fall through with warning
+    // if Ok(None): global absent; metadata reachable; continue to group level
+    if global_raw is Err(API):
+        warn!("Metadata repo unreachable; skipping global AND group levels")
+        metadata_reachable ← false
 
     // 2b. Group policy (need group name from repo dotfile peek)
-    group_name ← peek_group_field(owner, repo, branch, scoped)  // may return None
-    if group_name is Some(name):
-        group_raw ← fetch_file(scoped, org, ".release-regent", "groups/{name}.toml")
-        if group_raw is Ok(Some(content)):
-            group_config ← parse_and_validate(content)  // Err → hard fail
-            new_locks ← validate_lockable(group_config.locked_fields)
-            // Locks already in `locks` remain; new_locks adds more
-            locks.extend(new_locks)
-            result ← merge_with_locks(result, group_config, locks)
-        if group_raw is Ok(None):
-            warn!("Group '{name}' declared in {owner}/{repo} but no group config found")
-            // skip group level, continue
+    // Only attempted when metadata repo was reachable (global returned Ok)
+    if metadata_reachable:
+        group_name ← peek_group_field(owner, repo, branch, scoped)  // may return None
+        if group_name is Some(name):
+            group_raw ← fetch_file(scoped, org, ".release-regent", "groups/{name}.toml")
+            if group_raw is Ok(Some(content)):
+                group_config ← parse_and_validate(content)  // Err → hard fail
+                new_locks ← validate_lockable(group_config.locked_fields)
+                // Locks already in `locks` remain; new_locks adds more
+                locks.extend(new_locks)
+                result ← merge_with_locks(result, group_config, locks)
+            if group_raw is Ok(None):
+                warn!("Group '{name}' declared in {owner}/{repo} but no group config found")
+                // skip group level, continue
 
 else:
     warn!("Metadata repo {org}/.release-regent not accessible; using app-level as baseline")

--- a/docs/specs/architecture/overview.md
+++ b/docs/specs/architecture/overview.md
@@ -1,7 +1,7 @@
 # System Architecture Overview
 
-**Last Updated**: 2026-03-16
-**Status**: Updated — see ADR-002
+**Last Updated**: 2026-05-09
+**Status**: Updated — 5-level enterprise config hierarchy added (ADR-007)
 
 ## High-Level Architecture
 
@@ -48,17 +48,21 @@ C4Container
     Container(function, "Server", "Docker / OCI container", "Long-running Axum HTTP server")
     Container(core, "Core Engine", "Rust", "Business logic and workflow orchestration")
     Container(github_client, "GitHub Client", "Rust", "GitHub API integration")
-    Container(config, "Configuration", "YAML", "Application and repository settings")
+    ContainerDb(app_config, "App Config", "YAML / TOML", "Bootstrap defaults in CONFIG_DIR (local disk)")
 
-    Container_Ext(github_api, "GitHub API", "REST API", "Repository operations")
+    Container_Ext(github_api, "GitHub API", "REST API", "Repository operations + config file fetch")
     Container_Ext(github_webhooks, "GitHub Webhooks", "HTTP", "Event notifications")
-    ContainerDb_Ext(secrets, "Secret Store", "Key Vault/Secrets Manager", "Credentials storage")
+    ContainerDb_Ext(metadata_repo, "Metadata Repo", "{org}/.release-regent", "Global policy + group policies (GitHub)")
+    ContainerDb_Ext(repo_config, "Repo Dotfile", ".release-regent.yml", "Per-repository config in each managed repo")
+    ContainerDb_Ext(secrets, "Secret Store", "Key Vault / Secrets Manager", "Credentials storage")
 
     Rel(github_webhooks, function, "POST webhook events", "HTTPS")
     Rel(function, core, "Invokes", "Function call")
     Rel(core, github_client, "Uses", "Function call")
     Rel(github_client, github_api, "API calls", "HTTPS")
-    Rel(core, config, "Reads", "File system")
+    Rel(core, app_config, "Reads bootstrap defaults", "File system")
+    Rel(github_client, metadata_repo, "Fetches global + group policy", "HTTPS (Contents API)")
+    Rel(github_client, repo_config, "Fetches repo dotfile", "HTTPS (Contents API)")
     Rel(github_client, secrets, "Retrieves tokens", "HTTPS")
 ```
 
@@ -164,7 +168,71 @@ flowchart TD
 - Handle rate limiting and retries
 - Manage installation tokens
 
-#### 7. Version Calculator
+#### 7. Configuration Provider
+
+**Purpose**: Load and merge configuration from five levels into a single resolved config
+**Location**: `crates/config_provider/src/`
+**See**: [ADR-007](../../adr/ADR-007-enterprise-config-hierarchy.md)
+
+**Implementations**:
+
+- `FileConfigurationProvider` — reads config from local files in `CONFIG_DIR`. Used as
+  the app-level bootstrap / fallback and as the CLI fallback for all levels.
+- `GitHubConfigurationProvider` — **server deployment**. Orchestrates the full five-level
+  merge, fetching global policy and group policy from the metadata repository
+  (`{org}/.release-regent`) and the repo dotfile from the target repository via
+  `GitHubOperations::get_file_content`. Wraps `FileConfigurationProvider` for the
+  app-level baseline.
+
+**Configuration hierarchy** (later levels override earlier ones for unlocked fields):
+
+| # | Level | Source | Required? |
+|---|---|---|---|
+| 1 | Built-in defaults | Hard-coded `ReleaseRegentConfig::default()` | Always |
+| 2 | App-level | `CONFIG_DIR/release-regent.yml` — local disk | Required (bootstrap + fallback) |
+| 3 | Global policy | `{org}/.release-regent/global.toml` — metadata repo | Optional |
+| 4 | Group policy | `{org}/.release-regent/groups/{group}.toml` — metadata repo | Optional |
+| 5 | Repository config | `.release-regent.yml` in target repo root | Optional |
+
+**Per-field locks**:
+
+Global and group policy files may include a `locked_fields` list of dotted field paths
+(e.g. `["versioning.strategy", "releases.draft"]`). A locked field cannot be overridden
+by any lower level. Only policy fields can be locked (templates and notification fields
+are never lockable). Locks accumulate downward and cannot be removed by a lower level.
+A lower level specifying a value for a locked field results in a `warn!`; the event is
+not failed.
+
+**Group membership**:
+
+Repositories declare their group via a top-level `group = "name"` field in the repo
+dotfile. The provider fetches `{org}/.release-regent/groups/{name}.toml` from the
+metadata repository. A declared group with no corresponding group file causes a `warn!`
+and skips the group level; it is not an error.
+
+**Key contracts**:
+
+- Absent at any level → skip that level silently; no error.
+- Present but invalid (parse or schema error) → hard fail the event.
+- Metadata repo unreachable (API error, App not installed) → warn and skip global +
+  group levels; app-level is the effective top.
+- `LoadOptions.installation_id` must be set by the processor so the provider can scope
+  the GitHub client for each fetch.
+- `LoadOptions.default_branch` should be populated from the webhook payload; falls back
+  to `"main"` when absent.
+
+**Caching**:
+
+| Level | Cache key | TTL |
+|---|---|---|
+| Global policy | `{org}` | 600 s |
+| Group policy | `{org}/{group}` | 300 s |
+| Repository config | `{owner}/{repo}` | 300 s |
+| Metadata installation ID | `{org}` | Permanent (process lifetime) |
+
+A parse or validation error evicts the corresponding cache entry immediately.
+
+#### 8. Version Calculator
 
 **Purpose**: Derive the next semantic version and changelog from commit history
 **Implementations**:

--- a/docs/specs/interfaces/github_operations_additions.md
+++ b/docs/specs/interfaces/github_operations_additions.md
@@ -516,3 +516,360 @@ the testing crate) covering at minimum:
 | Search with `label:rr:override-major` | `search_pull_requests` | Filtered by label |
 | Search `is:open label:rr:override-minor` | `search_pull_requests` | Filtered by state AND label |
 | Failure simulation | all new methods | `CoreError::Network` |
+
+---
+
+# Interface Additions: `GitHubConfigurationProvider` — ADR-007 enterprise config hierarchy
+
+**Status**: Ready for implementation
+**ADR**: [ADR-007](../../adr/ADR-007-enterprise-config-hierarchy.md)
+**Layer**: Config-provider crate — `crates/config_provider/src/github_provider.rs`
+
+---
+
+## Overview
+
+`GitHubConfigurationProvider` resolves configuration across five levels in order:
+
+1. Built-in defaults (`ReleaseRegentConfig::default()`)
+2. App-level — local `CONFIG_DIR/release-regent.yml` (via `FileConfigurationProvider`)
+3. Global policy — `{org}/.release-regent/global.toml` (metadata repo, GitHub API)
+4. Group policy — `{org}/.release-regent/groups/{group}.toml` (metadata repo, conditional)
+5. Repository config — `.release-regent.yml` in target repo root (GitHub API)
+
+Each level can lock specific policy fields, preventing lower levels from overriding them.
+
+---
+
+## 1. `ReleaseRegentConfig` additions
+
+**File**: `crates/core/src/config.rs`
+
+```rust
+/// Repository group name declared by the repository itself.
+///
+/// When set in a repository dotfile, the provider fetches the corresponding
+/// group policy from `{org}/.release-regent/groups/{group}.toml`.
+///
+/// Ignored (with `warn!`) if present in global or group policy files.
+#[serde(default)]
+pub group: Option<String>,
+
+/// Field paths that cannot be overridden at lower configuration levels.
+///
+/// Only valid in global policy and group policy files. Silently ignored
+/// (with `warn!`) if present in repository dotfiles.
+///
+/// Each entry is a dotted field path such as `"versioning.strategy"`.
+/// Only policy fields are lockable; see ADR-007 for the complete list.
+/// Non-lockable paths are silently dropped with `warn!`.
+#[serde(default)]
+pub locked_fields: Vec<String>,
+```
+
+---
+
+## 2. `ConfigLocks` internal type
+
+**File**: `crates/config_provider/src/github_provider.rs` (internal, not exported)
+
+```rust
+/// Accumulated set of locked field paths through the config merge pipeline.
+///
+/// Built up as each level (global, then group) is processed.
+/// Once a field is added it cannot be removed by a lower level.
+#[derive(Debug, Default)]
+struct ConfigLocks {
+    locked: std::collections::HashSet<String>,
+}
+
+/// Field paths of all lockable policy fields.
+/// Non-policy paths are filtered out of `locked_fields` with `warn!`.
+const LOCKABLE_FIELDS: &[&str] = &[
+    "versioning.strategy",
+    "versioning.allow_override",
+    "releases.draft",
+    "releases.prerelease",
+    "releases.generate_notes",
+    "core.branches.main",
+    "core.version_prefix",
+    "error_handling.max_retries",
+    "error_handling.backoff_multiplier",
+    "error_handling.initial_delay_ms",
+];
+
+impl ConfigLocks {
+    /// Add entries from a `locked_fields` list, filtering non-lockable paths.
+    /// Emits `warn!` for non-lockable paths and for already-locked paths.
+    fn extend_from(&mut self, locked_fields: &[String], source_level: &str) {
+        for path in locked_fields {
+            if !LOCKABLE_FIELDS.contains(&path.as_str()) {
+                tracing::warn!(
+                    path = %path, level = %source_level,
+                    "locked_fields entry is not a lockable policy field; ignoring"
+                );
+                continue;
+            }
+            self.locked.insert(path.clone());
+        }
+    }
+
+    fn is_locked(&self, path: &str) -> bool {
+        self.locked.contains(path)
+    }
+}
+```
+
+---
+
+## 3. `LoadOptions` extensions
+
+**File**: `crates/core/src/traits/configuration_provider.rs`
+
+Two new fields: `installation_id: Option<u64>` and `default_branch: Option<String>`.
+Callers in `crates/core/src/lib.rs` are unchanged.
+
+---
+
+## 4. `GitHubConfigurationProvider` struct
+
+**File**: `crates/config_provider/src/github_provider.rs`
+
+```rust
+pub struct GitHubConfigurationProvider<G>
+where
+    G: GitHubOperations + Clone + Send + Sync,
+{
+    /// App-level baseline; also used as CLI fallback for all levels.
+    inner: FileConfigurationProvider,
+    /// Unscoped GitHub client; scoped per call via `scoped_to`.
+    github: G,
+    /// org → installation_id. Never expires (stable for process lifetime).
+    metadata_installation_cache: tokio::sync::RwLock<HashMap<String, u64>>,
+    /// org → (config, cached_at). TTL: 600 s.
+    global_cache: tokio::sync::RwLock<HashMap<String, (ReleaseRegentConfig, Instant)>>,
+    /// "{org}/{group}" → (config, cached_at). TTL: 300 s.
+    group_cache: tokio::sync::RwLock<HashMap<String, (ReleaseRegentConfig, Instant)>>,
+    /// "{owner}/{repo}" → (config, cached_at). TTL: 300 s.
+    repo_cache: tokio::sync::RwLock<HashMap<String, (ReleaseRegentConfig, Instant)>>,
+    validator: ConfigValidator,
+}
+
+impl<G: GitHubOperations + Clone + Send + Sync> GitHubConfigurationProvider<G> {
+    pub fn new(inner: FileConfigurationProvider, github: G) -> Self {
+        Self {
+            inner, github,
+            metadata_installation_cache: Default::default(),
+            global_cache: Default::default(),
+            group_cache: Default::default(),
+            repo_cache: Default::default(),
+            validator: ConfigValidator::new(),
+        }
+    }
+}
+```
+
+---
+
+## 5. `get_merged_config` implementation (primary entry point)
+
+```rust
+async fn get_merged_config(
+    &self, owner: &str, repo: &str, options: LoadOptions,
+) -> CoreResult<ReleaseRegentConfig> {
+    // CLI / no-GitHub fallback
+    if options.installation_id.is_none() {
+        return self.inner.get_merged_config(owner, repo, options).await;
+    }
+    let installation_id = options.installation_id.unwrap();
+    let default_branch = options.default_branch.as_deref().unwrap_or("main");
+
+    let mut result = ReleaseRegentConfig::default();
+    let mut locks = ConfigLocks::default();
+
+    // Level 2: App-level (local disk)
+    result = merge_config(result, self.inner.load_global_config(options.clone()).await?);
+
+    // Levels 3 & 4: Metadata repo
+    match self.resolve_metadata_installation(owner).await {
+        Some(meta_id) => {
+            let meta = self.github.scoped_to(meta_id);
+
+            // Level 3: Global policy
+            match self.load_global_policy(owner, &meta).await {
+                Ok(Some(g)) => {
+                    locks.extend_from(&g.locked_fields, "global");
+                    result = merge_config_with_locks(result, g, &locks);
+                }
+                Ok(None) => {}
+                Err(e) if e.is_config_error() => return Err(e),
+                Err(e) => tracing::warn!(org=%owner, error=%e,
+                    "Metadata repo unreachable; skipping global+group levels"),
+            }
+
+            // Peek repo dotfile to discover group name (fetched once, applied at level 5)
+            let repo_result = self.fetch_repo_dotfile(owner, repo, default_branch, &meta).await;
+
+            // Level 4: Group policy
+            let group = repo_result.as_ref().ok()
+                .and_then(Option::as_ref)
+                .and_then(|c: &ReleaseRegentConfig| c.group.clone());
+
+            if let Some(ref g) = group {
+                match self.load_group_policy(owner, g, &meta).await {
+                    Ok(Some(gc)) => {
+                        locks.extend_from(&gc.locked_fields, &format!("group:{g}"));
+                        result = merge_config_with_locks(result, gc, &locks);
+                    }
+                    Ok(None) => tracing::warn!(org=%owner, group=%g,
+                        "Group '{g}' declared in {owner}/{repo} but no group config found; skipping"),
+                    Err(e) if e.is_config_error() => return Err(e),
+                    Err(e) => tracing::warn!(group=%g, error=%e,
+                        "Failed to load group policy; skipping group level"),
+                }
+            }
+
+            // Level 5: Repo dotfile (using already-fetched result)
+            match repo_result? {
+                Some(mut rc) => {
+                    if !rc.locked_fields.is_empty() {
+                        tracing::warn!(repo=%format!("{owner}/{repo}"),
+                            "locked_fields in repository dotfile is ignored");
+                        rc.locked_fields.clear();
+                    }
+                    result = merge_config_with_locks(result, rc, &locks);
+                }
+                None => {}
+            }
+        }
+        None => {
+            tracing::warn!(org=%owner,
+                "Metadata repo {owner}/.release-regent not accessible; \
+                 using app-level as baseline");
+            let scoped = self.github.scoped_to(installation_id);
+            if let Some(rc) = self.fetch_repo_dotfile(owner, repo, default_branch, &scoped).await? {
+                result = merge_config_with_locks(result, rc, &locks);
+            }
+        }
+    }
+
+    Ok(result)
+}
+```
+
+---
+
+## 6. Internal helpers summary
+
+| Method | Fetches from | Probe paths | Cache | TTL |
+|---|---|---|---|---|
+| `resolve_metadata_installation(org)` | GitHub App API | N/A (installation lookup) | `metadata_installation_cache` | ∞ |
+| `load_global_policy(org, client)` | `{org}/.release-regent` | `global.toml`, `global.yml`, `global.yaml` | `global_cache[org]` | 600 s |
+| `load_group_policy(org, group, client)` | `{org}/.release-regent` | `groups/{group}.toml/.yml/.yaml` | `group_cache["{org}/{group}"]` | 300 s |
+| `fetch_repo_dotfile(owner, repo, branch, client)` | `{owner}/{repo}` | `.release-regent.yml/.yaml/.toml` | `repo_cache["{owner}/{repo}"]` | 300 s |
+
+All fetch helpers return `Ok(None)` for absent files, `Err(CoreError::Config)` for invalid
+content, and `Err(CoreError::GitHub)` for API errors. Parse/validation errors evict the
+relevant cache entry immediately.
+
+---
+
+## 7. `merge_config_with_locks` contract
+
+```rust
+/// Merge `incoming` into `base`, skipping fields whose dotted path is in `locks`.
+///
+/// For each locked field where `incoming` differs from `base`:
+///   - Keep `base` value (the locked value)
+///   - Emit `warn!` identifying the field path, locked value, and override value
+///
+/// Template and notification fields (never lockable) are always overridden.
+/// The mapping from struct fields to dotted paths is explicit and must be
+/// maintained in sync with `LOCKABLE_FIELDS`.
+fn merge_config_with_locks(
+    base: ReleaseRegentConfig,
+    incoming: ReleaseRegentConfig,
+    locks: &ConfigLocks,
+) -> ReleaseRegentConfig { /* … */ }
+
+/// Merge without lock checks (app-level baseline; no locks active yet).
+fn merge_config(base: ReleaseRegentConfig, incoming: ReleaseRegentConfig)
+    -> ReleaseRegentConfig { /* … */ }
+```
+
+---
+
+## 8. Server wiring changes
+
+**File**: `crates/server/src/main.rs`
+
+```rust
+// Type alias — shape unchanged
+type ServerProcessor = release_regent_core::ReleaseRegentProcessor<
+    release_regent_github_client::GitHubClient,
+    release_regent_config_provider::GitHubConfigurationProvider<
+        release_regent_github_client::GitHubClient,
+    >,
+    Arc<dyn VersionCalculator + Send + Sync>,
+>;
+
+// build_server_processor — no TTL parameter now; use GitHubConfigurationProvider::new
+let config_provider = release_regent_config_provider::GitHubConfigurationProvider::new(
+    file_provider,
+    github_client.clone(),
+);
+```
+
+---
+
+## 9. Mock seeding (test helpers)
+
+```rust
+// Seed metadata repo installation
+mock.with_installation_id("myorg", ".release-regent", 99001)
+
+// Seed global policy
+.with_file_content("myorg", ".release-regent", "global.toml", "main", r#"
+    [versioning]
+    strategy = "conventional"
+    locked_fields = ["versioning.strategy"]
+"#)
+
+// Seed group policy
+.with_file_content("myorg", ".release-regent", "groups/platform.toml", "main", r#"
+    [releases]
+    draft = true
+    locked_fields = ["releases.draft"]
+"#)
+
+// Seed repo dotfile
+.with_file_content("myorg", "platform-api", ".release-regent.yml", "main", r#"
+    group = "platform"
+    [release_pr]
+    title_template = "chore(release): ${version} [platform-api]"
+"#)
+```
+
+---
+
+## 10. Test matrix for `GitHubConfigurationProvider`
+
+| Scenario | Metadata repo | `global.toml` | Group declared | Group file | Repo dotfile | Expected result |
+|---|---|---|---|---|---|---|
+| No metadata access | ✗ | — | No | — | Valid | App + repo dotfile only |
+| Global only | ✓ | Valid | No | — | Absent | App + global |
+| Global + group | ✓ | Valid | Yes | Valid | Absent | App + global + group |
+| Full 5-level stack | ✓ | Valid | Yes | Valid | Valid | All 5 levels merged |
+| Global locks field; group overrides | ✓ | Locks `versioning.strategy` | Yes | Overrides it | Any | `warn!`; global value wins |
+| Group locks field; repo overrides | ✓ | Valid | Yes | Locks `releases.draft` | Overrides it | `warn!`; group value wins |
+| `locked_fields` in repo dotfile | ✓ | Valid | No | — | Contains `locked_fields` | `warn!`; ignored |
+| Non-lockable in `locked_fields` | ✓ | `locked_fields = ["release_pr.title_template"]` | No | — | Valid | `warn!`; field not locked |
+| Group declared; group file absent | ✓ | Valid | "missing" | Absent | Valid | `warn!`; skip group; proceed |
+| `global.toml` invalid | ✓ | Invalid | No | — | Valid | `Err(CoreError::Config)` |
+| Group file invalid | ✓ | Valid | Yes | Invalid | Valid | `Err(CoreError::Config)` |
+| Repo dotfile invalid | ✓ | Valid | No | — | Invalid | `Err(CoreError::Config)` |
+| API 503 fetching global | ✓ | API 503 | No | — | Valid | `warn!`; use app + repo only |
+| Global cache hit (< 600 s) | ✓ | Cached | No | — | Valid | No API call for global |
+| Group cache hit (< 300 s) | ✓ | Valid | Yes | Cached | Valid | No API call for group |
+| Repo cache hit (< 300 s) | ✓ | Valid | No | — | Cached | No API call for repo |
+| CLI mode (`installation_id = None`) | — | — | — | — | — | Delegate entirely to `FileConfigurationProvider` |

--- a/docs/specs/interfaces/github_operations_additions.md
+++ b/docs/specs/interfaces/github_operations_additions.md
@@ -803,6 +803,20 @@ All fetch helpers return `Ok(None)` for absent files, `Err(CoreError::Config)` f
 content, and `Err(CoreError::GitHub)` for API errors. Parse/validation errors evict the
 relevant cache entry immediately.
 
+> **Probe order asymmetry (intentional)**: Metadata repo helpers probe TOML-first
+> (`global.toml`, `global.yml`, `global.yaml`) because TOML is the preferred format for
+> policy files authored by platform teams. The repo dotfile probes YAML-first
+> (`.release-regent.yml`, `.release-regent.yaml`, `.release-regent.toml`) because most
+> existing repository dotfiles in the wild use YAML. This asymmetry is deliberate.
+
+> **Metadata installation scope**: The `meta` client is scoped to the metadata repo
+> installation (`meta_id` from `resolve_metadata_installation`). This installation must
+> be an **org-level** GitHub App installation with access to all repositories in `{owner}`
+> — not one scoped only to `.release-regent`. If the installation is repo-scoped, the
+> `fetch_repo_dotfile` call using `&meta` will return `Err(403)`. The `None` branch
+> (no metadata repo) correctly uses `self.github.scoped_to(installation_id)` which is
+> the per-event repo installation and always has access to the target repository.
+
 ---
 
 ## 7. `merge_config_with_locks` contract
@@ -817,6 +831,16 @@ relevant cache entry immediately.
 /// Template and notification fields (never lockable) are always overridden.
 /// The mapping from struct fields to dotted paths is explicit and must be
 /// maintained in sync with `LOCKABLE_FIELDS`.
+///
+/// **Enforcement**: Add a compile-time assertion alongside `LOCKABLE_FIELDS` to
+/// prevent silent drift as the config struct evolves:
+/// ```rust
+/// const _: () = assert!(
+///     LOCKABLE_FIELDS.len() == 10,
+///     "Update merge_config_with_locks field checks when adding or removing lockable fields"
+/// );
+/// ```
+/// Update the count and the merge logic atomically whenever `LOCKABLE_FIELDS` changes.
 fn merge_config_with_locks(
     base: ReleaseRegentConfig,
     incoming: ReleaseRegentConfig,

--- a/docs/specs/interfaces/github_operations_additions.md
+++ b/docs/specs/interfaces/github_operations_additions.md
@@ -610,7 +610,14 @@ impl ConfigLocks {
                 );
                 continue;
             }
-            self.locked.insert(path.clone());
+            if self.locked.contains(path.as_str()) {
+                tracing::warn!(
+                    path = %path, level = %source_level,
+                    "field already locked by higher level; ignoring duplicate lock entry"
+                );
+            } else {
+                self.locked.insert(path.clone());
+            }
         }
     }
 
@@ -627,7 +634,9 @@ impl ConfigLocks {
 **File**: `crates/core/src/traits/configuration_provider.rs`
 
 Two new fields: `installation_id: Option<u64>` and `default_branch: Option<String>`.
-Callers in `crates/core/src/lib.rs` are unchanged.
+Existing call sites compile without modification because both fields are `Option<_>`, but
+they **must be updated** to populate `installation_id` and `default_branch` from the
+webhook payload for the new GitHub-sourced config levels to activate.
 
 ---
 
@@ -652,6 +661,12 @@ where
     group_cache: tokio::sync::RwLock<HashMap<String, (ReleaseRegentConfig, Instant)>>,
     /// "{owner}/{repo}" → (config, cached_at). TTL: 300 s.
     repo_cache: tokio::sync::RwLock<HashMap<String, (ReleaseRegentConfig, Instant)>>,
+    /// Validates each parsed config level using schema rules and custom constraints.
+    ///
+    /// Uses `release_regent_config_provider::ConfigValidator` (re-exported from
+    /// `crates/config_provider/src/validation.rs`). Constructed with
+    /// `ConfigValidator::new()` (permissive mode); switch to `ConfigValidator::strict()`
+    /// for stricter policy enforcement if desired.
     validator: ConfigValidator,
 }
 
@@ -696,36 +711,52 @@ async fn get_merged_config(
             let meta = self.github.scoped_to(meta_id);
 
             // Level 3: Global policy
-            match self.load_global_policy(owner, &meta).await {
+            let metadata_reachable = match self.load_global_policy(owner, &meta).await {
                 Ok(Some(g)) => {
                     locks.extend_from(&g.locked_fields, "global");
                     result = merge_config_with_locks(result, g, &locks);
+                    true
                 }
-                Ok(None) => {}
+                Ok(None) => true,
                 Err(e) if e.is_config_error() => return Err(e),
-                Err(e) => tracing::warn!(org=%owner, error=%e,
-                    "Metadata repo unreachable; skipping global+group levels"),
-            }
+                Err(e) => {
+                    tracing::warn!(org=%owner, error=%e,
+                        "Metadata repo unreachable; skipping global AND group levels");
+                    false
+                }
+            };
 
             // Peek repo dotfile to discover group name (fetched once, applied at level 5)
             let repo_result = self.fetch_repo_dotfile(owner, repo, default_branch, &meta).await;
 
-            // Level 4: Group policy
-            let group = repo_result.as_ref().ok()
-                .and_then(Option::as_ref)
-                .and_then(|c: &ReleaseRegentConfig| c.group.clone());
+            // Warn if dotfile fetch failed with a transient API error: group policy will
+            // not be applied (group name cannot be resolved) and the event will hard-fail
+            // at level 5. The warn gives operators a clear signal in the log.
+            if let Err(ref e) = repo_result {
+                if !e.is_config_error() {
+                    tracing::warn!(repo=%format!("{owner}/{repo}"), error=%e,
+                        "Transient API error fetching repo dotfile; group policy will not be applied");
+                }
+            }
 
-            if let Some(ref g) = group {
-                match self.load_group_policy(owner, g, &meta).await {
-                    Ok(Some(gc)) => {
-                        locks.extend_from(&gc.locked_fields, &format!("group:{g}"));
-                        result = merge_config_with_locks(result, gc, &locks);
+            // Level 4: Group policy (only when metadata repo was reachable)
+            if metadata_reachable {
+                let group = repo_result.as_ref().ok()
+                    .and_then(Option::as_ref)
+                    .and_then(|c: &ReleaseRegentConfig| c.group.clone());
+
+                if let Some(ref g) = group {
+                    match self.load_group_policy(owner, g, &meta).await {
+                        Ok(Some(gc)) => {
+                            locks.extend_from(&gc.locked_fields, &format!("group:{g}"));
+                            result = merge_config_with_locks(result, gc, &locks);
+                        }
+                        Ok(None) => tracing::warn!(org=%owner, group=%g,
+                            "Group '{g}' declared in {owner}/{repo} but no group config found; skipping"),
+                        Err(e) if e.is_config_error() => return Err(e),
+                        Err(e) => tracing::warn!(group=%g, error=%e,
+                            "Failed to load group policy; skipping group level"),
                     }
-                    Ok(None) => tracing::warn!(org=%owner, group=%g,
-                        "Group '{g}' declared in {owner}/{repo} but no group config found; skipping"),
-                    Err(e) if e.is_config_error() => return Err(e),
-                    Err(e) => tracing::warn!(group=%g, error=%e,
-                        "Failed to load group policy; skipping group level"),
                 }
             }
 
@@ -830,21 +861,24 @@ mock.with_installation_id("myorg", ".release-regent", 99001)
 
 // Seed global policy
 .with_file_content("myorg", ".release-regent", "global.toml", "main", r#"
+    locked_fields = ["versioning.strategy"]
+
     [versioning]
     strategy = "conventional"
-    locked_fields = ["versioning.strategy"]
 "#)
 
 // Seed group policy
 .with_file_content("myorg", ".release-regent", "groups/platform.toml", "main", r#"
+    locked_fields = ["releases.draft"]
+
     [releases]
     draft = true
-    locked_fields = ["releases.draft"]
 "#)
 
 // Seed repo dotfile
-.with_file_content("myorg", "platform-api", ".release-regent.yml", "main", r#"
+.with_file_content("myorg", "platform-api", ".release-regent.toml", "main", r#"
     group = "platform"
+
     [release_pr]
     title_template = "chore(release): ${version} [platform-api]"
 "#)

--- a/docs/specs/requirements/functional-requirements.md
+++ b/docs/specs/requirements/functional-requirements.md
@@ -180,8 +180,8 @@ Configuration is resolved in this order (later levels override earlier for unloc
   → `.release-regent.toml`; absence is not an error.
 - Locked fields at global/group level cannot be overridden by lower levels; violation
   causes a `warn!`, not a failure.
-- Template variables supported: `{version}`, `{version_tag}`, `{changelog}`,
-  `{commit_count}`, `{date}`.
+- Template variables supported: `${version}`, `${version_tag}`, `${changelog}`,
+  `${commit_count}`, `${date}`.
 - Separate in-memory caches per level (global: 600 s, group and repo: 300 s).
 - Parse or schema errors at any level fail the event; cache entry is evicted immediately.
 - CLI fallback: when `LoadOptions.installation_id` is `None`, all GitHub-sourced levels

--- a/docs/specs/requirements/functional-requirements.md
+++ b/docs/specs/requirements/functional-requirements.md
@@ -182,7 +182,8 @@ Configuration is resolved in this order (later levels override earlier for unloc
   causes a `warn!`, not a failure.
 - Template variables supported: `${version}`, `${version_tag}`, `${changelog}`,
   `${commit_count}`, `${date}`.
-- Separate in-memory caches per level (global: 600 s, group and repo: 300 s).
+- Separate in-memory caches per level (global: 600 s TTL, group and repo: 300 s TTL).
+  These are the normative TTL values; FR-8 references them.
 - Parse or schema errors at any level fail the event; cache entry is evicted immediately.
 - CLI fallback: when `LoadOptions.installation_id` is `None`, all GitHub-sourced levels
   are skipped; only app-level (local file) is used.
@@ -234,8 +235,9 @@ repositories in an organisation.
 **Acceptance Criteria**:
 
 - Global policy changes in the metadata repository take effect within 10 minutes
-  (600-second TTL) without server restart.
-- Group policy changes take effect within 5 minutes (300-second TTL) without server restart.
+  (600-second TTL, as defined in FR-6) without server restart.
+- Group policy changes take effect within 5 minutes (300-second TTL, as defined in FR-6)
+  without server restart.
 - A repository can change its group membership by updating `group` in its dotfile;
   the change takes effect within 5 minutes of the dotfile being merged.
 - An invalid metadata repository config (global or group) fails events for affected

--- a/docs/specs/requirements/functional-requirements.md
+++ b/docs/specs/requirements/functional-requirements.md
@@ -1,7 +1,7 @@
 # Functional Requirements
 
-**Last Updated**: 2025-07-19
-**Status**: Complete
+**Last Updated**: 2026-05-09
+**Status**: Updated — FR-6 revised and FR-8 added for enterprise config hierarchy (ADR-007)
 
 ## Core Functional Requirements
 
@@ -125,26 +125,70 @@
 
 ### FR-6: Configuration Management
 
-**Requirement**: The system must support flexible configuration at application and repository levels.
+**Requirement**: The system must support flexible, enterprise-grade configuration across
+five hierarchical levels with per-field policy locks.
 
 **Details**:
 
-- Load application-wide default configuration
-- Override with repository-specific configuration
-- Validate configuration before processing
-- Support template customization for PR titles and bodies
-- Provide clear error messages for invalid configuration
+Configuration is resolved in this order (later levels override earlier for unlocked fields):
+
+1. **Built-in defaults** — hard-coded in `ReleaseRegentConfig::default()`.
+2. **App-level** — `CONFIG_DIR/release-regent.yml` on local disk. Always present;
+   acts as bootstrap and fallback if higher GitHub-sourced levels are unavailable.
+3. **Global policy** — `{org}/.release-regent/global.toml` in the metadata repository.
+   Org-wide defaults and field locks set by platform teams. Optional.
+4. **Group policy** — `{org}/.release-regent/groups/{group}.toml` in the metadata
+   repository. Applies to all repositories that declare `group = "{group}"` in their
+   dotfile. Optional.
+5. **Repository config** — `.release-regent.yml` (or `.yaml` / `.toml`) in the target
+   repository root on its default branch. Optional; fetched via GitHub API at
+   event-processing time.
+
+**Per-field locks**:
+
+- Global and group policy files may include `locked_fields = ["versioning.strategy", ...]`.
+- A locked field cannot be overridden by any lower level.
+- Only designated policy fields are lockable (see [ADR-007](../../adr/ADR-007-enterprise-config-hierarchy.md)).
+  Template and notification fields are never lockable.
+- Locks accumulate downward; a lower level cannot remove a lock set above it.
+- A lower level specifying a value for a locked field is silently ignored with a
+  `warn!`; the event is **not** failed.
+- `locked_fields` in repository dotfiles is silently ignored with a `warn!`.
+
+**Group membership**:
+
+- A repository declares its group with a top-level `group = "name"` field in its dotfile.
+- The provider fetches the corresponding group policy file from the metadata repository.
+- A declared group with no corresponding group policy file causes a `warn!` and skips
+  the group level (not an error).
+
+**Fallback behaviour**:
+
+- If the metadata repository is unreachable (App not installed, API error), the provider
+  falls back to app-level as the effective top of the hierarchy; a `warn!` is emitted.
+- Absent files at any optional level are not errors; that level is silently skipped.
+- Present but invalid files (parse error or schema violation) are hard failures.
 
 **Acceptance Criteria**:
 
-- Configuration loaded from YAML files
-- Repository config overrides application defaults
-- Template variables supported: `{version}`, `{version_tag}`, `{changelog}`, `{commit_count}`, `{date}`
-- Configuration validation prevents runtime errors
-- Invalid configuration reports specific field errors with guidance
+- App-level config always loaded from `CONFIG_DIR/release-regent.yml` (required at startup).
+- Global policy fetched from `{org}/.release-regent/global.toml` via GitHub API when
+  the App is installed on the metadata repository.
+- Group policy fetched from `{org}/.release-regent/groups/{group}.toml` when repo
+  declares `group`; absence of the group file is a warn-and-skip, not an error.
+- Repository dotfile fetched in probe order: `.release-regent.yml` → `.release-regent.yaml`
+  → `.release-regent.toml`; absence is not an error.
+- Locked fields at global/group level cannot be overridden by lower levels; violation
+  causes a `warn!`, not a failure.
+- Template variables supported: `{version}`, `{version_tag}`, `{changelog}`,
+  `{commit_count}`, `{date}`.
+- Separate in-memory caches per level (global: 600 s, group and repo: 300 s).
+- Parse or schema errors at any level fail the event; cache entry is evicted immediately.
+- CLI fallback: when `LoadOptions.installation_id` is `None`, all GitHub-sourced levels
+  are skipped; only app-level (local file) is used.
 
 **Priority**: High
-**Status**: ✅ Complete
+**Status**: 🚧 In Progress (see [ADR-007](../../adr/ADR-007-enterprise-config-hierarchy.md))
 
 ### FR-7: CLI Operations
 
@@ -168,6 +212,42 @@
 
 **Priority**: Medium
 **Status**: ✅ Complete
+
+### FR-8: Enterprise Configuration Governance
+
+**Requirement**: The system must support organisation-level policy enforcement through
+a metadata repository, allowing platform teams to set non-overridable defaults for all
+repositories in an organisation.
+
+**Details**:
+
+- Metadata repository (`{org}/.release-regent`) holds global and group policy files.
+- Platform teams manage the metadata repository through standard git workflows (PRs,
+  branch protection, CODEOWNERS).
+- Release Regent does not enforce authorship of changes to the metadata repository;
+  this is delegated to GitHub branch protection rules.
+- Repository groups allow shared policy for sets of related repositories without
+  duplicating configuration in each repository.
+- Policy locks allow platform teams to prevent individual repositories from changing
+  specific settings (e.g. versioning strategy, release draft status).
+
+**Acceptance Criteria**:
+
+- Global policy changes in the metadata repository take effect within 10 minutes
+  (600-second TTL) without server restart.
+- Group policy changes take effect within 5 minutes (300-second TTL) without server restart.
+- A repository can change its group membership by updating `group` in its dotfile;
+  the change takes effect within 5 minutes of the dotfile being merged.
+- An invalid metadata repository config (global or group) fails events for affected
+  repositories with a clear error identifying the offending file and field.
+- Locked fields in global policy cannot be overridden by group or repository config;
+  violations cause `warn!` logs identifying the repository and field.
+- `locked_fields` lists in repository dotfiles are silently ignored with `warn!`.
+- Non-lockable fields (templates, notifications) in any `locked_fields` list are
+  silently ignored with `warn!`.
+
+**Priority**: High
+**Status**: 🚧 In Progress (see [ADR-007](../../adr/ADR-007-enterprise-config-hierarchy.md))
 
 ## Data Processing Requirements
 

--- a/docs/specs/requirements/user-stories.md
+++ b/docs/specs/requirements/user-stories.md
@@ -1,7 +1,7 @@
 # User Stories & Personas
 
-**Last Updated**: 2025-07-19
-**Status**: Complete
+**Last Updated**: 2026-05-09
+**Status**: Updated — US-6 revised and US-9 added for enterprise config hierarchy (ADR-007)
 
 ## User Personas
 
@@ -163,20 +163,34 @@
 **Priority**: Medium
 **Status**: Future Enhancement
 
-### US-6: Configuration Management
+### US-6: Repository Configuration Management
 
-**As** the DevOps team, **I want** to configure Release Regent behavior per repository **so that** different projects can have appropriate release processes.
+**As** the DevOps team, **I want** to configure Release Regent behaviour per repository
+**so that** different projects can have appropriate release processes without requiring
+server re-deployment.
 
 **Acceptance Criteria**:
 
-- Repository-specific configuration overrides
-- Template customization for PR titles and bodies
-- Configurable versioning strategies
-- Validation of configuration before processing
-- Clear error messages for invalid configuration
+- Adding a `.release-regent.yml` file to the root of a repository is sufficient to supply
+  per-repository configuration; no server re-deployment is required.
+- Repository config is read from the repository’s default branch on each webhook event
+  (subject to a 5-minute TTL cache), so configuration changes take effect within
+  5 minutes of merging them.
+- Repository-specific configuration overrides app-level and global policy defaults for
+  fields that are not locked.
+- Absence of a `.release-regent.yml` in the repository is not an error; the resolved
+  defaults from higher levels (app / global / group) apply.
+- Template customisation for PR titles and bodies is always available at the repo level
+  regardless of any locks set at higher levels.
+- Configurable versioning strategies per repository (subject to `versioning.strategy`
+  not being locked globally).
+- Validation of configuration before processing; parse errors or schema violations in the
+  repository dotfile produce a clear error on the event and do not silently fall back.
+- A repository can declare its group membership with `group = "name"` in the dotfile;
+  the corresponding group policy is applied transparently.
 
 **Priority**: Medium
-**Status**: Complete
+**Status**: 🚧 In Progress (see [ADR-007](../../adr/ADR-007-enterprise-config-hierarchy.md))
 
 ### US-7: CLI Testing
 
@@ -207,6 +221,37 @@
 
 **Priority**: Medium
 **Status**: Complete
+
+### US-9: Enterprise Configuration Governance
+
+**As** the platform engineering team, **I want** to enforce organisation-wide release
+policies that individual repositories cannot override **so that** compliance and
+consistency requirements are met across a large repository estate.
+
+**Acceptance Criteria**:
+
+- A single metadata repository (`{org}/.release-regent`) holds all org-level policy;
+  no per-repository changes or server re-deployments are needed to apply a policy change.
+- Global policy (`global.toml`) sets defaults and locks for the entire organisation;
+  changes take effect within 10 minutes of merging without server restart.
+- Locking a field in `global.toml` (e.g. `locked_fields = ["versioning.strategy"]`)
+  prevents **any** repository in the org from overriding that field, silently using the
+  locked value and logging a `warn!` if a lower level tries to set it differently.
+- Only designated policy fields are lockable; template and notification fields are
+  **always** customisable by individual repositories regardless of global policy.
+- Group policies (`groups/{name}.toml`) allow shared defaults for sets of related
+  repositories (e.g. all services in the `platform` group get `releases.draft = true`).
+- A repository joins a group by adding `group = "name"` to its dotfile; no central
+  membership file needs updating.
+- A declared group with no corresponding group policy file is a `warn!`, not an error;
+  the event is processed normally using global defaults.
+- An invalid `global.toml` or group policy file produces a clear error identifying the
+  offending file and field, making remediation straightforward.
+- Release Regent does not validate who merged changes to the metadata repository;
+  authorship control is delegated to GitHub branch protection and CODEOWNERS.
+
+**Priority**: High
+**Status**: 🚧 In Progress (see [ADR-007](../../adr/ADR-007-enterprise-config-hierarchy.md))
 
 ## User Journey Maps
 

--- a/docs/specs/testing/behavioral-assertions.md
+++ b/docs/specs/testing/behavioral-assertions.md
@@ -1,7 +1,7 @@
 # Behavioral Assertions
 
-**Last Updated**: 2025-07-19
-**Status**: Complete - Addresses Spec Feedback
+**Last Updated**: 2026-05-09
+**Status**: Updated — enterprise config hierarchy assertions added (ADR-007)
 
 ## Overview
 
@@ -484,3 +484,416 @@ Each behavioral assertion can be verified through:
 - Validate release metadata and notes
 
 This comprehensive set of behavioral assertions provides clear, testable specifications for Release Regent that address all the gaps identified in the spec feedback while maintaining implementation independence.
+
+## Repository Configuration Source Assertions
+
+These assertions define behaviour for `GitHubConfigurationProvider` — the component that
+resolves configuration across five levels. See
+[ADR-007](../../adr/ADR-007-enterprise-config-hierarchy.md) and
+[FR-6/FR-8](../requirements/functional-requirements.md).
+
+### Config File Resolution
+
+**BA-36**: A repository that contains `.release-regent.yml` in its root on the default
+branch must have that file used as its per-repository configuration, overriding global
+defaults.
+
+*Preconditions*: `.release-regent.yml` exists at the root of the default branch of
+`myorg/my-repo`; its content specifies `versioning.strategy = "external"`.
+
+*Sequence*: A merge event arrives for `myorg/my-repo`.
+
+*Expected*:
+
+- `get_file_content("myorg", "my-repo", ".release-regent.yml", default_branch)` is called.
+- The returned content is parsed as YAML.
+- `get_merged_config` returns a config with `versioning.strategy = External`.
+- The global default strategy is **not** used.
+
+**BA-37**: When none of `.release-regent.yml`, `.release-regent.yaml`, or
+`.release-regent.toml` exist in the repository root, the global defaults must be used
+without raising an error.
+
+*Preconditions*: None of the three probe paths return a file for `myorg/vanilla-repo`.
+
+*Expected*:
+
+- `get_file_content` is called for `.release-regent.yml`, then `.release-regent.yaml`,
+  then `.release-regent.toml` in that order; each returns `Ok(None)`.
+- `load_repository_config` returns `Ok(None)`.
+- `get_merged_config` returns the global config unchanged.
+- No error is propagated; the event is processed normally.
+
+**BA-38**: Probe order must be strictly: `.release-regent.yml` → `.release-regent.yaml`
+→ `.release-regent.toml`. The first file found wins; remaining probes are skipped.
+
+*Preconditions*: Both `.release-regent.yml` and `.release-regent.toml` exist in the repo.
+
+*Expected*:
+
+- `get_file_content` is called for `.release-regent.yml` and returns `Ok(Some(…))`.
+- `get_file_content` is **not** called for `.release-regent.yaml` or `.release-regent.toml`.
+- The `.release-regent.yml` content is used.
+
+**BA-39**: A repository dotfile with a parse error (invalid YAML/TOML) must fail the event
+with `CoreError::Config`; it must **not** silently fall back to global defaults.
+
+*Preconditions*: `.release-regent.yml` in `myorg/broken-repo` contains invalid YAML
+(e.g., `versioning: : bad`).
+
+*Expected*:
+
+- File content is fetched successfully.
+- Parsing fails.
+- `load_repository_config` returns `Err(CoreError::Config(…))`.
+- The event processing fails; the error includes the repository name and parse details.
+- No version calculation or PR operation is attempted.
+
+**BA-40**: A repository dotfile that fails schema validation (required field missing,
+value out of range) must fail the event with `CoreError::Config`, not fall back to
+global defaults.
+
+*Preconditions*: `.release-regent.yml` in `myorg/invalid-config-repo` is valid YAML but
+specifies an unknown versioning strategy (`versioning.strategy = "magic"`).
+
+*Expected*:
+
+- File is fetched and parsed successfully.
+- Validation fails.
+- `load_repository_config` returns `Err(CoreError::Config(…))`.
+- The event processing fails with a description of the validation error.
+
+### Error Handling
+
+**BA-41**: A non-404 GitHub API error during config file fetch (e.g., HTTP 503, network
+timeout) must propagate as `CoreError::GitHub` and fail the event. The standard retry
+policy applies.
+
+*Preconditions*: GitHub API returns HTTP 503 when fetching `.release-regent.yml`.
+
+*Expected*:
+
+- `get_file_content` returns `Err(CoreError::GitHub(…))`.
+- `load_repository_config` propagates the error.
+- The event fails and is eligible for retry (transient error category per error-handling spec).
+- The cache entry for `myorg/repo` is **not** updated.
+
+**BA-42**: A parse or validation error must invalidate any existing cache entry for the
+repository so that a corrected dotfile is picked up on the very next event.
+
+*Preconditions*: A valid cache entry exists for `myorg/my-repo` (from a previous event).
+Then the dotfile is changed to contain invalid YAML.
+
+*Sequence*: A new event arrives after the TTL has expired and the invalidated file is
+fetched.
+
+*Expected*:
+
+- The stale cache entry is not used after TTL expiry.
+- The new fetch sees the invalid YAML.
+- The event fails with `CoreError::Config`.
+- The cache entry for `myorg/my-repo` is cleared (not updated with the invalid result).
+- A subsequent event, once the YAML is fixed, fetches and caches the corrected config.
+
+### Caching
+
+**BA-43**: Within the 300-second TTL window, a second event for the same repository must
+use the cached config and must not issue a second `get_file_content` call.
+
+*Preconditions*: First event for `myorg/cached-repo` fetches and caches the config.
+Second event arrives 30 seconds later (within TTL).
+
+*Expected*:
+
+- `get_file_content` is called exactly once across both events.
+- Both events use identical configuration values.
+
+**BA-44**: After the 300-second TTL expires, the next event for that repository must
+re-fetch the dotfile via the GitHub API.
+
+*Preconditions*: Config was cached at T=0. Next event arrives at T=301.
+
+*Expected*:
+
+- `get_file_content` is called again at T=301.
+- If the file has changed since T=0, the new content is used.
+
+### `LoadOptions` Contract
+
+**BA-45**: When `LoadOptions.installation_id` is `None` (CLI mode), `load_repository_config`
+must not make any GitHub API call. It must fall back to searching `CONFIG_DIR` for a
+local file named `{owner}-{repo}.yaml` (or `.yml` / `.toml`).
+
+*Preconditions*: CLI invokes `get_merged_config("myorg", "my-repo", LoadOptions::default())`;
+no local file exists in `CONFIG_DIR`.
+
+*Expected*:
+
+- No `get_file_content` call is made.
+- `load_repository_config` returns `Ok(None)`.
+- Global defaults are used.
+
+**BA-46**: When `LoadOptions.installation_id` is `Some(id)`, the provider must scope the
+GitHub client to that installation before fetching the config file.
+
+*Preconditions*: Event for installation `42345` of `myorg/my-repo` triggers config load.
+
+*Expected*:
+
+- `github_client.scoped_to(42345)` is called before `get_file_content`.
+- `get_file_content` is called on the scoped client, not the root client.
+
+**BA-47**: When `LoadOptions.default_branch` is `None`, the provider must fall back to
+`"main"` as the ref for `get_file_content`.
+
+*Preconditions*: `LoadOptions { installation_id: Some(42345), default_branch: None, … }`.
+
+*Expected*:
+
+- `get_file_content(…, "main")` is called.
+
+*Note*: Callers should always populate `default_branch` from the webhook payload when
+available; this fallback exists only as a safety net.
+
+### App-Level Fallback
+
+**BA-48**: When no metadata repository is accessible for an org (App not installed,
+network error, or repository absent), the provider must use only the app-level config
+(local `CONFIG_DIR/release-regent.yml`) as the effective top of the hierarchy, emit a
+`warn!`, and continue processing the event.
+
+*Preconditions*: `myorg/.release-regent` does not exist or the App is not installed on it.
+
+*Expected*:
+
+- `get_installation_id_for_repo("myorg", ".release-regent")` returns an error or `None`.
+- A `warn!` is emitted identifying the org and reason.
+- The merge proceeds using only app-level + repo dotfile (if present).
+- The event is **not** failed.
+
+**BA-49**: The app-level config (local `CONFIG_DIR/release-regent.yml`) must always be
+loaded as the second level in the merge, regardless of metadata repo availability.
+
+*Preconditions*: Both `CONFIG_DIR/release-regent.yml` and `myorg/.release-regent/global.toml`
+exist and are valid.
+
+*Expected*:
+
+- App-level is loaded first.
+- Global policy is merged on top, overriding unlocked app-level fields.
+- The resulting config reflects global policy values for fields present in `global.toml`.
+
+## Global Policy Assertions
+
+**BA-50**: An org with a valid `global.toml` in its metadata repository must have those
+settings applied to all repositories in the org that do not have conflicting locked fields.
+
+*Preconditions*: `myorg/.release-regent/global.toml` sets `versioning.strategy = "external"`;
+`myorg/repo-a` has no dotfile; `myorg/repo-b` has a dotfile that sets `versioning.strategy = "conventional"`.
+
+*Expected for `myorg/repo-a`*: effective strategy is `external` (global policy applied).
+*Expected for `myorg/repo-b`*: effective strategy is `conventional` (repo overrides unlocked field).
+
+**BA-51**: A valid `global.toml` that cannot be parsed (invalid TOML/YAML) must hard-fail
+all events for repositories in that org.
+
+*Preconditions*: `myorg/.release-regent/global.toml` contains a syntax error.
+
+*Expected*:
+
+- `load_global_policy("myorg")` returns `Err(CoreError::Config)`.
+- The event processing fails with a message identifying the offending file.
+- No version calculation or PR operation is attempted.
+- The global policy cache entry for `myorg` is **not** updated.
+
+**BA-52**: An absent `global.toml` (file not found) must skip the global level silently
+without error.
+
+*Preconditions*: `myorg/.release-regent` exists and the App is installed, but `global.toml`
+is absent.
+
+*Expected*:
+
+- `get_file_content(…, "global.toml", …)` returns `Ok(None)`.
+- No error is propagated.
+- Merge continues with app-level → group (if applicable) → repo.
+
+**BA-53**: The global policy cache must expire after 600 seconds. Within the TTL, a
+second event for any repo in the same org must not re-fetch `global.toml`.
+
+*Preconditions*: First event for any repo in `myorg` fetches and caches `global.toml`.
+Second event for a different repo in `myorg` arrives 60 seconds later.
+
+*Expected*:
+
+- `get_file_content` for `global.toml` is called exactly once across both events.
+- Both events use the same global policy values.
+
+## Group Policy Assertions
+
+**BA-54**: A repository dotfile declaring `group = "platform"` must cause the provider to
+fetch `{org}/.release-regent/groups/platform.toml` and apply it between global policy
+and the repo dotfile.
+
+*Preconditions*: `myorg/.release-regent/groups/platform.toml` exists and sets
+`releases.draft = true`. `myorg/platform-api/.release-regent.yml` declares
+`group = "platform"` and does not set `releases.draft`.
+
+*Expected*:
+
+- `get_file_content(…, "groups/platform.toml", …)` is called.
+- Effective config has `releases.draft = true` (from group policy).
+
+**BA-55**: A repository dotfile declaring `group = "engineering"` when
+`groups/engineering.toml` does not exist must emit a `warn!`, skip the group level, and
+continue processing normally.
+
+*Preconditions*: `myorg/.release-regent/groups/engineering.toml` is absent.
+
+*Expected*:
+
+- `get_file_content` for the group file returns `Ok(None)`.
+- A `warn!` is emitted: `"Group 'engineering' declared in myorg/some-repo but no group config found"`.
+- The merge continues with global policy → repo dotfile.
+- The event is **not** failed.
+
+**BA-56**: A repository dotfile that does not declare `group` must not trigger any group
+policy fetch.
+
+*Preconditions*: `myorg/ungrouped-repo/.release-regent.yml` has no `group` field.
+
+*Expected*:
+
+- `get_file_content` is **not** called for any path under `groups/`.
+
+**BA-57**: An invalid group policy file (present but unparseable) must hard-fail events
+for repositories in that group.
+
+*Preconditions*: `myorg/.release-regent/groups/broken.toml` contains invalid TOML.
+`myorg/repo-x/.release-regent.yml` declares `group = "broken"`.
+
+*Expected*:
+
+- `load_group_config("myorg", "broken")` returns `Err(CoreError::Config)`.
+- The event for `myorg/repo-x` fails with a clear error.
+- The group policy cache entry for `myorg/broken` is **not** populated.
+
+**BA-58**: The group policy cache must expire after 300 seconds per group name within an org.
+
+*Preconditions*: Two repos both in group `"platform"` generate events 30 seconds apart.
+
+*Expected*:
+
+- `get_file_content` for `groups/platform.toml` is called exactly once.
+- Both events use the same group policy values.
+
+## Lock Assertion Assertions
+
+**BA-59**: A field listed in `global.toml`'s `locked_fields` must not be overridable by
+group policy.
+
+*Preconditions*:
+
+- `global.toml` sets `versioning.strategy = "conventional"` with
+  `locked_fields = ["versioning.strategy"]`.
+- `groups/mobile.toml` sets `versioning.strategy = "external"`.
+- `myorg/mobile-app/.release-regent.yml` declares `group = "mobile"`.
+
+*Expected*:
+
+- Effective `versioning.strategy` is `"conventional"` (global lock wins).
+- A `warn!` is emitted identifying the field, the locked value, and the level that
+  attempted the override.
+- The event is **not** failed.
+
+**BA-60**: A field listed in `global.toml`'s `locked_fields` must not be overridable by
+a repository dotfile.
+
+*Preconditions*:
+
+- `global.toml` has `locked_fields = ["versioning.allow_override"]` and
+  `versioning.allow_override = false`.
+- `myorg/some-repo/.release-regent.yml` sets `versioning.allow_override = true`.
+
+*Expected*:
+
+- Effective `versioning.allow_override` is `false` (global lock wins).
+- A `warn!` is emitted.
+- The event is **not** failed.
+
+**BA-61**: A field listed in a group policy's `locked_fields` must not be overridable by
+a repository dotfile, provided global did not already lock a different value.
+
+*Preconditions*:
+
+- `global.toml` does **not** lock `releases.draft`.
+- `groups/platform.toml` sets `releases.draft = true` with
+  `locked_fields = ["releases.draft"]`.
+- `myorg/platform-api/.release-regent.yml` declares `group = "platform"` and sets
+  `releases.draft = false`.
+
+*Expected*:
+
+- Effective `releases.draft` is `true` (group lock wins).
+- A `warn!` is emitted.
+
+**BA-62**: A group policy must not be able to remove a lock set by global policy.
+
+*Preconditions*:
+
+- `global.toml` has `locked_fields = ["versioning.strategy"]`.
+- `groups/frontend.toml` does **not** list `versioning.strategy` in its own
+  `locked_fields`, and sets `versioning.strategy = "external"`.
+
+*Expected*:
+
+- `versioning.strategy` remains locked (global lock cannot be removed).
+- `groups/frontend.toml`'s value for `versioning.strategy` is silently discarded.
+- A `warn!` is emitted.
+
+**BA-63**: A non-lockable field (e.g. `release_pr.title_template`) listed in a
+`locked_fields` array must be silently ignored with a `warn!`; it must not be treated
+as a real lock.
+
+*Preconditions*:
+
+- `global.toml` sets `locked_fields = ["release_pr.title_template"]`.
+- `myorg/some-repo/.release-regent.yml` sets
+  `release_pr.title_template = "custom: ${version}"`.
+
+*Expected*:
+
+- `release_pr.title_template` is **not** locked.
+- The repo's `title_template` value is used.
+- A `warn!` is emitted for the invalid lock path.
+
+**BA-64**: A `locked_fields` array present in a repository dotfile must be silently
+ignored with a `warn!`; it must not affect the active lock set.
+
+*Preconditions*:
+
+- `myorg/some-repo/.release-regent.yml` contains
+  `locked_fields = ["versioning.strategy"]`.
+
+*Expected*:
+
+- `versioning.strategy` is **not** locked (repo dotfiles cannot add locks).
+- A `warn!` is emitted.
+- All other fields in the repo dotfile are applied normally.
+
+**BA-65**: Lock accumulation is additive: group policy may add new locks to fields that
+global did not lock; the combined lock set applies for the repo dotfile step.
+
+*Preconditions*:
+
+- `global.toml` has `locked_fields = ["versioning.strategy"]`.
+- `groups/backend.toml` has `locked_fields = ["releases.draft"]` (a different field).
+- `myorg/backend-api/.release-regent.yml` declares `group = "backend"` and sets
+  both `versioning.strategy = "external"` and `releases.draft = false`.
+
+*Expected*:
+
+- Active locks after group merge: `{"versioning.strategy", "releases.draft"}`.
+- `versioning.strategy` is locked to global's value.
+- `releases.draft` is locked to group's value (`true`).
+- Both override attempts in the repo dotfile are silently discarded with `warn!`.

--- a/docs/specs/testing/behavioral-assertions.md
+++ b/docs/specs/testing/behavioral-assertions.md
@@ -787,7 +787,7 @@ for repositories in that group.
 - `get_file_content` for `groups/platform.toml` is called exactly once.
 - Both events use the same group policy values.
 
-## Lock Assertion Assertions
+## Lock Assertions
 
 **BA-59**: A field listed in `global.toml`'s `locked_fields` must not be overridable by
 group policy.

--- a/docs/specs/testing/behavioral-assertions.md
+++ b/docs/specs/testing/behavioral-assertions.md
@@ -706,6 +706,24 @@ all events for repositories in that org.
 - No version calculation or PR operation is attempted.
 - The global policy cache entry for `myorg` is **not** updated.
 
+**BA-51a**: A previously valid `global.toml` that becomes invalid after TTL expiry must
+evict the stale cache entry; the stale (valid) config must not continue to be served.
+
+*Preconditions*:
+
+- First event for `myorg` fetches and caches a valid `global.toml` with
+  `versioning.strategy = "conventional"`.
+- 601 seconds later (TTL expired), `global.toml` is replaced with an invalid file
+  (TOML syntax error).
+- A second event for any repo in `myorg` arrives after the TTL has expired.
+
+*Expected*:
+
+- `load_global_policy` re-fetches (cache expired); `parse_and_validate` fails.
+- The stale cache entry is evicted — not retained.
+- The second event fails with `Err(CoreError::Config)` identifying the offending file.
+- A subsequent event after the file is corrected re-fetches and caches the corrected config.
+
 **BA-52**: An absent `global.toml` (file not found) must skip the global level silently
 without error.
 


### PR DESCRIPTION
Adds ADR-007 and updates all related specification documents to define a five-level
configuration hierarchy that supports enterprise-grade policy enforcement across large
repository estates.

## What Changed

- `docs/adr/ADR-007-enterprise-config-hierarchy.md` — new ADR defining the hierarchy,
  lock semantics, metadata repository structure, group membership model, caching
  strategy, and merge algorithm
- `docs/specs/architecture/overview.md` — updated container diagram and configuration
  provider section for five-level resolution
- `docs/specs/interfaces/github_operations_additions.md` — full interface spec for
  `GitHubConfigurationProvider`: struct layout, `ConfigLocks` type, `LOCKABLE_FIELDS`
  allowlist, `get_merged_config` pseudocode, internal helpers, server wiring, mock
  seeding API, and a 17-scenario test matrix
- `docs/specs/requirements/functional-requirements.md` — FR-6 revised for the five-level
  model; FR-8 (Enterprise Configuration Governance) added
- `docs/specs/requirements/user-stories.md` — US-6 revised; US-9 (Enterprise
  Configuration Governance) added; US ordering corrected (US-8 before US-9)
- `docs/specs/testing/behavioral-assertions.md` — BA-48 through BA-65 added covering
  app-level fallback, global policy, group policy, and lock accumulation behaviour

## Why

The existing two-level model (app-level local config → repo dotfile) has no mechanism
for a platform team to enforce organisation-wide policy or share defaults across groups
of repositories. Large deployments need policy locks, group-level inheritance, and a
git-auditable central policy store without requiring server re-deployments to apply
configuration changes.

## How

The hierarchy resolves five levels in order (each merges over the previous for unlocked
fields only):

1. Built-in defaults
2. App-level — `CONFIG_DIR/release-regent.yml` on local disk
3. Global policy — `{org}/.release-regent/global.toml` fetched via GitHub Contents API
4. Group policy — `{org}/.release-regent/groups/{group}.toml`, where a repo declares
   its group via `group = "name"` in its dotfile
5. Repository dotfile — `.release-regent.yml` in the target repo root

Policy fields can be locked at global or group level via `locked_fields`; lower levels
that conflict are silently overridden with a `warn!`. Non-lockable fields (templates,
notifications) are always overridable. Global policy is cached for 600 s; group and repo
configs for 300 s. A missing group policy file is a warning, not a hard failure.

## Testing Evidence

- **Test Coverage:** BA-48 through BA-65 define 18 new behavioral assertions covering
  all levels, lock accumulation, warn-and-skip paths, invalid config hard-fail paths,
  and cache hit scenarios. The 17-scenario test matrix in the interface spec maps each
  scenario to expected `GitHubConfigurationProvider` behaviour.
- **Test Results:** Specification only — no implementation code in this PR.
- **Manual Testing:** N/A — this PR contains only ADR and specification documents.

## Reviewer Guidance

- Review lock accumulation semantics in ADR-007 §"merge_with_locks semantics" — the
  rule that locks can only be added (never removed) as levels are resolved is the core
  invariant; verify the pseudocode reflects this correctly.
- Review `LOCKABLE_FIELDS` allowlist in the interface spec — these are the only paths a
  global or group policy may lock; confirm no policy-relevant fields are missing and no
  template/notification fields are included.
- The group membership model (repos self-declare via dotfile; no central membership
  file) is an explicit design choice — flag if compliance requirements demand a
  centrally-authoritative membership registry instead.
- The metadata repository is auto-discovered as `{org}/.release-regent`; confirm this
  naming convention won't conflict with any existing repositories in target organisations.
- No breaking changes — this is specification only; implementation is a separate task.