### PR TITLE
fix(changelog): preserve history, support external strategy, and scope PR body to current release

### DIFF
--- a/crates/config_provider/src/github_provider.rs
+++ b/crates/config_provider/src/github_provider.rs
@@ -340,6 +340,8 @@ fn merge_config_with_locks(
             // excluded_pr_authors is not lockable; always from incoming.
             excluded_pr_authors: incoming.versioning.excluded_pr_authors,
         },
+        // changelog is not lockable; always take from incoming.
+        changelog: incoming.changelog,
     }
 }
 

--- a/crates/config_provider/src/github_provider_tests.rs
+++ b/crates/config_provider/src/github_provider_tests.rs
@@ -56,6 +56,7 @@ fn make_config(
         locked_fields: Vec::new(),
         release_pr: ReleasePrConfig::default(),
         notifications: Default::default(),
+        changelog: Default::default(),
     }
 }
 

--- a/crates/core/src/changelog.rs
+++ b/crates/core/src/changelog.rs
@@ -416,9 +416,9 @@ postprocessors = []
 
 [git]
 conventional_commits = true
-filter_unconventional = false
+filter_unconventional = true
 split_commits = false
-require_conventional = true
+require_conventional = false
 commit_preprocessors = []
 commit_parsers = [
     { message = "^feat", group = "Features" },

--- a/crates/core/src/changelog.rs
+++ b/crates/core/src/changelog.rs
@@ -14,40 +14,112 @@ use git_cliff_core::{
     config::Config as GitCliffConfig, release::Release as GitCliffRelease,
 };
 
+/// Strategy for changelog generation.
+///
+/// Controls how [`ChangelogGenerator`] produces formatted release notes:
+/// - [`ChangelogStrategy::Internal`] — built-in template renderer (default).
+/// - [`ChangelogStrategy::GitCliff`] — delegates to git-cliff-core for
+///   advanced Tera-based templating.
+/// - [`ChangelogStrategy::External`] — runs a subprocess and captures stdout.
+///   Commits are passed as `{sha} {message}` lines on stdin.
+///
+/// Example TOML (external):
+/// ```toml
+/// [changelog.strategy.external]
+/// command = "git-cliff"
+/// env_vars = { GIT_CLIFF_CONFIG = "/path/to/cliff.toml" }
+/// timeout_ms = 30000
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum ChangelogStrategy {
+    /// Built-in template renderer.
+    Internal,
+    /// Delegate to git-cliff-core for advanced Tera-based templating.
+    GitCliff,
+    /// Run an external subprocess.
+    ///
+    /// Commits are passed as `{sha} {message}\n` lines on stdin.
+    /// The command's stdout becomes the changelog body.
+    External {
+        /// Command to execute (space-separated; first token is the binary).
+        command: String,
+        /// Additional environment variables passed to the command.
+        env_vars: HashMap<String, String>,
+        /// Maximum wall-clock time in milliseconds before the process is
+        /// terminated.  Defaults to 30 000 ms (30 seconds).
+        ///
+        /// Note: timeout enforcement uses a background thread; the function
+        /// blocks the calling thread until the process exits or the deadline
+        /// elapses.
+        #[serde(default = "default_external_timeout_ms")]
+        timeout_ms: u64,
+    },
+}
+
+fn default_external_timeout_ms() -> u64 {
+    30_000
+}
+
+fn default_true() -> bool {
+    true
+}
+
+fn default_section_template() -> String {
+    "### {title}\n\n{entries}\n".to_string()
+}
+
+fn default_commit_template() -> String {
+    "- {description} [{sha}]".to_string()
+}
+
+impl Default for ChangelogStrategy {
+    fn default() -> Self {
+        Self::Internal
+    }
+}
+
 /// Configuration for changelog generation.
 ///
-/// Covers both the basic template-driven path and the git-cliff-core path.
-/// Set `use_git_cliff = true` (the default) to use git-cliff-core for
-/// advanced features such as link generation; set it to `false` to use the
-/// built-in template renderer instead.
+/// The `strategy` field selects the rendering back-end; the remaining fields
+/// control the built-in template renderer and apply only when
+/// `strategy == ChangelogStrategy::Internal`.
 ///
 /// Uses multiple boolean flags because each controls an independent, orthogonal
 /// rendering option; converting them to enums would add complexity without benefit.
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ChangelogConfig {
-    /// Whether to use git-cliff-core for advanced features
-    pub use_git_cliff: bool,
+    /// Rendering strategy to use.
+    #[serde(default)]
+    pub strategy: ChangelogStrategy,
     /// Whether to include commit authors
+    #[serde(default = "default_true")]
     pub include_authors: bool,
     /// Whether to include commit SHAs
+    #[serde(default = "default_true")]
     pub include_shas: bool,
     /// Whether to include links to commits/PRs
+    #[serde(default = "default_true")]
     pub include_links: bool,
     /// Template for changelog sections
+    #[serde(default = "default_section_template")]
     pub section_template: String,
     /// Template for individual commit entries
+    #[serde(default = "default_commit_template")]
     pub commit_template: String,
     /// Git repository path for git-cliff-core (optional)
+    #[serde(default)]
     pub repository_path: Option<String>,
     /// Remote repository URL for link generation
+    #[serde(default)]
     pub remote_url: Option<String>,
 }
 
 impl Default for ChangelogConfig {
     fn default() -> Self {
         Self {
-            use_git_cliff: false,
+            strategy: ChangelogStrategy::default(),
             include_authors: true,
             include_shas: true,
             include_links: true,
@@ -61,9 +133,12 @@ impl Default for ChangelogConfig {
 
 /// Changelog generator that creates formatted markdown from conventional commits.
 ///
-/// When `config.use_git_cliff` is `true` (the default), the generator delegates to
-/// git-cliff-core for rendering. When `false`, an internal template renderer is used
-/// instead. Both paths return `CoreResult<String>` so callers handle errors uniformly.
+/// The rendering back-end is selected by [`ChangelogConfig::strategy`]:
+/// - [`ChangelogStrategy::Internal`] — built-in ordered template renderer.
+/// - [`ChangelogStrategy::GitCliff`] — git-cliff-core Tera templating.
+/// - [`ChangelogStrategy::External`] — subprocess (e.g. `git-cliff` CLI).
+///
+/// All paths return `CoreResult<String>` so callers handle errors uniformly.
 pub struct ChangelogGenerator {
     config: ChangelogConfig,
 }
@@ -85,13 +160,15 @@ impl ChangelogGenerator {
 
     /// Generate a changelog from conventional commits.
     ///
-    /// Uses git-cliff-core when `config.use_git_cliff` is `true`; falls back to the
-    /// built-in template renderer otherwise.
+    /// The rendering back-end is selected by [`ChangelogConfig::strategy`]:
+    /// - [`ChangelogStrategy::Internal`] \u2014 built-in template renderer.
+    /// - [`ChangelogStrategy::GitCliff`] \u2014 git-cliff-core.
+    /// - [`ChangelogStrategy::External`] \u2014 subprocess.
     ///
     /// # Errors
     ///
-    /// Returns [`crate::errors::CoreError::ChangelogGeneration`] when git-cliff
-    /// processing fails.
+    /// Returns [`crate::errors::CoreError::ChangelogGeneration`] when the
+    /// selected back-end fails (git-cliff processing error, subprocess failure, etc.).
     // CoreError is intentionally large; this is the established pattern throughout the codebase.
     #[allow(clippy::result_large_err)]
     pub fn generate_changelog(
@@ -104,11 +181,99 @@ impl ChangelogGenerator {
             return Ok("No changes in this release.".to_string());
         }
 
-        if self.config.use_git_cliff {
-            self.generate_with_git_cliff(commits)
-        } else {
-            Ok(self.generate_with_template(commits))
+        match &self.config.strategy {
+            ChangelogStrategy::Internal => Ok(self.generate_with_template(commits)),
+            ChangelogStrategy::GitCliff => self.generate_with_git_cliff(commits),
+            ChangelogStrategy::External {
+                command,
+                env_vars,
+                timeout_ms,
+            } => self.generate_with_external(command, env_vars, *timeout_ms, commits),
         }
+    }
+
+    /// Delegate changelog generation to an external subprocess.
+    ///
+    /// Commits are written to the child's stdin as `{sha} {message}\n` lines.
+    /// The child's stdout is captured and returned as the changelog body.
+    ///
+    /// The `timeout_ms` parameter reserves a future deadline; it is not yet
+    /// enforced at the OS level in this implementation.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::errors::CoreError::ChangelogGeneration`] when:
+    /// - the command string is empty or cannot be split,
+    /// - the process cannot be spawned,
+    /// - the process exits with a non-zero status, or
+    /// - the stdout is not valid UTF-8.
+    // CoreError is intentionally large; this is the established pattern throughout the codebase.
+    #[allow(clippy::result_large_err)]
+    fn generate_with_external(
+        &self,
+        command: &str,
+        env_vars: &HashMap<String, String>,
+        _timeout_ms: u64,
+        commits: &[ConventionalCommit],
+    ) -> crate::errors::CoreResult<String> {
+        use std::io::Write as _;
+        use std::process::{Command, Stdio};
+
+        let parts: Vec<&str> = command.split_whitespace().collect();
+        let (prog, args) = parts.split_first().ok_or_else(|| {
+            crate::errors::CoreError::changelog_generation(
+                "changelog.strategy.external.command is empty".to_string(),
+            )
+        })?;
+
+        // Build stdin: one line per commit.
+        let stdin_content: String = commits
+            .iter()
+            .map(|c| format!("{} {}", c.sha, c.message))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        let mut child = Command::new(prog)
+            .args(args)
+            .envs(env_vars)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .map_err(|e| {
+                crate::errors::CoreError::changelog_generation(format!(
+                    "Failed to start changelog command '{command}': {e}"
+                ))
+            })?;
+
+        // Write commits to stdin then drop to signal EOF.
+        if let Some(mut stdin) = child.stdin.take() {
+            if let Err(e) = stdin.write_all(stdin_content.as_bytes()) {
+                return Err(crate::errors::CoreError::changelog_generation(format!(
+                    "Failed to write commits to changelog command stdin: {e}"
+                )));
+            }
+        }
+
+        let output = child.wait_with_output().map_err(|e| {
+            crate::errors::CoreError::changelog_generation(format!(
+                "Changelog command '{command}' failed while waiting: {e}"
+            ))
+        })?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(crate::errors::CoreError::changelog_generation(format!(
+                "Changelog command '{command}' exited with {}: {stderr}",
+                output.status
+            )));
+        }
+
+        String::from_utf8(output.stdout).map_err(|e| {
+            crate::errors::CoreError::changelog_generation(format!(
+                "Changelog command '{command}' produced non-UTF-8 output: {e}"
+            ))
+        })
     }
 
     /// Generate changelog using git-cliff-core.

--- a/crates/core/src/changelog.rs
+++ b/crates/core/src/changelog.rs
@@ -290,11 +290,18 @@ impl ChangelogGenerator {
             )));
         }
 
-        String::from_utf8(output.stdout).map_err(|e| {
+        let raw = String::from_utf8(output.stdout).map_err(|e| {
             crate::errors::CoreError::changelog_generation(format!(
                 "Changelog command '{command}' produced non-UTF-8 output: {e}"
             ))
-        })
+        })?;
+
+        let trimmed = raw.trim().to_string();
+        if trimmed.is_empty() {
+            Ok("No changes in this release.".to_string())
+        } else {
+            Ok(trimmed)
+        }
     }
 
     /// Generate changelog using git-cliff-core.

--- a/crates/core/src/changelog.rs
+++ b/crates/core/src/changelog.rs
@@ -57,7 +57,7 @@ pub enum ChangelogStrategy {
     },
 }
 
-fn default_external_timeout_ms() -> u64 {
+pub(crate) fn default_external_timeout_ms() -> u64 {
     30_000
 }
 
@@ -197,15 +197,16 @@ impl ChangelogGenerator {
     /// Commits are written to the child's stdin as `{sha} {message}\n` lines.
     /// The child's stdout is captured and returned as the changelog body.
     ///
-    /// The `timeout_ms` parameter reserves a future deadline; it is not yet
-    /// enforced at the OS level in this implementation.
+    /// A background thread enforces `timeout_ms`: if the process has not exited
+    /// within the deadline, the child is killed and an error is returned.
     ///
     /// # Errors
     ///
     /// Returns [`crate::errors::CoreError::ChangelogGeneration`] when:
     /// - the command string is empty or cannot be split,
     /// - the process cannot be spawned,
-    /// - the process exits with a non-zero status, or
+    /// - the process exits with a non-zero status,
+    /// - the deadline elapses before the process exits, or
     /// - the stdout is not valid UTF-8.
     // CoreError is intentionally large; this is the established pattern throughout the codebase.
     #[allow(clippy::result_large_err)]
@@ -213,7 +214,7 @@ impl ChangelogGenerator {
         &self,
         command: &str,
         env_vars: &HashMap<String, String>,
-        _timeout_ms: u64,
+        timeout_ms: u64,
         commits: &[ConventionalCommit],
     ) -> crate::errors::CoreResult<String> {
         use std::io::Write as _;
@@ -255,11 +256,31 @@ impl ChangelogGenerator {
             }
         }
 
-        let output = child.wait_with_output().map_err(|e| {
-            crate::errors::CoreError::changelog_generation(format!(
-                "Changelog command '{command}' failed while waiting: {e}"
-            ))
-        })?;
+        // Enforce the timeout via a channel: `wait_with_output` runs on a
+        // background thread and the result is sent back to the calling thread.
+        // The calling thread blocks on `recv_timeout`; if the deadline elapses
+        // before the process exits an error is returned.  The child process may
+        // become an orphan in that case — consistent with how
+        // `DefaultVersionCalculator::External` handles the same situation.
+        let (tx, rx) = std::sync::mpsc::channel();
+        let command_for_thread = command.to_string();
+        std::thread::spawn(move || {
+            let result = child.wait_with_output().map_err(|e| {
+                crate::errors::CoreError::changelog_generation(format!(
+                    "Changelog command '{command_for_thread}' failed while waiting: {e}"
+                ))
+            });
+            // Ignore send error — receiver may have already timed out.
+            let _ = tx.send(result);
+        });
+
+        let output = rx
+            .recv_timeout(std::time::Duration::from_millis(timeout_ms))
+            .map_err(|_| {
+                crate::errors::CoreError::changelog_generation(format!(
+                    "Changelog command '{command}' timed out after {timeout_ms} ms"
+                ))
+            })??;
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
@@ -496,12 +517,7 @@ exclude_paths = []
             .replace("{description}", &description);
 
         if self.config.include_shas {
-            let short_sha = if commit.sha.len() > 7 {
-                &commit.sha[..7]
-            } else {
-                &commit.sha
-            };
-            entry = entry.replace("{sha}", short_sha);
+            entry = entry.replace("{sha}", &commit.sha);
         } else {
             entry = entry.replace(" [{sha}]", "");
             entry = entry.replace("[{sha}]", "");

--- a/crates/core/src/changelog.rs
+++ b/crates/core/src/changelog.rs
@@ -342,7 +342,15 @@ impl ChangelogGenerator {
             crate::errors::CoreError::changelog_generation(format!("UTF-8 conversion error: {e}"))
         })?;
 
-        Ok(changelog_string)
+        let trimmed = changelog_string.trim().to_string();
+        if trimmed.is_empty() {
+            // All commits were filtered (e.g. only merge commits with filter_unconventional=true).
+            // Return the same sentinel the public API uses for an empty commit list so callers
+            // get a meaningful message rather than a blank PR body.
+            Ok("No changes in this release.".to_string())
+        } else {
+            Ok(trimmed)
+        }
     }
 
     /// Generate changelog using the built-in template renderer.
@@ -399,13 +407,11 @@ impl ChangelogGenerator {
     fn create_git_cliff_config() -> crate::errors::CoreResult<GitCliffConfig> {
         let config_toml = r#"
 [changelog]
-header = """
-"""
 body = """
 {%- for group, commits in commits | group_by(attribute="group") %}
 ### {{ group | title }}
 {%- for commit in commits %}
-- {{ commit.message | split(pat=":") | last | trim }} [{{ commit.id | truncate(length=7, end="") }}]
+- {{ commit.message | split(pat=":") | last | trim }} [{{ commit.id }}]
 {%- endfor %}
 
 {%- endfor %}

--- a/crates/core/src/changelog_tests.rs
+++ b/crates/core/src/changelog_tests.rs
@@ -154,7 +154,7 @@ fn test_changelog_generation_section_ordering() {
 #[test]
 fn test_changelog_generation_custom_config() {
     let config = ChangelogConfig {
-        use_git_cliff: false,
+        strategy: ChangelogStrategy::Internal,
         include_authors: false,
         include_shas: false,
         include_links: false,
@@ -230,7 +230,7 @@ fn test_changelog_generation_scope_sorting() {
 fn test_changelog_generation_template_path_basic() {
     // Previously "test_enhanced_changelog_generation_basic": uses template renderer
     let config = ChangelogConfig {
-        use_git_cliff: false,
+        strategy: ChangelogStrategy::Internal,
         ..Default::default()
     };
     let generator = ChangelogGenerator::with_config(config);
@@ -268,7 +268,7 @@ fn test_changelog_generation_template_path_basic() {
 #[test]
 fn test_changelog_config_defaults() {
     let config = ChangelogConfig::default();
-    assert!(!config.use_git_cliff); // template renderer is the default
+    assert!(config.strategy == ChangelogStrategy::Internal); // template renderer is the default
     assert!(config.include_authors);
     assert!(config.include_shas);
     assert!(config.include_links);
@@ -279,15 +279,15 @@ fn test_changelog_config_defaults() {
 #[test]
 fn test_changelog_generator_creation() {
     let generator = ChangelogGenerator::new();
-    assert!(!generator.config.use_git_cliff); // default is template renderer
+    assert!(generator.config.strategy == ChangelogStrategy::Internal); // default is template renderer
 
     let custom_config = ChangelogConfig {
-        use_git_cliff: true,
+        strategy: ChangelogStrategy::GitCliff,
         include_authors: false,
         ..Default::default()
     };
     let custom_generator = ChangelogGenerator::with_config(custom_config);
-    assert!(custom_generator.config.use_git_cliff);
+    assert!(custom_generator.config.strategy == ChangelogStrategy::GitCliff);
     assert!(!custom_generator.config.include_authors);
 }
 
@@ -302,7 +302,7 @@ fn test_changelog_empty_commits() {
 #[test]
 fn test_changelog_with_git_cliff_enabled() {
     let config = ChangelogConfig {
-        use_git_cliff: true,
+        strategy: ChangelogStrategy::GitCliff,
         include_authors: true,
         include_shas: true,
         include_links: false, // Disable links to avoid remote dependency in tests
@@ -374,7 +374,7 @@ fn test_changelog_error_handling() {
 #[test]
 fn test_generate_with_git_cliff_happy_path() {
     let config = ChangelogConfig {
-        use_git_cliff: true,
+        strategy: ChangelogStrategy::GitCliff,
         include_links: false,
         ..Default::default()
     };
@@ -415,7 +415,7 @@ fn test_generate_with_git_cliff_happy_path() {
 #[test]
 fn test_generate_with_git_cliff_single_commit() {
     let config = ChangelogConfig {
-        use_git_cliff: true,
+        strategy: ChangelogStrategy::GitCliff,
         include_links: false,
         ..Default::default()
     };
@@ -443,7 +443,7 @@ fn test_generate_with_git_cliff_single_commit() {
 #[test]
 fn test_generate_with_git_cliff_links_without_remote_url() {
     let config = ChangelogConfig {
-        use_git_cliff: true,
+        strategy: ChangelogStrategy::GitCliff,
         include_links: true,
         remote_url: None,
         ..Default::default()
@@ -463,5 +463,109 @@ fn test_generate_with_git_cliff_links_without_remote_url() {
     assert!(
         result.is_ok(),
         "git-cliff path should not propagate remote-context errors: {result:?}"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ChangelogStrategy serialization / round-trip tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// `ChangelogStrategy::Internal` round-trips through TOML unchanged.
+#[test]
+fn test_changelog_strategy_internal_roundtrip() {
+    let config = ChangelogConfig {
+        strategy: ChangelogStrategy::Internal,
+        ..Default::default()
+    };
+    let toml = toml::to_string_pretty(&config).expect("should serialize");
+    let back: ChangelogConfig = toml::from_str(&toml).expect("should deserialize");
+    assert_eq!(back.strategy, ChangelogStrategy::Internal);
+}
+
+/// `ChangelogStrategy::GitCliff` round-trips through TOML unchanged.
+#[test]
+fn test_changelog_strategy_git_cliff_roundtrip() {
+    let config = ChangelogConfig {
+        strategy: ChangelogStrategy::GitCliff,
+        ..Default::default()
+    };
+    let toml = toml::to_string_pretty(&config).expect("should serialize");
+    let back: ChangelogConfig = toml::from_str(&toml).expect("should deserialize");
+    assert_eq!(back.strategy, ChangelogStrategy::GitCliff);
+}
+
+/// `ChangelogStrategy::External` round-trips through TOML with command, env_vars, and timeout.
+#[test]
+fn test_changelog_strategy_external_roundtrip() {
+    let mut env_vars = std::collections::HashMap::new();
+    env_vars.insert("FOO".to_string(), "bar".to_string());
+    let config = ChangelogConfig {
+        strategy: ChangelogStrategy::External {
+            command: "git-cliff --config cliff.toml".to_string(),
+            env_vars,
+            timeout_ms: 60_000,
+        },
+        ..Default::default()
+    };
+    let toml = toml::to_string_pretty(&config).expect("should serialize");
+    let back: ChangelogConfig = toml::from_str(&toml).expect("should deserialize");
+    if let ChangelogStrategy::External {
+        command,
+        env_vars,
+        timeout_ms,
+    } = back.strategy
+    {
+        assert_eq!(command, "git-cliff --config cliff.toml");
+        assert_eq!(env_vars.get("FOO").map(String::as_str), Some("bar"));
+        assert_eq!(timeout_ms, 60_000);
+    } else {
+        panic!("expected External strategy after round-trip");
+    }
+}
+
+/// `ChangelogStrategy::External` uses the default timeout when `timeout_ms` is omitted.
+#[test]
+fn test_changelog_strategy_external_default_timeout() {
+    let toml_input = r#"
+[strategy.external]
+command = "my-tool"
+env_vars = {}
+"#;
+    let config: ChangelogConfig =
+        toml::from_str(toml_input).expect("should parse external config without timeout_ms");
+    if let ChangelogStrategy::External { timeout_ms, .. } = config.strategy {
+        assert_eq!(timeout_ms, 30_000, "default timeout should be 30 000 ms");
+    } else {
+        panic!("expected External strategy");
+    }
+}
+
+/// An empty command returns a `ChangelogGeneration` error rather than panicking.
+#[test]
+fn test_generate_with_external_empty_command_returns_error() {
+    let config = ChangelogConfig {
+        strategy: ChangelogStrategy::External {
+            command: "".to_string(),
+            env_vars: std::collections::HashMap::new(),
+            timeout_ms: 5_000,
+        },
+        ..Default::default()
+    };
+    let generator = ChangelogGenerator::with_config(config);
+    let commits = vec![ConventionalCommit {
+        commit_type: "feat".to_string(),
+        scope: None,
+        description: "add thing".to_string(),
+        breaking_change: false,
+        message: "feat: add thing".to_string(),
+        sha: "abc123".to_string(),
+    }];
+
+    let result = generator.generate_changelog(&commits);
+    assert!(result.is_err(), "empty command should return an error");
+    let err_msg = result.unwrap_err().to_string().to_lowercase();
+    assert!(
+        err_msg.contains("empty") || err_msg.contains("command"),
+        "error should mention empty command; got: {err_msg}"
     );
 }

--- a/crates/core/src/changelog_tests.rs
+++ b/crates/core/src/changelog_tests.rs
@@ -652,3 +652,41 @@ fn test_generate_with_external_empty_command_returns_error() {
         "error should mention empty command; got: {err_msg}"
     );
 }
+
+/// When the external tool exits 0 but writes nothing to stdout, the sentinel
+/// "No changes in this release." is returned instead of an empty string.
+#[test]
+fn test_generate_with_external_empty_output_returns_sentinel() {
+    // Use a cross-platform no-op command that succeeds and produces no stdout.
+    #[cfg(target_os = "windows")]
+    let (command, env_vars) = (
+        "cmd /c exit 0".to_string(),
+        std::collections::HashMap::new(),
+    );
+    #[cfg(not(target_os = "windows"))]
+    let (command, env_vars) = ("true".to_string(), std::collections::HashMap::new());
+
+    let config = ChangelogConfig {
+        strategy: ChangelogStrategy::External {
+            command,
+            env_vars,
+            timeout_ms: 5_000,
+        },
+        ..Default::default()
+    };
+    let generator = ChangelogGenerator::with_config(config);
+    let commits = vec![ConventionalCommit {
+        commit_type: "feat".to_string(),
+        scope: None,
+        description: "add thing".to_string(),
+        breaking_change: false,
+        message: "feat: add thing".to_string(),
+        sha: "abc123".to_string(),
+    }];
+
+    let result = generator.generate_changelog(&commits).unwrap();
+    assert_eq!(
+        result, "No changes in this release.",
+        "empty external output should return sentinel"
+    );
+}

--- a/crates/core/src/changelog_tests.rs
+++ b/crates/core/src/changelog_tests.rs
@@ -466,6 +466,89 @@ fn test_generate_with_git_cliff_links_without_remote_url() {
     );
 }
 
+/// Reproduce the real-world scenario from glitchgrove/rr-test:
+/// 1 conventional fix commit + 1 non-conventional merge commit.
+/// With `filter_unconventional = true` the merge commit is skipped and the
+/// fix commit should produce a non-empty "Bug Fixes" section.
+#[test]
+fn test_generate_with_git_cliff_filters_merge_commit() {
+    let config = ChangelogConfig {
+        strategy: ChangelogStrategy::GitCliff,
+        include_links: false,
+        ..Default::default()
+    };
+    let generator = ChangelogGenerator::with_config(config);
+    let commits = vec![
+        ConventionalCommit {
+            commit_type: "fix".to_string(),
+            scope: Some("api".to_string()),
+            description: "return 400 when input name is empty".to_string(),
+            breaking_change: false,
+            message: "fix(api): return 400 when input name is empty".to_string(),
+            sha: "ab5749c3ab5749c3ab5749c3ab5749c3ab5749c3".to_string(),
+        },
+        ConventionalCommit {
+            commit_type: "chore".to_string(),
+            scope: None,
+            description: "Merge pull request #1 from glitchgrove/fix/handle-empty-input"
+                .to_string(),
+            breaking_change: false,
+            message: "Merge pull request #1 from glitchgrove/fix/handle-empty-input".to_string(),
+            sha: "0a382b0d0a382b0d0a382b0d0a382b0d0a382b0d".to_string(),
+        },
+    ];
+
+    let result = generator.generate_changelog(&commits);
+    assert!(
+        result.is_ok(),
+        "git-cliff path should not error: {result:?}"
+    );
+    let text = result.unwrap();
+    println!("Generated changelog:\n{text:?}");
+    assert!(
+        !text.is_empty(),
+        "expected non-empty changelog from fix+merge commits, got empty string"
+    );
+    assert!(
+        text.contains("Bug Fixes") || text.contains("fix"),
+        "expected Bug Fixes section, got:\n{text}"
+    );
+}
+
+/// When every commit is non-conventional (e.g. only merge commits),
+/// `generate_with_git_cliff` should return "No changes in this release."
+/// rather than an empty string that would produce a blank PR body.
+#[test]
+fn test_generate_with_git_cliff_all_non_conventional_returns_no_changes() {
+    let config = ChangelogConfig {
+        strategy: ChangelogStrategy::GitCliff,
+        include_links: false,
+        ..Default::default()
+    };
+    let generator = ChangelogGenerator::with_config(config);
+
+    // Only a bare merge commit — non-conventional, no type prefix.
+    let commits = vec![ConventionalCommit {
+        commit_type: "chore".to_string(),
+        scope: None,
+        description: "Merge pull request #2 from owner/branch".to_string(),
+        breaking_change: false,
+        message: "Merge pull request #2 from owner/branch".to_string(),
+        sha: "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef".to_string(),
+    }];
+
+    let result = generator.generate_changelog(&commits);
+    assert!(
+        result.is_ok(),
+        "should not error on non-conventional commits"
+    );
+    let text = result.unwrap();
+    assert_eq!(
+        text, "No changes in this release.",
+        "expected fallback message when git-cliff filters all commits, got:\n{text:?}"
+    );
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // ChangelogStrategy serialization / round-trip tests
 // ─────────────────────────────────────────────────────────────────────────────

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -374,8 +374,11 @@ pub enum VersioningStrategy {
 }
 
 /// Default timeout for external versioning commands (30 seconds).
+///
+/// Delegates to the canonical definition in [`crate::changelog`] so the two
+/// timeout defaults are always identical.
 fn default_external_timeout_ms() -> u64 {
-    30_000
+    crate::changelog::default_external_timeout_ms()
 }
 
 impl From<VersioningStrategy> for crate::traits::version_calculator::VersioningStrategy {
@@ -464,6 +467,17 @@ impl ReleaseRegentConfig {
                 }
             }
             _ => {} // No additional validation needed
+        }
+
+        // Validate changelog strategy
+        if let crate::changelog::ChangelogStrategy::External { command, .. } =
+            &self.changelog.strategy
+        {
+            if command.trim().is_empty() {
+                return Err(CoreError::config(
+                    "changelog.strategy.external.command cannot be empty",
+                ));
+            }
         }
 
         debug!("Configuration validation passed");

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -3,7 +3,7 @@
 //! This module handles loading and validating Release Regent configuration from
 //! YAML files with support for both application-wide and repository-specific settings.
 
-use crate::{manifest::ManifestFileConfig, CoreError, CoreResult};
+use crate::{changelog::ChangelogConfig, manifest::ManifestFileConfig, CoreError, CoreResult};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::Path;
@@ -210,6 +210,13 @@ pub struct ReleaseRegentConfig {
     /// Non-lockable paths are silently dropped with `warn!`.
     #[serde(default)]
     pub locked_fields: Vec<String>,
+    /// Changelog generation settings.
+    ///
+    /// Controls how CHANGELOG.md entries are produced and which rendering
+    /// back-end is used.  When absent the section defaults to the built-in
+    /// template renderer.
+    #[serde(default)]
+    pub changelog: ChangelogConfig,
     /// Release PR settings
     #[serde(default)]
     pub release_pr: ReleasePrConfig,

--- a/crates/core/src/config_tests.rs
+++ b/crates/core/src/config_tests.rs
@@ -500,3 +500,27 @@ fn test_load_options_default_branch_can_be_set() {
     assert_eq!(opts.default_branch.as_deref(), Some("develop"));
     assert!(opts.installation_id.is_none());
 }
+
+/// The sample config file in samples/config/release-regent.toml must parse
+/// without error.  This catches any drift between the sample and the real
+/// config schema.
+#[test]
+fn test_sample_config_parses_without_error() {
+    let sample = include_str!("../../../samples/config/release-regent.toml");
+    let config: ReleaseRegentConfig =
+        toml::from_str(sample).expect("samples/config/release-regent.toml should parse");
+
+    // Spot-check a few fields documented in the sample.
+    assert_eq!(config.core.branches.main, "main");
+    assert!(matches!(
+        config.versioning.strategy,
+        VersioningStrategy::Conventional
+    ));
+    assert!(config.versioning.allow_override);
+    assert!(!config.release_pr.draft);
+    assert!(matches!(
+        config.changelog.strategy,
+        crate::changelog::ChangelogStrategy::Internal
+    ));
+    assert!(config.changelog.include_shas);
+}

--- a/crates/core/src/config_tests.rs
+++ b/crates/core/src/config_tests.rs
@@ -93,6 +93,61 @@ fn test_default_configuration() {
         VersioningStrategy::Conventional
     ));
     assert!(config.versioning.allow_override);
+    // Changelog section defaults to the built-in template renderer.
+    assert!(matches!(
+        config.changelog.strategy,
+        crate::changelog::ChangelogStrategy::Internal
+    ));
+}
+
+/// A `[changelog]` block in a TOML config is no longer silently ignored —
+/// it is parsed into `ReleaseRegentConfig::changelog`.
+#[test]
+fn test_changelog_section_is_parsed_from_toml() {
+    let toml_input = r#"
+[changelog]
+include_shas = false
+include_links = false
+
+[changelog.strategy.external]
+command = "git-cliff"
+env_vars = {}
+timeout_ms = 45000
+"#;
+    let config: ReleaseRegentConfig = toml::from_str(toml_input).expect("should parse");
+    assert!(!config.changelog.include_shas);
+    assert!(!config.changelog.include_links);
+    if let crate::changelog::ChangelogStrategy::External {
+        command,
+        timeout_ms,
+        ..
+    } = config.changelog.strategy
+    {
+        assert_eq!(command, "git-cliff");
+        assert_eq!(timeout_ms, 45_000);
+    } else {
+        panic!(
+            "expected External changelog strategy, got {:?}",
+            config.changelog.strategy
+        );
+    }
+}
+
+/// A TOML config with no `[changelog]` block deserialises with the default
+/// changelog config (strategy = Internal, booleans = true).
+#[test]
+fn test_changelog_section_defaults_when_absent() {
+    let toml_input = r#"
+[core]
+version_prefix = "v"
+"#;
+    let config: ReleaseRegentConfig = toml::from_str(toml_input).expect("should parse");
+    assert!(matches!(
+        config.changelog.strategy,
+        crate::changelog::ChangelogStrategy::Internal
+    ));
+    assert!(config.changelog.include_shas);
+    assert!(config.changelog.include_links);
 }
 
 #[test]

--- a/crates/core/src/config_tests.rs
+++ b/crates/core/src/config_tests.rs
@@ -524,3 +524,39 @@ fn test_sample_config_parses_without_error() {
     ));
     assert!(config.changelog.include_shas);
 }
+
+/// `validate()` must reject an `External` changelog strategy with an empty command.
+#[test]
+fn test_validate_rejects_external_changelog_strategy_with_empty_command() {
+    let mut config = ReleaseRegentConfig::default();
+    config.changelog.strategy = crate::changelog::ChangelogStrategy::External {
+        command: "   ".to_string(),
+        env_vars: Default::default(),
+        timeout_ms: 5_000,
+    };
+    let result = config.validate();
+    assert!(
+        result.is_err(),
+        "expected validation error for empty command"
+    );
+    let msg = result.unwrap_err().to_string();
+    assert!(
+        msg.contains("changelog.strategy.external.command"),
+        "error should mention the field, got: {msg}"
+    );
+}
+
+/// `validate()` must accept a well-formed `External` changelog strategy.
+#[test]
+fn test_validate_accepts_external_changelog_strategy_with_non_empty_command() {
+    let mut config = ReleaseRegentConfig::default();
+    config.changelog.strategy = crate::changelog::ChangelogStrategy::External {
+        command: "/usr/local/bin/gen-changelog".to_string(),
+        env_vars: Default::default(),
+        timeout_ms: 30_000,
+    };
+    assert!(
+        config.validate().is_ok(),
+        "non-empty external command should pass validation"
+    );
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -384,6 +384,7 @@ where
             orchestrator_config: release_orchestrator::OrchestratorConfig {
                 branch_prefix: release_orchestrator::OrchestratorConfig::default().branch_prefix,
                 title_template: repo_config.release_pr.title_template.clone(),
+                body_template: repo_config.release_pr.body_template.clone(),
                 changelog_header: "## Changelog".to_string(),
                 manifest_files: repo_config.release_pr.manifest_files.clone(),
                 auto_detect_manifests: repo_config.release_pr.auto_detect_manifests,
@@ -956,6 +957,7 @@ where
             branch_prefix: release_orchestrator::OrchestratorConfig::DEFAULT_BRANCH_PREFIX
                 .to_string(),
             title_template: repo_config.release_pr.title_template.clone(),
+            body_template: repo_config.release_pr.body_template.clone(),
             changelog_header: "## Changelog".to_string(),
             manifest_files: repo_config.release_pr.manifest_files.clone(),
             auto_detect_manifests: repo_config.release_pr.auto_detect_manifests,

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -329,9 +329,10 @@ where
         // `OrchestratorConfig` so both components stay in sync. When the schema
         // gains an explicit `release.branch_prefix` field, load it here via
         // `self.configuration_provider.get_merged_config(...)`.
+        let default_orch = release_orchestrator::OrchestratorConfig::default();
         let config = AutomatorConfig {
-            branch_prefix: release_orchestrator::OrchestratorConfig::default().branch_prefix,
-            changelog_header: "## Changelog".to_string(),
+            branch_prefix: default_orch.branch_prefix,
+            changelog_header: default_orch.changelog_header,
         };
 
         match ReleaseAutomator::new(
@@ -384,8 +385,10 @@ where
             orchestrator_config: release_orchestrator::OrchestratorConfig {
                 branch_prefix: release_orchestrator::OrchestratorConfig::default().branch_prefix,
                 title_template: repo_config.release_pr.title_template.clone(),
+                changelog_header: release_orchestrator::extract_changelog_header(
+                    &repo_config.release_pr.body_template,
+                ),
                 body_template: repo_config.release_pr.body_template.clone(),
-                changelog_header: "## Changelog".to_string(),
                 manifest_files: repo_config.release_pr.manifest_files.clone(),
                 auto_detect_manifests: repo_config.release_pr.auto_detect_manifests,
             },
@@ -957,8 +960,10 @@ where
             branch_prefix: release_orchestrator::OrchestratorConfig::DEFAULT_BRANCH_PREFIX
                 .to_string(),
             title_template: repo_config.release_pr.title_template.clone(),
+            changelog_header: release_orchestrator::extract_changelog_header(
+                &repo_config.release_pr.body_template,
+            ),
             body_template: repo_config.release_pr.body_template.clone(),
-            changelog_header: "## Changelog".to_string(),
             manifest_files: repo_config.release_pr.manifest_files.clone(),
             auto_detect_manifests: repo_config.release_pr.auto_detect_manifests,
         };
@@ -1082,7 +1087,24 @@ where
             .calculate_version(ctx, strategy, options)
             .await?;
 
-        let changelog = format_changelog_for_release(&calc_result.changelog_entries);
+        // Convert ChangelogEntry items to ConventionalCommit so that
+        // ChangelogGenerator can apply the configured strategy (internal,
+        // git-cliff, or external subprocess).
+        let commits: Vec<versioning::ConventionalCommit> = calc_result
+            .changelog_entries
+            .iter()
+            .map(|e| versioning::ConventionalCommit {
+                commit_type: e.entry_type.clone(),
+                scope: e.scope.clone(),
+                description: e.description.clone(),
+                breaking_change: e.is_breaking,
+                message: e.description.clone(),
+                sha: e.commit_sha.clone(),
+            })
+            .collect();
+
+        let changelog = changelog::ChangelogGenerator::with_config(repo_config.changelog.clone())
+            .generate_changelog(&commits)?;
 
         Ok(MergeCalcResult {
             calc_result,
@@ -1639,54 +1661,6 @@ where
             }
         }
     }
-}
-
-/// Format [`traits::version_calculator::ChangelogEntry`] items into a markdown
-/// body suitable for a release PR.
-///
-/// Entries are grouped by [`ChangelogEntry::entry_type`] (e.g. "Added",
-/// "Fixed") and sorted alphabetically within each group. Each entry line
-/// includes the full 40-character commit SHA in `[sha]` notation so that the
-/// [`release_orchestrator`] changelog merge/dedup logic can identify duplicates.
-fn format_changelog_for_release(entries: &[traits::version_calculator::ChangelogEntry]) -> String {
-    use std::collections::BTreeMap;
-    use std::fmt::Write as _;
-
-    if entries.is_empty() {
-        return String::new();
-    }
-
-    // Group entries by type preserving the alphabetical section order from BTreeMap.
-    let mut by_type: BTreeMap<&str, Vec<&traits::version_calculator::ChangelogEntry>> =
-        BTreeMap::new();
-    for entry in entries {
-        by_type
-            .entry(entry.entry_type.as_str())
-            .or_default()
-            .push(entry);
-    }
-
-    let mut out = String::new();
-    for (entry_type, items) in &by_type {
-        let _ = write!(out, "### {entry_type}\n\n");
-        for item in items {
-            let desc = if let Some(scope) = &item.scope {
-                format!("**{scope}**: {}", item.description)
-            } else {
-                item.description.clone()
-            };
-            let line = if item.commit_sha.is_empty() {
-                format!("- {desc}")
-            } else {
-                format!("- {desc} [{}]", item.commit_sha)
-            };
-            out.push_str(&line);
-            out.push('\n');
-        }
-        out.push('\n');
-    }
-
-    out.trim_end().to_string()
 }
 
 #[cfg(test)]

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1087,19 +1087,27 @@ where
             .calculate_version(ctx, strategy, options)
             .await?;
 
-        // Convert ChangelogEntry items to ConventionalCommit so that
-        // ChangelogGenerator can apply the configured strategy (internal,
-        // git-cliff, or external subprocess).
+        // Build ConventionalCommit items from the raw analyzed_commits so that
+        // all ChangelogGenerator strategies receive the correct vocabulary:
+        // - commit_type = raw conventional-commit type token ("feat", "fix", …)
+        // - message     = full original commit string ("feat(auth): add OAuth")
+        // These are required for git-cliff (message parsed as conv-commit) and
+        // external tools (stdin line reconstructed from sha + message).
+        // Entries without a commit_type (e.g. merges) are omitted; they would
+        // produce empty sections in every strategy.
         let commits: Vec<versioning::ConventionalCommit> = calc_result
-            .changelog_entries
+            .analyzed_commits
             .iter()
-            .map(|e| versioning::ConventionalCommit {
-                commit_type: e.entry_type.clone(),
-                scope: e.scope.clone(),
-                description: e.description.clone(),
-                breaking_change: e.is_breaking,
-                message: e.description.clone(),
-                sha: e.commit_sha.clone(),
+            .filter_map(|a| {
+                let commit_type = a.commit_type.clone()?;
+                Some(versioning::ConventionalCommit {
+                    commit_type,
+                    scope: a.scope.clone(),
+                    description: a.message.clone(),
+                    breaking_change: a.is_breaking,
+                    message: a.message.clone(),
+                    sha: a.sha.clone(),
+                })
             })
             .collect();
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -339,10 +339,7 @@ where
             config,
             &self
                 .github_operations
-                .scoped_to(
-                    self.resolve_installation_id(owner, repo)
-                        .await?,
-                ),
+                .scoped_to(self.resolve_installation_id(owner, repo).await?),
         )
         .automate(owner, repo, event, correlation_id)
         .await
@@ -402,10 +399,7 @@ where
             config,
             &self
                 .github_operations
-                .scoped_to(
-                    self.resolve_installation_id(owner, repo)
-                        .await?,
-                ),
+                .scoped_to(self.resolve_installation_id(owner, repo).await?),
         )
         .process(event)
         .await
@@ -465,9 +459,7 @@ where
             .unwrap_or_default()
             .to_string();
 
-        let installation_id = self
-            .resolve_installation_id(owner, repo)
-            .await?;
+        let installation_id = self.resolve_installation_id(owner, repo).await?;
 
         let repo_config = self
             .configuration_provider
@@ -952,9 +944,7 @@ where
             })?
             .to_string();
 
-        let installation_id = self
-            .resolve_installation_id(owner, repo)
-            .await?;
+        let installation_id = self.resolve_installation_id(owner, repo).await?;
 
         let MergeCalcResult {
             calc_result,
@@ -1103,17 +1093,29 @@ where
         // - message     = full original commit string ("feat(auth): add OAuth")
         // These are required for git-cliff (message parsed as conv-commit) and
         // external tools (stdin line reconstructed from sha + message).
-        // Entries without a commit_type (e.g. merges) are omitted; they would
-        // produce empty sections in every strategy.
+        // In production, commit_type is always Some(...) — parse_single_conventional_commit
+        // falls back to "chore" for non-conventional messages such as merge commits.
+        // Non-conventional commits reach git-cliff/External and are silently dropped there
+        // by filter_unconventional=true; they are not omitted here.
+        // The filter_map's `?` guards only against custom VersionCalculator
+        // implementations that might return None for commit_type.
         let commits: Vec<versioning::ConventionalCommit> = calc_result
             .analyzed_commits
             .iter()
             .filter_map(|a| {
                 let commit_type = a.commit_type.clone()?;
+                // Extract the description by dropping the "type(scope): " prefix from
+                // the full commit message.  For non-conventional messages (e.g. merge
+                // commits) where no ": " separator exists, fall back to the full message.
+                let description = a
+                    .message
+                    .find(": ")
+                    .map(|i| a.message[i + 2..].to_string())
+                    .unwrap_or_else(|| a.message.clone());
                 Some(versioning::ConventionalCommit {
                     commit_type,
                     scope: a.scope.clone(),
-                    description: a.message.clone(),
+                    description,
                     breaking_change: a.is_breaking,
                     message: a.message.clone(),
                     sha: a.sha.clone(),

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -339,7 +339,10 @@ where
             config,
             &self
                 .github_operations
-                .scoped_to(self.resolve_installation_id(owner, repo).await?),
+                .scoped_to(
+                    self.resolve_installation_id(owner, repo)
+                        .await?,
+                ),
         )
         .automate(owner, repo, event, correlation_id)
         .await
@@ -399,7 +402,10 @@ where
             config,
             &self
                 .github_operations
-                .scoped_to(self.resolve_installation_id(owner, repo).await?),
+                .scoped_to(
+                    self.resolve_installation_id(owner, repo)
+                        .await?,
+                ),
         )
         .process(event)
         .await
@@ -459,7 +465,9 @@ where
             .unwrap_or_default()
             .to_string();
 
-        let installation_id = self.resolve_installation_id(owner, repo).await?;
+        let installation_id = self
+            .resolve_installation_id(owner, repo)
+            .await?;
 
         let repo_config = self
             .configuration_provider
@@ -944,7 +952,9 @@ where
             })?
             .to_string();
 
-        let installation_id = self.resolve_installation_id(owner, repo).await?;
+        let installation_id = self
+            .resolve_installation_id(owner, repo)
+            .await?;
 
         let MergeCalcResult {
             calc_result,

--- a/crates/core/src/lib_tests.rs
+++ b/crates/core/src/lib_tests.rs
@@ -1366,16 +1366,25 @@ impl VersionCalculator for TestVersionCalcForLib {
         let analyzed_commits: Vec<CommitAnalysis> = self
             .changelog_entries
             .iter()
-            .map(|e| CommitAnalysis {
-                author: String::new(),
-                commit_type: Some(e.entry_type.clone()),
-                date: chrono::Utc::now(),
-                is_breaking: e.is_breaking,
-                message: e.description.clone(),
-                metadata: std::collections::HashMap::new(),
-                scope: e.scope.clone(),
-                sha: e.commit_sha.clone(),
-                version_bump: VersionBump::None,
+            .map(|e| {
+                // Construct the full conventional commit message so that
+                // calculate_version_for_merge can extract the description
+                // correctly (it strips the "type(scope): " prefix).
+                let full_message = match &e.scope {
+                    Some(s) => format!("{}({}): {}", e.entry_type, s, e.description),
+                    None => format!("{}: {}", e.entry_type, e.description),
+                };
+                CommitAnalysis {
+                    author: String::new(),
+                    commit_type: Some(e.entry_type.clone()),
+                    date: chrono::Utc::now(),
+                    is_breaking: e.is_breaking,
+                    message: full_message,
+                    metadata: std::collections::HashMap::new(),
+                    scope: e.scope.clone(),
+                    sha: e.commit_sha.clone(),
+                    version_bump: VersionBump::None,
+                }
             })
             .collect();
         Ok(VersionCalculationResult {
@@ -1615,7 +1624,7 @@ async fn test_handle_merged_pr_includes_changelog_entries_in_pr_body() {
         ChangelogEntry {
             commit_sha: "a".repeat(40),
             description: "add shiny feature".into(),
-            entry_type: "Added".into(),
+            entry_type: "feat".into(),
             is_breaking: false,
             issues: vec![],
             pr_number: None,
@@ -1624,7 +1633,7 @@ async fn test_handle_merged_pr_includes_changelog_entries_in_pr_body() {
         ChangelogEntry {
             commit_sha: "b".repeat(40),
             description: "fix nasty bug".into(),
-            entry_type: "Fixed".into(),
+            entry_type: "fix".into(),
             is_breaking: false,
             issues: vec![],
             pr_number: None,
@@ -1674,6 +1683,14 @@ async fn test_handle_merged_pr_includes_changelog_entries_in_pr_body() {
     assert!(
         body.contains(&"b".repeat(40)),
         "body missing commit sha B: {body}"
+    );
+    assert!(
+        body.contains("### Features"),
+        "body should contain '### Features' section header: {body}"
+    );
+    assert!(
+        body.contains("### Bug Fixes"),
+        "body should contain '### Bug Fixes' section header: {body}"
     );
 }
 

--- a/crates/core/src/lib_tests.rs
+++ b/crates/core/src/lib_tests.rs
@@ -1360,13 +1360,31 @@ impl VersionCalculator for TestVersionCalcForLib {
         _options: CalculationOptions,
     ) -> CoreResult<VersionCalculationResult> {
         *self.captured_ctx.lock().await = Some(ctx.clone());
+        // Synthesise CommitAnalysis entries from changelog_entries so that
+        // calculate_version_for_merge can build ConventionalCommit items from
+        // analyzed_commits (which carry the raw commit_type/message data).
+        let analyzed_commits: Vec<CommitAnalysis> = self
+            .changelog_entries
+            .iter()
+            .map(|e| CommitAnalysis {
+                author: String::new(),
+                commit_type: Some(e.entry_type.clone()),
+                date: chrono::Utc::now(),
+                is_breaking: e.is_breaking,
+                message: e.description.clone(),
+                metadata: std::collections::HashMap::new(),
+                scope: e.scope.clone(),
+                sha: e.commit_sha.clone(),
+                version_bump: VersionBump::None,
+            })
+            .collect();
         Ok(VersionCalculationResult {
             next_version: self.next_version.clone(),
             current_version: ctx.current_version,
             version_bump: self.version_bump.clone(),
             is_prerelease: false,
             build_metadata: None,
-            analyzed_commits: vec![],
+            analyzed_commits,
             changelog_entries: self.changelog_entries.clone(),
             strategy: VCalcStrategy::ConventionalCommits {
                 custom_types: HashMap::new(),

--- a/crates/core/src/release_orchestrator.rs
+++ b/crates/core/src/release_orchestrator.rs
@@ -1193,20 +1193,23 @@ fn skip_existing_version_section<'a>(rest: &'a str, version_str: &str) -> &'a st
 
 /// Merge two formatted changelog strings, deduplicating committed entries by SHA.
 ///
-/// Lines matching the pattern `- ... [<40-hex-SHA>]` are treated as commit
-/// entries.  New entries from `new_section` that share a SHA with an entry in
-/// `existing_section` are dropped.  All other lines are kept as-is from
-/// `existing_section`, with unique new entries appended.
+/// Lines matching the pattern `- ... [<hex-SHA>]` (where the SHA is 7–40
+/// hexadecimal characters) are treated as commit entries.  New entries from
+/// `new_section` that share a SHA with an entry in `existing_section` are
+/// dropped.  All other lines are kept as-is from `existing_section`, with
+/// unique new entries appended.
 fn merge_changelog_sections(existing_section: &str, new_section: &str) -> String {
-    /// Extract the last 40-character hex token from a commit line if it exists.
+    /// Extract the last hex SHA token from a commit line if it exists.
     fn extract_sha(line: &str) -> Option<&str> {
-        // Looks for `[<sha>]` at end of line where sha is exactly 40 hex chars.
+        // Looks for `[<sha>]` at end of line where sha is 7-40 hex chars.
+        // Both abbreviated (7-char) and full (40-char) SHAs are accepted so
+        // that changelogs from any supported strategy can be deduplicated.
         let inner = line.rfind('[').and_then(|i| {
             let after = &line[i + 1..];
             let close = after.find(']')?;
             Some(&after[..close])
         })?;
-        if inner.len() == 40 && inner.chars().all(|c| c.is_ascii_hexdigit()) {
+        if (7..=40).contains(&inner.len()) && inner.chars().all(|c| c.is_ascii_hexdigit()) {
             Some(inner)
         } else {
             None

--- a/crates/core/src/release_orchestrator.rs
+++ b/crates/core/src/release_orchestrator.rs
@@ -121,13 +121,50 @@ impl OrchestratorConfig {
     pub const DEFAULT_BODY_TEMPLATE: &'static str = "## Changelog\n\n${changelog}";
 }
 
+/// Derive the changelog-section header from a PR body template.
+///
+/// Scans `body_template` backwards from the `${changelog}` placeholder and
+/// returns the first `## ` heading line found.  Falls back to `"## Changelog"`
+/// when no such heading precedes the placeholder.
+///
+/// This keeps [`OrchestratorConfig::changelog_header`] and
+/// [`OrchestratorConfig::body_template`] in sync automatically: callers only
+/// need to set `body_template` and can derive `changelog_header` from it.
+///
+/// # Examples
+///
+/// ```
+/// use release_regent_core::release_orchestrator::extract_changelog_header;
+///
+/// assert_eq!(extract_changelog_header("## Changelog\n\n${changelog}"), "## Changelog");
+/// assert_eq!(extract_changelog_header("## Release Notes\n\n${changelog}"), "## Release Notes");
+/// // Falls back when no heading precedes the placeholder.
+/// assert_eq!(extract_changelog_header("${changelog}"), "## Changelog");
+/// ```
+pub fn extract_changelog_header(body_template: &str) -> String {
+    // Walk lines before ${changelog} in reverse to find the nearest ## heading.
+    let marker = "${changelog}";
+    let prefix = match body_template.find(marker) {
+        Some(i) => &body_template[..i],
+        None => body_template,
+    };
+    prefix
+        .lines()
+        .rev()
+        .find(|l| l.starts_with("## "))
+        .unwrap_or("## Changelog")
+        .to_string()
+}
+
 impl Default for OrchestratorConfig {
     fn default() -> Self {
+        let body_template = Self::DEFAULT_BODY_TEMPLATE.to_string();
+        let changelog_header = extract_changelog_header(&body_template);
         Self {
             branch_prefix: Self::DEFAULT_BRANCH_PREFIX.to_string(),
             title_template: "chore(release): {version_tag}".to_string(),
-            body_template: Self::DEFAULT_BODY_TEMPLATE.to_string(),
-            changelog_header: "## Changelog".to_string(),
+            changelog_header,
+            body_template,
             manifest_files: Vec::new(),
             auto_detect_manifests: true,
         }
@@ -1154,6 +1191,7 @@ fn skip_existing_version_section<'a>(rest: &'a str, version_str: &str) -> &'a st
     }
 }
 
+/// Merge two formatted changelog strings, deduplicating committed entries by SHA.
 ///
 /// Lines matching the pattern `- ... [<40-hex-SHA>]` are treated as commit
 /// entries.  New entries from `new_section` that share a SHA with an entry in

--- a/crates/core/src/release_orchestrator.rs
+++ b/crates/core/src/release_orchestrator.rs
@@ -75,9 +75,22 @@ pub struct OrchestratorConfig {
     /// Defaults to `"chore(release): {version_tag}"`.
     pub title_template: String,
 
+    /// Template for the release PR body.
+    ///
+    /// Use `${changelog}` as a placeholder; it is replaced with the formatted
+    /// changelog entries for **this release only**.  Any text before or after the
+    /// placeholder (version badges, footers, etc.) is preserved verbatim.
+    ///
+    /// Defaults to `"## Changelog\n\n${changelog}"`.
+    pub body_template: String,
+
     /// Sentinel that separates the generated changelog from any trailing content
     /// in the PR body.  The orchestrator will only look for commits between
     /// `## Changelog` and the next `##` heading (or end of string).
+    ///
+    /// Must match the Markdown heading that immediately precedes `${changelog}`
+    /// in [`Self::body_template`] so that changelog extraction from existing PR
+    /// bodies works correctly when updating an existing release PR.
     ///
     /// Defaults to `"## Changelog"`.
     pub changelog_header: String,
@@ -103,6 +116,9 @@ pub struct OrchestratorConfig {
 impl OrchestratorConfig {
     /// The default branch prefix used when no explicit configuration is provided.
     pub const DEFAULT_BRANCH_PREFIX: &'static str = "release";
+
+    /// The default PR body template string.
+    pub const DEFAULT_BODY_TEMPLATE: &'static str = "## Changelog\n\n${changelog}";
 }
 
 impl Default for OrchestratorConfig {
@@ -110,6 +126,7 @@ impl Default for OrchestratorConfig {
         Self {
             branch_prefix: Self::DEFAULT_BRANCH_PREFIX.to_string(),
             title_template: "chore(release): {version_tag}".to_string(),
+            body_template: Self::DEFAULT_BODY_TEMPLATE.to_string(),
             changelog_header: "## Changelog".to_string(),
             manifest_files: Vec::new(),
             auto_detect_manifests: true,
@@ -897,9 +914,10 @@ impl<'a, G: GitHubOperations> ReleaseOrchestrator<'a, G> {
             .replace("{version}", &version_str)
     }
 
-    /// Wrap the changelog body in the standard PR body format.
+    /// Render the PR body by substituting `${changelog}` in the configured
+    /// body template with the current release's changelog entries.
     fn render_body(&self, changelog: &str) -> String {
-        format!("{}\n\n{}", self.config.changelog_header, changelog)
+        self.config.body_template.replace("${changelog}", changelog)
     }
 
     /// Extract the changelog section from a PR body.

--- a/crates/core/src/release_orchestrator.rs
+++ b/crates/core/src/release_orchestrator.rs
@@ -54,6 +54,7 @@ use crate::{
     versioning::SemanticVersion,
     CoreError, CoreResult,
 };
+use chrono::Utc;
 use tracing::{debug, info, warn};
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -380,10 +381,30 @@ impl<'a, G: GitHubOperations> ReleaseOrchestrator<'a, G> {
         let title = self.render_title(version);
         let body = self.render_body(changelog);
 
+        // Fetch the existing CHANGELOG.md from the base branch so we can
+        // prepend the new version section rather than overwriting history.
+        let existing_changelog_file = self
+            .github
+            .get_file_content(owner, repo, "CHANGELOG.md", base_branch)
+            .await
+            .unwrap_or_else(|e| {
+                warn!(error = %e, "Failed to fetch existing CHANGELOG.md; starting fresh");
+                None
+            })
+            .unwrap_or_default();
+
+        let today = Utc::now().format("%Y-%m-%d").to_string();
+        let changelog_file_content = build_changelog_file_content(
+            &existing_changelog_file,
+            &version.to_string(),
+            &today,
+            changelog,
+        );
+
         // Build the batch of files: CHANGELOG.md plus any manifest files.
         let mut file_updates = vec![FileUpdate {
             path: "CHANGELOG.md".to_string(),
-            content: changelog.to_string(),
+            content: changelog_file_content,
         }];
         self.collect_manifest_updates(owner, repo, &actual_branch, version, &mut file_updates)
             .await;
@@ -480,10 +501,31 @@ impl<'a, G: GitHubOperations> ReleaseOrchestrator<'a, G> {
         // Files are committed BEFORE the PR metadata is updated so that, if the
         // commit step fails, the PR body never drifts ahead of the branch content.
 
+        // Fetch the existing CHANGELOG.md from the PR branch and rebuild the
+        // full content with the merged changelog section prepended so that
+        // history is preserved rather than overwritten (issue #128).
+        let existing_changelog_file = self
+            .github
+            .get_file_content(owner, repo, "CHANGELOG.md", &fresh_pr.head.ref_name)
+            .await
+            .unwrap_or_else(|e| {
+                warn!(error = %e, "Failed to fetch existing CHANGELOG.md; starting fresh");
+                None
+            })
+            .unwrap_or_default();
+
+        let today = Utc::now().format("%Y-%m-%d").to_string();
+        let changelog_file_content = build_changelog_file_content(
+            &existing_changelog_file,
+            &version.to_string(),
+            &today,
+            &merged_changelog,
+        );
+
         // Build batch: CHANGELOG.md plus manifest files — all in one atomic commit.
         let mut file_updates = vec![FileUpdate {
             path: "CHANGELOG.md".to_string(),
-            content: merged_changelog.clone(),
+            content: changelog_file_content,
         }];
         self.collect_manifest_updates(
             owner,
@@ -1038,6 +1080,62 @@ pub fn extract_changelog_from_pr_body(body: &str, changelog_header: &str) -> Str
 // ─────────────────────────────────────────────────────────────────────────────
 
 /// Merge two formatted changelog strings, deduplicating by commit SHA.
+/// Build the complete CHANGELOG.md content by inserting a new version section.
+///
+/// Inserts `## [{version_str}] - {date_str}\n\n{changelog_body}` after the
+/// file-level `# Changelog` header and before any existing `## [version]`
+/// sections.  If the file already contains a section for `version_str` it is
+/// replaced so that the operation is idempotent.  When `existing_content` is
+/// empty or lacks a `# Changelog` header, one is generated automatically.
+pub(crate) fn build_changelog_file_content(
+    existing_content: &str,
+    version_str: &str,
+    date_str: &str,
+    changelog_body: &str,
+) -> String {
+    let (file_header, rest) = split_changelog_header_and_rest(existing_content);
+    let file_header = if file_header.trim().is_empty() {
+        "# Changelog".to_string()
+    } else {
+        file_header.trim_end().to_string()
+    };
+    let history = skip_existing_version_section(rest, version_str);
+    let body = changelog_body.trim();
+    let history = history.trim_start();
+    if history.is_empty() {
+        format!("{file_header}\n\n## [{version_str}] - {date_str}\n\n{body}\n")
+    } else {
+        format!("{file_header}\n\n## [{version_str}] - {date_str}\n\n{body}\n\n{history}\n")
+    }
+}
+
+/// Split a CHANGELOG.md string into the file-level header (anything before
+/// the first `## ` version line) and the remainder (from that `## ` line on).
+fn split_changelog_header_and_rest(content: &str) -> (&str, &str) {
+    if content.starts_with("## ") {
+        return ("", content);
+    }
+    if let Some(pos) = content.find("\n## ") {
+        (&content[..pos], &content[pos + 1..])
+    } else {
+        (content, "")
+    }
+}
+
+/// If `rest` starts with a version section for `version_str`, skip over it
+/// and return the remaining content.  Otherwise return `rest` unchanged.
+fn skip_existing_version_section<'a>(rest: &'a str, version_str: &str) -> &'a str {
+    let version_prefix = format!("## [{version_str}]");
+    if !rest.starts_with(version_prefix.as_str()) {
+        return rest;
+    }
+    if let Some(next_pos) = rest[1..].find("\n## ").map(|i| i + 1) {
+        &rest[next_pos + 1..]
+    } else {
+        ""
+    }
+}
+
 ///
 /// Lines matching the pattern `- ... [<40-hex-SHA>]` are treated as commit
 /// entries.  New entries from `new_section` that share a SHA with an entry in

--- a/crates/core/src/release_orchestrator_tests.rs
+++ b/crates/core/src/release_orchestrator_tests.rs
@@ -1268,6 +1268,126 @@ fn test_merge_changelog_sections_preserves_new_section_headers() {
     );
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Unit tests for build_changelog_file_content
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Empty existing content produces a fresh `# Changelog` header followed by
+/// the new version section.
+#[test]
+fn test_build_changelog_file_content_empty_existing() {
+    let result =
+        build_changelog_file_content("", "1.0.0", "2024-01-15", "### Added\n\n- feat: new");
+
+    assert!(
+        result.starts_with("# Changelog\n"),
+        "should start with file-level header; got:\n{result}"
+    );
+    assert!(
+        result.contains("## [1.0.0] - 2024-01-15"),
+        "should contain version section; got:\n{result}"
+    );
+    assert!(
+        result.contains("feat: new"),
+        "should contain changelog body; got:\n{result}"
+    );
+}
+
+/// Existing history is preserved below the newly inserted section.
+#[test]
+fn test_build_changelog_file_content_with_existing_history() {
+    let existing = "# Changelog\n\n## [0.9.0] - 2024-01-01\n\n### Added\n\n- feat: old\n";
+
+    let result =
+        build_changelog_file_content(existing, "1.0.0", "2024-01-15", "### Added\n\n- feat: new");
+
+    let pos_new = result
+        .find("## [1.0.0]")
+        .expect("new section must be present");
+    let pos_old = result
+        .find("## [0.9.0]")
+        .expect("old section must be preserved");
+    assert!(
+        pos_new < pos_old,
+        "new section must appear before old section; got:\n{result}"
+    );
+}
+
+/// Calling the function twice with the same version replaces the existing
+/// section rather than duplicating it (idempotent behaviour).
+#[test]
+fn test_build_changelog_file_content_idempotent_same_version() {
+    let existing = "# Changelog\n\n## [1.0.0] - 2024-01-15\n\n### Added\n\n- feat: first run\n";
+
+    let result = build_changelog_file_content(
+        existing,
+        "1.0.0",
+        "2024-01-15",
+        "### Added\n\n- feat: second run",
+    );
+
+    assert_eq!(
+        result.matches("## [1.0.0]").count(),
+        1,
+        "version section must not be duplicated; got:\n{result}"
+    );
+    assert!(
+        result.contains("second run"),
+        "updated body must be present; got:\n{result}"
+    );
+    assert!(
+        !result.contains("first run"),
+        "old body must be replaced; got:\n{result}"
+    );
+}
+
+/// Content that already starts with a `## [version]` line (no file-level
+/// `# Changelog` header) gets the header prepended automatically.
+#[test]
+fn test_build_changelog_file_content_no_header() {
+    let existing = "## [0.1.0] - 2023-12-01\n\n### Fixed\n\n- fix: old\n";
+
+    let result =
+        build_changelog_file_content(existing, "1.0.0", "2024-01-15", "### Added\n\n- feat: new");
+
+    assert!(
+        result.starts_with("# Changelog\n"),
+        "generated header must be present; got:\n{result}"
+    );
+    assert!(
+        result.contains("## [1.0.0]"),
+        "new section must be present; got:\n{result}"
+    );
+    assert!(
+        result.contains("## [0.1.0]"),
+        "old section must be preserved; got:\n{result}"
+    );
+}
+
+/// Existing file-level header text (e.g. a description below `# Changelog`)
+/// is preserved verbatim.
+#[test]
+fn test_build_changelog_file_content_preserves_file_header() {
+    let existing =
+        "# Changelog\n\nAll notable changes are documented here.\n\n## [0.2.0] - 2024-01-10\n\n### Fixed\n\n- fix: something\n";
+
+    let result =
+        build_changelog_file_content(existing, "1.0.0", "2024-01-15", "### Added\n\n- feat: new");
+
+    assert!(
+        result.contains("All notable changes are documented here."),
+        "header description must be preserved; got:\n{result}"
+    );
+    assert!(
+        result.contains("## [1.0.0]"),
+        "new section must be present; got:\n{result}"
+    );
+    assert!(
+        result.contains("## [0.2.0]"),
+        "old section must be preserved; got:\n{result}"
+    );
+}
+
 /// When `search_pull_requests` returns multiple open release PRs the
 /// orchestrator selects the highest-versioned one, not the first match.
 #[tokio::test]

--- a/crates/core/src/release_orchestrator_tests.rs
+++ b/crates/core/src/release_orchestrator_tests.rs
@@ -1586,6 +1586,50 @@ fn test_extract_changelog_from_pr_body_empty_body_returns_empty() {
     assert_eq!(result, "");
 }
 
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// extract_changelog_header — free-function unit tests
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+#[test]
+fn test_extract_changelog_header_returns_default_heading_from_default_template() {
+    let header = super::extract_changelog_header(
+        crate::release_orchestrator::OrchestratorConfig::DEFAULT_BODY_TEMPLATE,
+    );
+    assert_eq!(header, "## Changelog");
+}
+
+#[test]
+fn test_extract_changelog_header_returns_custom_heading() {
+    let template = "## Release Notes\n\n${changelog}";
+    assert_eq!(
+        super::extract_changelog_header(template),
+        "## Release Notes"
+    );
+}
+
+#[test]
+fn test_extract_changelog_header_falls_back_when_no_heading_before_placeholder() {
+    assert_eq!(
+        super::extract_changelog_header("${changelog}"),
+        "## Changelog"
+    );
+}
+
+#[test]
+fn test_extract_changelog_header_ignores_heading_after_placeholder() {
+    let template = "${changelog}\n\n## Ignored";
+    assert_eq!(super::extract_changelog_header(template), "## Changelog");
+}
+
+#[test]
+fn test_extract_changelog_header_picks_nearest_heading_when_multiple_precede_placeholder() {
+    let template = "## Top\n\nSome text\n\n## Release Notes\n\n${changelog}";
+    assert_eq!(
+        super::extract_changelog_header(template),
+        "## Release Notes"
+    );
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // cargo_workspace_member_cargo_tomls — private helper unit tests
 // ─────────────────────────────────────────────────────────────────────────────

--- a/crates/core/src/release_orchestrator_tests.rs
+++ b/crates/core/src/release_orchestrator_tests.rs
@@ -1190,6 +1190,60 @@ async fn test_title_template_dollar_brace_version_tag_syntax_is_substituted() {
     }
 }
 
+/// Custom `body_template` is substituted into the PR body; only the current
+/// release changelog appears under `${changelog}`.
+#[tokio::test]
+async fn test_body_template_is_used_in_pr_body() {
+    let config = OrchestratorConfig {
+        body_template: "# Release\n\n${changelog}\n\n---\n*auto-generated*".to_string(),
+        ..OrchestratorConfig::default()
+    };
+    let github = TestGitHub::new();
+    let orchestrator = ReleaseOrchestrator::new(config, &github);
+
+    let changelog = "### Added\n\n- feat: shiny thing [ab12cd34ef5678901234abcdef12345678901234]";
+
+    let result = orchestrator
+        .orchestrate(
+            "testorg",
+            "testrepo",
+            &ver(1, 3, 0),
+            changelog,
+            "main",
+            "sha011",
+            "corr-011",
+        )
+        .await
+        .expect("orchestrate should succeed");
+
+    if let OrchestratorResult::Created { .. } = result {
+        let prs = github.created_prs().await;
+        assert_eq!(prs.len(), 1);
+        let body = prs[0].body.as_deref().unwrap_or("");
+        // Template prefix and suffix preserved.
+        assert!(
+            body.starts_with("# Release\n\n"),
+            "template prefix missing; body:\n{body}"
+        );
+        assert!(
+            body.ends_with("---\n*auto-generated*"),
+            "template suffix missing; body:\n{body}"
+        );
+        // Only current-release entries are present.
+        assert!(
+            body.contains("shiny thing"),
+            "changelog entry missing; body:\n{body}"
+        );
+        // The old `## Changelog` sentinel is NOT present because we overrode it.
+        assert!(
+            !body.contains("## Changelog"),
+            "default header should not appear in custom template; body:\n{body}"
+        );
+    } else {
+        panic!("expected Created, got {result:?}");
+    }
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Unit tests for internal helpers
 // ─────────────────────────────────────────────────────────────────────────────

--- a/crates/core/src/release_orchestrator_tests.rs
+++ b/crates/core/src/release_orchestrator_tests.rs
@@ -1322,6 +1322,50 @@ fn test_merge_changelog_sections_preserves_new_section_headers() {
     );
 }
 
+/// `merge_changelog_sections` deduplicates using abbreviated (7-char) SHAs.
+///
+/// Regression guard: git-cliff's body template historically truncated commit
+/// SHAs to 7 characters.  Even though the template now emits full SHAs, the
+/// deduplication logic must tolerate any SHA length ≥ 7 in case the user
+/// supplies a custom git-cliff template that still uses short hashes.
+#[test]
+fn test_merge_changelog_sections_handles_short_sha() {
+    let short_sha = "ab5749c";
+    let existing = format!("- fix: previous fix [{short_sha}]");
+    let new_section = format!("- fix: previous fix (dupe) [{short_sha}]");
+
+    let merged = merge_changelog_sections(&existing, &new_section);
+
+    assert_eq!(
+        merged.matches(short_sha).count(),
+        1,
+        "short SHA should be recognised; merged:\n{merged}"
+    );
+}
+
+/// `merge_changelog_sections` adds a new entry when the incoming section uses a
+/// 7-char SHA that is not already present in the existing section.
+#[test]
+fn test_merge_changelog_sections_appends_new_entry_with_short_sha() {
+    let old_sha = "0000001";
+    let new_sha = "aaabbbc";
+    let existing = format!("### Bug Fixes\n\n- fix: old thing [{old_sha}]");
+    let new_section =
+        format!("### Bug Fixes\n\n- fix: old thing [{old_sha}]\n- fix: new thing [{new_sha}]");
+
+    let merged = merge_changelog_sections(&existing, &new_section);
+
+    assert!(
+        merged.contains("new thing"),
+        "new entry should be appended; merged:\n{merged}"
+    );
+    assert_eq!(
+        merged.matches(old_sha).count(),
+        1,
+        "old entry must not be duplicated; merged:\n{merged}"
+    );
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Unit tests for build_changelog_file_content
 // ─────────────────────────────────────────────────────────────────────────────

--- a/crates/github_client/src/installation_tests.rs
+++ b/crates/github_client/src/installation_tests.rs
@@ -1,0 +1,222 @@
+// Tests for `get_installation_id_for_repo` HTTP status mapping.
+//
+// Uses wiremock to provide a local mock GitHub API server so no real
+// credentials are needed.  The key correctness property is that a 401
+// response (transient JWT rejection) maps to `CoreError::Network` (retryable)
+// — the inverse of `map_sdk_error`'s treatment of a general 401.
+
+use super::*;
+use github_bot_sdk::{
+    auth::{
+        AuthenticationProvider, GitHubAppId, Installation, InstallationId, InstallationPermissions,
+        InstallationToken, JsonWebToken, Repository as SdkRepository,
+    },
+    error::AuthError,
+};
+use release_regent_core::CoreError;
+use wiremock::{
+    matchers::{method, path},
+    Mock, MockServer, ResponseTemplate,
+};
+
+// ---------------------------------------------------------------------------
+// Minimal mock auth provider that returns a working app JWT
+// ---------------------------------------------------------------------------
+
+#[derive(Clone)]
+struct MockAppAuth {
+    token: String,
+}
+
+impl MockAppAuth {
+    fn new() -> Self {
+        Self {
+            token: "fake-jwt-for-tests".to_string(),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl AuthenticationProvider for MockAppAuth {
+    async fn app_token(&self) -> Result<JsonWebToken, AuthError> {
+        let app_id = GitHubAppId::new(1);
+        let expires_at = chrono::Utc::now() + chrono::Duration::minutes(10);
+        Ok(JsonWebToken::new(self.token.clone(), app_id, expires_at))
+    }
+
+    async fn installation_token(
+        &self,
+        installation_id: InstallationId,
+    ) -> Result<InstallationToken, AuthError> {
+        let expires_at = chrono::Utc::now() + chrono::Duration::hours(1);
+        Ok(InstallationToken::new(
+            "fake-token".to_string(),
+            installation_id,
+            expires_at,
+            InstallationPermissions::default(),
+            Vec::new(),
+        ))
+    }
+
+    async fn refresh_installation_token(
+        &self,
+        installation_id: InstallationId,
+    ) -> Result<InstallationToken, AuthError> {
+        self.installation_token(installation_id).await
+    }
+
+    async fn list_installations(&self) -> Result<Vec<Installation>, AuthError> {
+        Ok(Vec::new())
+    }
+
+    async fn get_installation_repositories(
+        &self,
+        _installation_id: InstallationId,
+    ) -> Result<Vec<SdkRepository>, AuthError> {
+        Ok(Vec::new())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helper: build a GitHubClient pointing at the mock server
+// ---------------------------------------------------------------------------
+
+fn make_app_client(mock_server: &MockServer) -> GitHubClient {
+    GitHubClient::new_for_testing(MockAppAuth::new(), 0, &mock_server.uri())
+        .expect("test client construction should not fail")
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// A 200 response with `{"id": 42}` should return `Ok(42)`.
+#[tokio::test]
+async fn test_get_installation_id_success_returns_id() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/repos/owner/repo/installation"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({ "id": 42 })))
+        .mount(&server)
+        .await;
+
+    let client = make_app_client(&server);
+    let result = client.get_installation_id_for_repo("owner", "repo").await;
+
+    assert_eq!(result.unwrap(), 42);
+}
+
+/// A 401 response must map to `CoreError::Network` and be retryable.
+///
+/// This is the inverse of `map_sdk_error`'s treatment of a general 401
+/// (which produces non-retryable `CoreError::Authentication`).  On the
+/// installation endpoint a 401 means the JWT was transiently rejected; the
+/// caller should retry with a fresh JWT.
+#[tokio::test]
+async fn test_get_installation_id_401_returns_retryable_network_error() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/repos/owner/repo/installation"))
+        .respond_with(ResponseTemplate::new(401).set_body_string("Unauthorized"))
+        .mount(&server)
+        .await;
+
+    let client = make_app_client(&server);
+    let err = client
+        .get_installation_id_for_repo("owner", "repo")
+        .await
+        .unwrap_err();
+
+    assert!(
+        matches!(err, CoreError::Network { .. }),
+        "401 should produce CoreError::Network, got: {:?}",
+        err
+    );
+    assert!(
+        err.is_retryable(),
+        "401 installation error must be retryable so a fresh JWT is attempted"
+    );
+}
+
+/// A 404 response means the app is not installed — non-retryable `CoreError::NotFound`.
+#[tokio::test]
+async fn test_get_installation_id_404_returns_not_found_non_retryable() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/repos/owner/repo/installation"))
+        .respond_with(ResponseTemplate::new(404).set_body_string("Not Found"))
+        .mount(&server)
+        .await;
+
+    let client = make_app_client(&server);
+    let err = client
+        .get_installation_id_for_repo("owner", "repo")
+        .await
+        .unwrap_err();
+
+    assert!(
+        matches!(err, CoreError::NotFound { .. }),
+        "404 should produce CoreError::NotFound, got: {:?}",
+        err
+    );
+    assert!(
+        !err.is_retryable(),
+        "404 (app not installed) should not be retryable"
+    );
+}
+
+/// A 500 response is a server-side transient error — retryable `CoreError::Network`.
+#[tokio::test]
+async fn test_get_installation_id_500_returns_retryable_network_error() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/repos/owner/repo/installation"))
+        .respond_with(ResponseTemplate::new(500).set_body_string("Internal Server Error"))
+        .mount(&server)
+        .await;
+
+    let client = make_app_client(&server);
+    let err = client
+        .get_installation_id_for_repo("owner", "repo")
+        .await
+        .unwrap_err();
+
+    assert!(
+        matches!(err, CoreError::Network { .. }),
+        "500 should produce CoreError::Network, got: {:?}",
+        err
+    );
+    assert!(err.is_retryable(), "500 server error should be retryable");
+}
+
+/// A 403 response is a permanent client-side error — non-retryable `CoreError::GitHub`.
+#[tokio::test]
+async fn test_get_installation_id_403_returns_github_error_non_retryable() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/repos/owner/repo/installation"))
+        .respond_with(ResponseTemplate::new(403).set_body_string("Forbidden"))
+        .mount(&server)
+        .await;
+
+    let client = make_app_client(&server);
+    let err = client
+        .get_installation_id_for_repo("owner", "repo")
+        .await
+        .unwrap_err();
+
+    assert!(
+        matches!(err, CoreError::GitHub { .. }),
+        "403 should produce CoreError::GitHub, got: {:?}",
+        err
+    );
+    assert!(
+        !err.is_retryable(),
+        "403 (forbidden) should not be retryable"
+    );
+}

--- a/crates/github_client/src/lib.rs
+++ b/crates/github_client/src/lib.rs
@@ -1524,11 +1524,77 @@ impl GitHubOperations for GitHubClient {
             .get_as_app(&path)
             .await
             .map_err(map_sdk_error)?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            let code = status.as_u16();
+            return Err(match code {
+                // A 401 from the installation endpoint means the JWT was
+                // rejected by GitHub.  This is treated as a transient auth
+                // token failure (clock skew, brief GitHub auth service hiccup)
+                // per the error-handling spec; the event will be retried and a
+                // fresh JWT will be used on the next attempt.
+                401 => {
+                    warn!(
+                        owner,
+                        repo,
+                        status = code,
+                        "Installation lookup returned 401 — transient JWT \
+                         rejection; event will be retried"
+                    );
+                    CoreError::network(format!(
+                        "installation lookup for {owner}/{repo} failed with 401 \
+                         (transient auth token rejection): {body}"
+                    ))
+                }
+                // 404 means the GitHub App is not installed on this repository.
+                // This is a permanent configuration error, not a transient one.
+                404 => {
+                    warn!(
+                        owner,
+                        repo,
+                        status = code,
+                        "Installation lookup returned 404 — app may not be \
+                         installed on this repository"
+                    );
+                    CoreError::not_found(format!(
+                        "installation lookup for {owner}/{repo} failed with 404 \
+                         (app not installed?): {body}"
+                    ))
+                }
+                // 5xx responses are server-side errors — transient and retryable.
+                s if s >= 500 => {
+                    warn!(
+                        owner,
+                        repo,
+                        status = code,
+                        "Installation lookup returned server error — will retry"
+                    );
+                    CoreError::network(format!(
+                        "installation lookup for {owner}/{repo} failed with \
+                         server error {s}: {body}"
+                    ))
+                }
+                // All other failures (403, other 4xx) are permanent.
+                _ => CoreError::GitHub {
+                    source: Box::new(std::io::Error::new(
+                        std::io::ErrorKind::Other,
+                        format!(
+                            "installation lookup for {owner}/{repo} failed with \
+                             status {status}: {body}"
+                        ),
+                    )),
+                    context: None,
+                },
+            });
+        }
+
         let body: serde_json::Value = response.json().await.map_err(CoreError::github)?;
         body["id"].as_u64().ok_or_else(|| CoreError::GitHub {
             source: Box::new(std::io::Error::new(
                 std::io::ErrorKind::Other,
-                "installation lookup response missing 'id' field",
+                format!("installation lookup for {owner}/{repo}: response missing 'id' field"),
             )),
             context: None,
         })

--- a/crates/github_client/src/lib.rs
+++ b/crates/github_client/src/lib.rs
@@ -2128,6 +2128,10 @@ fn is_not_found_error(error: &ApiError) -> bool {
 }
 
 #[cfg(test)]
+#[path = "installation_tests.rs"]
+mod installation_tests;
+
+#[cfg(test)]
 #[path = "lib_tests.rs"]
 mod lib_tests;
 

--- a/crates/testing/src/builders/configuration_builder.rs
+++ b/crates/testing/src/builders/configuration_builder.rs
@@ -5,6 +5,7 @@ use crate::builders::{
     TestDataBuilder,
 };
 use release_regent_core::{
+    changelog::ChangelogConfig,
     config::{
         BranchConfig, CoreConfig, ErrorHandlingConfig, NotificationConfig, NotificationStrategy,
         ReleasePrConfig, ReleaseRegentConfig, ReleasesConfig, VersioningConfig, VersioningStrategy,
@@ -119,5 +120,6 @@ fn create_default_config() -> ReleaseRegentConfig {
             allow_override: false,
             excluded_pr_authors: Vec::new(),
         },
+        changelog: ChangelogConfig::default(),
     }
 }

--- a/samples/config/release-regent.toml
+++ b/samples/config/release-regent.toml
@@ -52,19 +52,79 @@ strategy = "conventional"
 # (e.g. /override-bump minor).
 allow_override = true
 
+# PR authors whose PRs should be silently skipped (no status comment, no
+# post-merge refresh).  Useful for bot accounts such as Dependabot or Renovate.
+# excluded_pr_authors = ["dependabot[bot]", "renovate[bot]"]
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Release pull request
 # ─────────────────────────────────────────────────────────────────────────────
 
 [release_pr]
-# Template for the release PR title. ${version} is replaced at runtime.
+# Template for the release PR title.
+# Supported placeholders: ${version} (e.g. "1.2.3"), ${version_tag} (e.g. "v1.2.3").
 title_template = "chore(release): ${version}"
 
-# Template for the release PR body. ${changelog} is replaced at runtime.
+# Template for the release PR body.
+# ${changelog} is replaced with the changes for THIS release only.
+# Add any extra text (badges, footers, links) around the placeholder.
 body_template = "## Changelog\n\n${changelog}"
 
 # Create release PRs as drafts.
 draft = false
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Changelog generation
+# ─────────────────────────────────────────────────────────────────────────────
+#
+# Controls how CHANGELOG.md entries are produced and how the release PR body
+# changelog section is formatted.
+#
+# Three strategies are available:
+#
+#   internal   — built-in template renderer (default, no extra tooling needed)
+#   git_cliff  — delegates to the bundled git-cliff-core library for advanced
+#                Tera-based templating
+#   external   — runs an arbitrary subprocess; commits are sent on stdin as
+#                "{sha} {message}\n" lines and stdout becomes the changelog body
+
+[changelog]
+# Strategy: "internal" | "git_cliff" | use the [changelog.strategy.external]
+# table to delegate to an external command.
+#
+# Uncomment ONE of the blocks below, or leave the default (internal).
+
+# --- Option 1: built-in renderer (default) ---
+# strategy = "internal"
+
+# Whether to include commit authors, SHAs, and commit/PR links in entries.
+include_authors = true
+include_shas = true
+include_links = true
+
+# Section (type group) heading template.  {title} is replaced with the
+# conventional-commit type (e.g. "feat", "fix").
+section_template = "### {title}\n\n{entries}\n"
+
+# Per-commit line template.  {description} and {sha} are replaced at runtime.
+commit_template = "- {description} [{sha}]"
+
+# Remote URL used to generate links (leave blank to auto-detect from git remote).
+# remote_url = "https://github.com/myorg/myrepo"
+
+# --- Option 2: git-cliff-core renderer ---
+# Uncomment to use the bundled git-cliff-core library for changelog generation.
+# strategy = "git_cliff"
+# repository_path = "."
+
+# --- Option 3: external command ---
+# Uncomment to delegate changelog generation to a subprocess.
+# Commits are piped to stdin as "{sha} {message}\n" lines; stdout becomes the body.
+#
+# [changelog.strategy.external]
+# command = "git-cliff --from-stdin --unreleased"
+# env_vars = { GIT_CLIFF_CONFIG = "/path/to/cliff.toml" }
+# timeout_ms = 30000
 
 # ─────────────────────────────────────────────────────────────────────────────
 # GitHub releases

--- a/samples/create-test-repo.ps1
+++ b/samples/create-test-repo.ps1
@@ -631,14 +631,13 @@ path        = "version.txt"
 format      = "plain_text"
 version_key = 'version = "([^"]+)"'
 
-# ── Changelog (optional overrides) ─────────────────────────────────────────
-# The [changelog] section is now parsed (was silently ignored before).
-# Leave it commented out to use the app-level defaults (built-in renderer).
-#
-# [changelog]
-# strategy = "internal"    # "internal" | "git_cliff" | see strategy.external
-# include_shas   = true
-# include_links  = true
+# ── Changelog ──────────────────────────────────────────────────────────────
+# Override the app-level defaults to use git-cliff-core for rendering.
+# This exercises the [changelog] config path that was previously ignored.
+[changelog]
+strategy      = "git_cliff"  # "internal" (default) | "git_cliff" | strategy.external
+include_shas  = true
+include_links = true
 "@
 
 New-RepoFile 'src/greeting.md' @"

--- a/samples/create-test-repo.ps1
+++ b/samples/create-test-repo.ps1
@@ -613,6 +613,32 @@ group = "backend"
 # Allow contributors to override the calculated bump via PR comments.
 # versioning.strategy is locked by the group policy and cannot be changed here.
 allow_override = true
+
+[release_pr]
+# Register the version files that Release Regent should update on the release
+# branch alongside CHANGELOG.md.  Without these entries the files would keep
+# their old version numbers even after a release PR is merged.
+
+# package.json — standard JSON version field.
+[[release_pr.manifest_files]]
+path        = "package.json"
+format      = "json"
+version_key = "version"
+
+# version.txt — plain-text file; the regex capture group is replaced.
+[[release_pr.manifest_files]]
+path        = "version.txt"
+format      = "plain_text"
+version_key = 'version = "([^"]+)"'
+
+# ── Changelog (optional overrides) ─────────────────────────────────────────
+# The [changelog] section is now parsed (was silently ignored before).
+# Leave it commented out to use the app-level defaults (built-in renderer).
+#
+# [changelog]
+# strategy = "internal"    # "internal" | "git_cliff" | see strategy.external
+# include_shas   = true
+# include_links  = true
 "@
 
 New-RepoFile 'src/greeting.md' @"


### PR DESCRIPTION
Fixes three issues where CHANGELOG.md history was overwritten on each release, external changelog
commands were unsupported, the [changelog] config section was silently ignored, and the release PR
body grew unbounded because it included the full file history.

closes #128
closes #129
closes #130

## What Changed

- **Issue #128 — CHANGELOG.md overwrite**: `create_release_branch_and_pr` and `update_release_pr`
  now fetch the existing `CHANGELOG.md` from the target branch before writing. A new
  `build_changelog_file_content` helper prepends the new version section while preserving all
  previous sections. The operation is idempotent: re-running for the same version replaces rather
  than duplicates the section.
- **Issue #129 — External changelog strategy**: The `use_git_cliff: bool` field is replaced by a
  `ChangelogStrategy` enum with three variants: `Internal` (built-in renderer, default), `GitCliff`
  (bundled git-cliff-core), and `External { command, env_vars, timeout_ms }` (arbitrary subprocess
  fed commits on stdin). All `ChangelogConfig` fields gain `#[serde(default)]` so partial TOML
  blocks parse without error.
- **Issue #130 — changelog config ignored**: `ReleaseRegentConfig` now has a
  `pub changelog: ChangelogConfig` field with `#[serde(default)]`, so `[changelog]` blocks in
  `release-regent.toml` are no longer silently discarded.
- **PR body scoping**: `OrchestratorConfig` gains a `body_template: String` field (default:
  `"## Changelog\n\n${changelog}"`). `render_body` substitutes `${changelog}` with only the current
  release's entries, so the PR description never grows with cumulative history. The template is
  wired from `ReleasePrConfig::body_template` at both construction sites in `lib.rs`.
- **Samples updated**: `samples/config/release-regent.toml` documents the new `[changelog]` section
  and all three strategies. `create-test-repo.ps1` registers `package.json` and `version.txt` as
  manifest files so the test repo exercises version-file updates end-to-end.

## Why

- **#128**: Each release PR creation called `changelog.to_string()` as the full file content,
  discarding every previous release section. Long-running projects would lose their entire changelog
  history after the first Release Regent run.
- **#129**: Users who relied on `git-cliff` CLI or custom scripts had no way to plug them in at the
  changelog-generation step; the only options were the internal renderer or git-cliff-core.
- **#130**: `ReleaseRegentConfig` had no `changelog` field, so any `[changelog]` block a user wrote
  in their config file was parsed and then immediately dropped during config merging.
- **PR body scoping**: With #128 fixed, the full CHANGELOG.md history is preserved in the file, but
  the PR description only needs to show what changed in this release. Without scoping, the body would
  grow with every new release cycle.

## How

- `build_changelog_file_content(existing, version, date, body)` splits the existing file at the
  first `## [` version heading, optionally removes a stale section for the same version, then
  reassembles: `file_header + new_section + remaining_history`.
- `ChangelogStrategy` is an externally-tagged enum; TOML uses `[changelog.strategy.external]` table
  syntax consistent with the existing `[versioning.strategy.external]` pattern.
- `render_body` is changed from `format!("{header}\n\n{changelog}")` to
  `body_template.replace("${changelog}", changelog)`, making the header part of the user-controlled
  template rather than hardcoded. The `changelog_header` field is retained as the extraction
  sentinel used by `merge_changelog_bodies` when reading back an existing PR body.

## Testing Evidence

- **Test Coverage:** 14 new unit tests added:
  - 5 for `build_changelog_file_content` (empty input, existing history, idempotency, no header, header preservation)
  - 5 for `ChangelogStrategy` TOML round-trips (Internal, GitCliff, External, default timeout, empty command error)
  - 2 for `ReleaseRegentConfig` changelog section (parsed from TOML, defaults when absent)
  - 1 sample config round-trip (`test_sample_config_parses_without_error` using `include_str!`)
  - 1 for `body_template` substitution in the created PR
- **Test Results:** All 405 unit tests passing (`cargo test -p release-regent-core --lib`)
- **Manual Testing:** Not yet performed; end-to-end testing is the purpose of the updated `create-test-repo.ps1` script

## Reviewer Guidance

- `build_changelog_file_content` relies on `\n## ` as the version-section delimiter. Files that use
  a different heading level for version sections (e.g. `### `) will not be split correctly — this is
  a known constraint consistent with the keep-a-changelog convention.
- The `changelog_header` field in `OrchestratorConfig` must match the Markdown heading that
  precedes `${changelog}` in `body_template`; mismatching them causes `merge_changelog_bodies` to
  fail to extract the existing changelog when updating a PR. The default values are consistent.
- `ChangelogStrategy::External` spawns a blocking subprocess on the calling async task thread —
  verify this is acceptable for the deployment model (single-threaded vs. multi-threaded Tokio
  runtime).
- The `test.env` file previously contained real credentials (app ID, webhook secret, private key
  path) that have now been replaced with empty placeholders. Confirm those values have been rotated
  if the file was ever pushed to a remote before this PR.