### PR TITLE
fix(core): use version_prefix config for base_ref instead of hardcoded v

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -494,7 +494,9 @@ where
             };
 
             let ctx = VersionContext {
-                base_ref: current_version.as_ref().map(|v| format!("v{v}")),
+                base_ref: current_version
+                    .as_ref()
+                    .map(|v| format!("{}{v}", repo_config.core.version_prefix)),
                 current_version: current_version.clone(),
                 head_ref: pr_head_sha,
                 owner: owner.to_string(),
@@ -1017,7 +1019,9 @@ where
             versioning::resolve_current_version(&scoped_github, owner, repo, false).await?;
 
         let ctx = VersionContext {
-            base_ref: current_version.as_ref().map(|v| format!("v{v}")),
+            base_ref: current_version
+                .as_ref()
+                .map(|v| format!("{}{v}", repo_config.core.version_prefix)),
             current_version: current_version.clone(),
             head_ref: base_sha.to_string(),
             owner: owner.to_string(),
@@ -1541,7 +1545,9 @@ where
             }
 
             let ctx = VersionContext {
-                base_ref: current_version.as_ref().map(|v| format!("v{v}")),
+                base_ref: current_version
+                    .as_ref()
+                    .map(|v| format!("{}{v}", repo_config.core.version_prefix)),
                 current_version: current_version.clone(),
                 head_ref: pr.head.sha.clone(),
                 owner: owner.to_string(),

--- a/crates/core/src/lib_tests.rs
+++ b/crates/core/src/lib_tests.rs
@@ -1311,6 +1311,7 @@ struct TestVersionCalcForLib {
     next_version: SemanticVersion,
     changelog_entries: Vec<ChangelogEntry>,
     version_bump: VersionBump,
+    captured_ctx: Arc<Mutex<Option<VersionContext>>>,
 }
 
 impl TestVersionCalcForLib {
@@ -1319,6 +1320,7 @@ impl TestVersionCalcForLib {
             next_version: versioning::VersionCalculator::parse_version(version).unwrap(),
             changelog_entries: vec![],
             version_bump: VersionBump::Minor,
+            captured_ctx: Arc::new(Mutex::new(None)),
         }
     }
 
@@ -1331,6 +1333,10 @@ impl TestVersionCalcForLib {
         self.version_bump = bump;
         self
     }
+
+    async fn last_context(&self) -> Option<VersionContext> {
+        self.captured_ctx.lock().await.clone()
+    }
 }
 
 #[async_trait]
@@ -1341,6 +1347,7 @@ impl VersionCalculator for TestVersionCalcForLib {
         _strategy: VCalcStrategy,
         _options: CalculationOptions,
     ) -> CoreResult<VersionCalculationResult> {
+        *self.captured_ctx.lock().await = Some(ctx.clone());
         Ok(VersionCalculationResult {
             next_version: self.next_version.clone(),
             current_version: ctx.current_version,
@@ -1433,6 +1440,7 @@ impl VersionCalculator for TestVersionCalcForLib {
             next_version: self.next_version.clone(),
             changelog_entries: self.changelog_entries.clone(),
             version_bump: self.version_bump.clone(),
+            captured_ctx: Arc::clone(&self.captured_ctx),
         })
     }
 }
@@ -2904,5 +2912,111 @@ async fn test_feature_pr_opened_with_queued_release_includes_annotation() {
     assert!(
         body.contains("already open"),
         "comment must note the queued release PR is open; got: {body}"
+    );
+}
+
+/// Regression test: when `version_prefix` is empty and the latest tag has no
+/// prefix (e.g. `0.5.0`), the `base_ref` passed to the version calculator must
+/// be `"0.5.0"` — not `"v0.5.0"`.
+///
+/// Before the fix, the code used `format!("v{v}")`, which hardcoded the `v`
+/// prefix regardless of configuration, causing GitHub's compare API to return
+/// 404 for bare-semver repositories.
+#[tokio::test]
+async fn test_feature_pr_opened_uses_version_prefix_for_base_ref_when_prefix_is_empty() {
+    let tag = GitTag {
+        name: "0.5.0".to_string(),
+        target_sha: "a".repeat(40),
+        tag_type: GitTagType::Lightweight,
+        message: None,
+        tagger: None,
+        created_at: None,
+    };
+
+    let mut cfg = config::ReleaseRegentConfig::default();
+    cfg.core.version_prefix = String::new();
+
+    let github = TestGitHubForLib::new_empty().with_tags(vec![tag]);
+    let config = TestConfigWith::new(cfg);
+    let version_calc = TestVersionCalcForLib::returning("0.6.0");
+    let processor = ReleaseRegentProcessor::new(github.clone(), config, version_calc.clone());
+
+    let event = ProcessingEvent {
+        event_id: "prefix-empty-1".into(),
+        correlation_id: "corr-prefix-empty-1".into(),
+        event_type: EventType::PullRequestOpened,
+        repository: test_repo(),
+        payload: make_pr_activity_payload(10, "deadbeef1234", "feat/new-feature", "alice"),
+        received_at: Utc::now(),
+        source: EventSourceKind::Webhook,
+        installation_id: 0,
+    };
+
+    processor
+        .handle_pull_request_activity(&event)
+        .await
+        .expect("handle_pull_request_activity should succeed");
+
+    let ctx = version_calc
+        .last_context()
+        .await
+        .expect("calculate_version must have been called");
+
+    assert_eq!(
+        ctx.base_ref.as_deref(),
+        Some("0.5.0"),
+        "base_ref must not get a hardcoded 'v' prefix when version_prefix is empty; \
+         got {:?}",
+        ctx.base_ref
+    );
+}
+
+/// Regression test: when `version_prefix` is `"v"` the `base_ref` is still
+/// constructed correctly as `"v0.5.0"`.
+#[tokio::test]
+async fn test_feature_pr_opened_uses_version_prefix_for_base_ref_when_prefix_is_v() {
+    let tag = GitTag {
+        name: "v0.5.0".to_string(),
+        target_sha: "b".repeat(40),
+        tag_type: GitTagType::Lightweight,
+        message: None,
+        tagger: None,
+        created_at: None,
+    };
+
+    let mut cfg = config::ReleaseRegentConfig::default();
+    cfg.core.version_prefix = "v".to_string();
+
+    let github = TestGitHubForLib::new_empty().with_tags(vec![tag]);
+    let config = TestConfigWith::new(cfg);
+    let version_calc = TestVersionCalcForLib::returning("0.6.0");
+    let processor = ReleaseRegentProcessor::new(github.clone(), config, version_calc.clone());
+
+    let event = ProcessingEvent {
+        event_id: "prefix-v-1".into(),
+        correlation_id: "corr-prefix-v-1".into(),
+        event_type: EventType::PullRequestOpened,
+        repository: test_repo(),
+        payload: make_pr_activity_payload(11, "deadbeef5678", "feat/another-feature", "bob"),
+        received_at: Utc::now(),
+        source: EventSourceKind::Webhook,
+        installation_id: 0,
+    };
+
+    processor
+        .handle_pull_request_activity(&event)
+        .await
+        .expect("handle_pull_request_activity should succeed");
+
+    let ctx = version_calc
+        .last_context()
+        .await
+        .expect("calculate_version must have been called");
+
+    assert_eq!(
+        ctx.base_ref.as_deref(),
+        Some("v0.5.0"),
+        "base_ref must include 'v' prefix when version_prefix is 'v'; got {:?}",
+        ctx.base_ref
     );
 }

--- a/crates/core/src/lib_tests.rs
+++ b/crates/core/src/lib_tests.rs
@@ -3020,3 +3020,145 @@ async fn test_feature_pr_opened_uses_version_prefix_for_base_ref_when_prefix_is_
         ctx.base_ref
     );
 }
+
+/// Regression test: when `version_prefix` is empty and the latest tag has no
+/// prefix (e.g. `0.5.0`), the `base_ref` passed to the version calculator
+/// during the merged-PR calculation must be `"0.5.0"` — not `"v0.5.0"`.
+///
+/// Before the fix, `calculate_version_for_merge` used `format!("v{v}")`,
+/// which hardcoded the `v` prefix regardless of configuration.
+#[tokio::test]
+async fn test_merged_pr_uses_version_prefix_for_base_ref_when_prefix_is_empty() {
+    let tag = GitTag {
+        name: "0.5.0".to_string(),
+        target_sha: "a".repeat(40),
+        tag_type: GitTagType::Lightweight,
+        message: None,
+        tagger: None,
+        created_at: None,
+    };
+
+    let mut cfg = config::ReleaseRegentConfig::default();
+    cfg.core.version_prefix = String::new();
+
+    let github = TestGitHubForLib::new_empty().with_tags(vec![tag]);
+    let config = TestConfigWith::new(cfg);
+    let version_calc = TestVersionCalcForLib::returning("0.6.0");
+    let processor = ReleaseRegentProcessor::new(github.clone(), config, version_calc.clone());
+
+    // Fire a feature-PR merged event.  Using the pub async fn directly avoids
+    // the refresh path so only the merge-calculation context is captured.
+    let event = ProcessingEvent {
+        event_id: "merged-prefix-empty-1".into(),
+        correlation_id: "corr-merged-prefix-empty-1".into(),
+        event_type: EventType::PullRequestMerged,
+        repository: test_repo(),
+        payload: serde_json::json!({
+            "pull_request": {
+                "number": 10,
+                "base": { "ref": "main" },
+                "merge_commit_sha": "b".repeat(40),
+                "head": { "sha": "c".repeat(40), "ref": "feat/my-feature" }
+            }
+        }),
+        received_at: Utc::now(),
+        source: EventSourceKind::Webhook,
+        installation_id: 0,
+    };
+
+    processor
+        .handle_merged_pull_request(&event)
+        .await
+        .expect("handle_merged_pull_request should succeed");
+
+    let ctx = version_calc
+        .last_context()
+        .await
+        .expect("calculate_version must have been called");
+
+    assert_eq!(
+        ctx.base_ref.as_deref(),
+        Some("0.5.0"),
+        "base_ref in the merge calculation must not get a hardcoded 'v' prefix \
+         when version_prefix is empty; got {:?}",
+        ctx.base_ref
+    );
+}
+
+/// Regression test: when `version_prefix` is empty and the latest tag has no
+/// prefix (e.g. `0.5.0`), the `base_ref` passed to the version calculator
+/// during the open-PR refresh scan must be `"0.5.0"` — not `"v0.5.0"`.
+///
+/// Before the fix, `refresh_open_feature_pr_comments` used `format!("v{v}")`,
+/// which hardcoded the `v` prefix regardless of configuration.
+#[tokio::test]
+async fn test_pr_refresh_scan_uses_version_prefix_for_base_ref_when_prefix_is_empty() {
+    use crate::traits::github_operations::IssueComment;
+
+    let tag = GitTag {
+        name: "0.5.0".to_string(),
+        target_sha: "a".repeat(40),
+        tag_type: GitTagType::Lightweight,
+        message: None,
+        tagger: None,
+        created_at: None,
+    };
+
+    let mut cfg = config::ReleaseRegentConfig::default();
+    cfg.core.version_prefix = String::new();
+
+    // One open feature PR with an existing status marker so the refresh path
+    // actually calls calculate_version for it.
+    let open_pr = make_open_pr_with_author(20, "feat/some-feature", "sha-feature", "alice");
+    let marker_comment = IssueComment {
+        id: 1,
+        body: format!("{}\nOld version", pr_status_commenter::PR_STATUS_MARKER),
+        user_login: None,
+    };
+
+    let github = TestGitHubForLib::new_empty()
+        .with_tags(vec![tag])
+        .with_search_results(vec![open_pr])
+        .with_stored_issue_comments(20, vec![marker_comment]);
+    let config = TestConfigWith::new(cfg);
+    let version_calc = TestVersionCalcForLib::returning("0.6.0");
+    let processor = ReleaseRegentProcessor::new(github.clone(), config, version_calc.clone());
+
+    // Invoke via the trait impl so that try_refresh_feature_pr_status_comments
+    // is called after orchestration.  After this, last_context() holds the
+    // context from the refresh scan (the final calculate_version call).
+    let event = ProcessingEvent {
+        event_id: "refresh-prefix-empty-1".into(),
+        correlation_id: "corr-refresh-prefix-empty-1".into(),
+        event_type: EventType::PullRequestMerged,
+        repository: test_repo(),
+        payload: serde_json::json!({
+            "pull_request": {
+                "number": 5,
+                "base": { "ref": "main" },
+                "merge_commit_sha": "d".repeat(40),
+                "head": { "sha": "e".repeat(40), "ref": "feat/other-feature" }
+            }
+        }),
+        received_at: Utc::now(),
+        source: EventSourceKind::Webhook,
+        installation_id: 0,
+    };
+
+    MergedPullRequestHandler::handle_merged_pull_request(&processor, &event)
+        .await
+        .expect("handle_merged_pull_request should succeed");
+
+    let ctx = version_calc
+        .last_context()
+        .await
+        .expect("calculate_version must have been called during refresh");
+
+    assert_eq!(
+        ctx.base_ref.as_deref(),
+        Some("0.5.0"),
+        "base_ref in the PR refresh scan must not get a hardcoded 'v' prefix \
+         when version_prefix is empty; got {:?}",
+        ctx.base_ref
+    );
+}


### PR DESCRIPTION
Repositories that tag without a v prefix (e.g. 0.5.0 not v0.5.0) received base_ref=v0.5.0 in get_commits_between, causing GitHub to return 404 and permanently reject the event with no release PR created.

Three VersionContext constructions in lib.rs used format!("v{v}") to build the base_ref for GitHub's compare API, ignoring version_prefix.

Replaced all three with format!("{}{v}", repo_config.core.version_prefix) so an empty prefix produces a bare version string and "v" works as before.

Added two regression tests asserting the VersionContext.base_ref value matches the configured prefix.

closes #112
