### PR TITLE
fix(orchestrator): preserve changelog history on release PR update

### DIFF
--- a/crates/core/src/release_orchestrator.rs
+++ b/crates/core/src/release_orchestrator.rs
@@ -1155,13 +1155,12 @@ pub(crate) fn build_changelog_file_content(
     // level-1 Markdown heading.  Content that starts with `## ` or `### `
     // section markers (e.g. raw changelog entries leaked from a corrupted PR
     // body) is not a valid file-level header and must be discarded.
-    let file_header = if file_header.trim().is_empty()
-        || !file_header.trim_start().starts_with("# ")
-    {
-        "# Changelog".to_string()
-    } else {
-        file_header.trim_end().to_string()
-    };
+    let file_header =
+        if file_header.trim().is_empty() || !file_header.trim_start().starts_with("# ") {
+            "# Changelog".to_string()
+        } else {
+            file_header.trim_end().to_string()
+        };
     let history = skip_existing_version_section(rest, version_str);
     let body = changelog_body.trim();
     let history = history.trim_start();

--- a/crates/core/src/release_orchestrator.rs
+++ b/crates/core/src/release_orchestrator.rs
@@ -555,12 +555,14 @@ impl<'a, G: GitHubOperations> ReleaseOrchestrator<'a, G> {
         // Files are committed BEFORE the PR metadata is updated so that, if the
         // commit step fails, the PR body never drifts ahead of the branch content.
 
-        // Fetch the existing CHANGELOG.md from the PR branch and rebuild the
-        // full content with the merged changelog section prepended so that
-        // history is preserved rather than overwritten (issue #128).
+        // Fetch the existing CHANGELOG.md from the PR *base* branch (e.g. master)
+        // rather than the PR head branch.  The head branch may contain corrupted
+        // content written by an older release-regent; the base branch is always the
+        // authoritative source of historical changelog data.  This is exactly
+        // symmetric with the create_release_branch_and_pr path.
         let existing_changelog_file = self
             .github
-            .get_file_content(owner, repo, "CHANGELOG.md", &fresh_pr.head.ref_name)
+            .get_file_content(owner, repo, "CHANGELOG.md", &fresh_pr.base.ref_name)
             .await
             .unwrap_or_else(|e| {
                 warn!(error = %e, "Failed to fetch existing CHANGELOG.md; starting fresh");
@@ -1149,7 +1151,13 @@ pub(crate) fn build_changelog_file_content(
     changelog_body: &str,
 ) -> String {
     let (file_header, rest) = split_changelog_header_and_rest(existing_content);
-    let file_header = if file_header.trim().is_empty() {
+    // Accept the file header only if it is non-empty AND begins with a `# `
+    // level-1 Markdown heading.  Content that starts with `## ` or `### `
+    // section markers (e.g. raw changelog entries leaked from a corrupted PR
+    // body) is not a valid file-level header and must be discarded.
+    let file_header = if file_header.trim().is_empty()
+        || !file_header.trim_start().starts_with("# ")
+    {
         "# Changelog".to_string()
     } else {
         file_header.trim_end().to_string()

--- a/crates/core/src/release_orchestrator_tests.rs
+++ b/crates/core/src/release_orchestrator_tests.rs
@@ -1520,6 +1520,10 @@ fn test_build_changelog_file_content_rejects_non_hash_prefix_as_file_header() {
         "raw section headers must not appear as file-level header; got:\n{result}"
     );
     assert!(
+        !result.contains("- **config**: some commit"),
+        "corrupted entry lines must not appear anywhere in output; got:\n{result}"
+    );
+    assert!(
         result.contains("## [1.0.0]"),
         "version section must be present; got:\n{result}"
     );

--- a/crates/core/src/release_orchestrator_tests.rs
+++ b/crates/core/src/release_orchestrator_tests.rs
@@ -50,6 +50,8 @@ struct TestState {
     batch_commits: Vec<(String, Vec<String>, String)>,
     /// Recorded `batch_commit_files_rebased` calls: (branch, paths, message, parent_sha).
     rebased_batch_commits: Vec<(String, Vec<String>, String, String)>,
+    /// Full `FileUpdate` lists from each `batch_commit_files_rebased` call.
+    rebased_batch_file_updates: Vec<Vec<FileUpdate>>,
     /// Pre-loaded file contents for `get_file_content`: (path, branch) → content.
     file_contents: std::collections::HashMap<(String, String), String>,
     /// Sequential PR number to return from `create_pull_request`.
@@ -125,6 +127,10 @@ impl TestGitHub {
 
     async fn rebased_batch_commits(&self) -> Vec<(String, Vec<String>, String, String)> {
         self.state.lock().await.rebased_batch_commits.clone()
+    }
+
+    async fn rebased_batch_file_updates(&self) -> Vec<Vec<FileUpdate>> {
+        self.state.lock().await.rebased_batch_file_updates.clone()
     }
 
     /// Pre-load a file content so `get_file_content` returns it.
@@ -514,12 +520,14 @@ impl GitHubOperations for TestGitHub {
         parent_sha: &str,
     ) -> CoreResult<()> {
         let paths: Vec<String> = files.iter().map(|f| f.path.clone()).collect();
-        self.state.lock().await.rebased_batch_commits.push((
+        let mut st = self.state.lock().await;
+        st.rebased_batch_commits.push((
             branch.to_string(),
             paths,
             message.to_string(),
             parent_sha.to_string(),
         ));
+        st.rebased_batch_file_updates.push(files.to_vec());
         Ok(())
     }
 
@@ -1483,6 +1491,113 @@ fn test_build_changelog_file_content_preserves_file_header() {
     assert!(
         result.contains("## [0.2.0]"),
         "old section must be preserved; got:\n{result}"
+    );
+}
+
+/// Content whose leading block starts with `### ` (not a proper `# ` file
+/// header) is treated as garbage and replaced by a generated `# Changelog`
+/// header rather than being preserved verbatim.
+///
+/// Regression guard for the secondary bug: corrupted CHANGELOG.md files written
+/// by old release-regent (raw `### feat`/`### fix` blocks at the top) must not
+/// be silently accepted as a valid file-level header.
+#[test]
+fn test_build_changelog_file_content_rejects_non_hash_prefix_as_file_header() {
+    // Simulates the corrupted content written by old release-regent: raw
+    // `### feat`/`### fix` section blocks at the top of the file, no
+    // `# Changelog` file-level header, and only the current version section.
+    let corrupted = "### feat\n- **config**: some commit [aabbccdd]\n### fix\n- **release**: another [bbccddee]\n\n## [1.0.0] - 2024-01-15\n\n### Features\n\n- feat: thing\n";
+
+    let result =
+        build_changelog_file_content(corrupted, "1.0.0", "2024-01-15", "### Added\n\n- feat: new");
+
+    assert!(
+        result.starts_with("# Changelog\n"),
+        "corrupted non-header content must be replaced by '# Changelog'; got:\n{result}"
+    );
+    assert!(
+        !result.contains("### feat\n"),
+        "raw section headers must not appear as file-level header; got:\n{result}"
+    );
+    assert!(
+        result.contains("## [1.0.0]"),
+        "version section must be present; got:\n{result}"
+    );
+}
+
+/// `update_release_pr` reads CHANGELOG.md from the PR *base* branch (e.g.
+/// `main`), not from the PR head branch.
+///
+/// Regression guard for the primary bug: when the head branch contains a
+/// corrupted CHANGELOG.md (written by an older release-regent), the update
+/// path must still produce a correct file with history by reading from the
+/// authoritative base branch.
+#[tokio::test]
+async fn test_update_release_pr_reads_changelog_from_base_branch() {
+    let version = ver(1, 0, 0);
+
+    let corrupted_head_changelog =
+        "### feat\n- some commit [aabbccdd]\n\n## [1.0.0] - 2026-01-01\n\n### Features\n\n- feat: thing\n";
+    let correct_base_changelog =
+        "# Changelog\n\nAll notable changes.\n\n## [0.9.0] - 2025-12-01\n\n### Fixed\n\n- fix: old thing [cccccccccccccccccccccccccccccccccccccccc]\n";
+
+    let existing_body =
+        "## Changelog\n\n- feat: something [1234567890abcdef1234567890abcdef12345678]";
+    let existing_pr = make_open_release_pr(55, "release/v1.0.0", Some(existing_body));
+
+    let github = TestGitHub::new()
+        .with_search_results(vec![existing_pr.clone()])
+        .await
+        .with_pr_by_number(existing_pr)
+        .await
+        // Corrupted content on the head branch.
+        .with_file_content("CHANGELOG.md", "release/v1.0.0", corrupted_head_changelog)
+        .await
+        // Correct content with history on the base branch.
+        .with_file_content("CHANGELOG.md", "main", correct_base_changelog)
+        .await;
+
+    let orchestrator = ReleaseOrchestrator::new(default_config(), &github);
+
+    orchestrator
+        .orchestrate(
+            "testorg",
+            "testrepo",
+            &version,
+            "- feat: new feature [1234567890abcdef1234567890abcdef12345678]",
+            "main",
+            "sha-base-001",
+            "corr-update-001",
+        )
+        .await
+        .expect("orchestrate should succeed");
+
+    let file_updates = github.rebased_batch_file_updates().await;
+    assert_eq!(
+        file_updates.len(),
+        1,
+        "expected exactly one rebased batch commit"
+    );
+
+    let changelog_update = file_updates[0]
+        .iter()
+        .find(|f| f.path == "CHANGELOG.md")
+        .expect("CHANGELOG.md must be in the committed files");
+
+    assert!(
+        changelog_update.content.starts_with("# Changelog\n"),
+        "committed CHANGELOG.md must start with '# Changelog'; got:\n{}",
+        changelog_update.content
+    );
+    assert!(
+        changelog_update.content.contains("## [0.9.0]"),
+        "history from base branch must be preserved; got:\n{}",
+        changelog_update.content
+    );
+    assert!(
+        !changelog_update.content.contains("### feat\n"),
+        "corrupted head-branch header must not appear; got:\n{}",
+        changelog_update.content
     );
 }
 


### PR DESCRIPTION
Fixes two bugs in the update_release_pr path that caused all historical CHANGELOG.md
sections to be silently lost on every release PR update cycle.

closes #133

## What Changed
- `update_release_pr`: changed `get_file_content` to read `CHANGELOG.md` from
  `fresh_pr.base.ref_name` (the base branch, e.g. `master`) instead of
  `fresh_pr.head.ref_name` (the release branch).
- `build_changelog_file_content`: tightened the file-header guard so that only
  content starting with a level-1 Markdown heading (`# `) is accepted as a valid
  file-level header. Content starting with `## ` or `### ` (e.g. raw section
  markers leaked from a corrupted PR body) is now discarded and replaced by a
  generated `# Changelog` header.

## Why
The `create_release_branch_and_pr` path already read `CHANGELOG.md` from the base
branch (fixed in PR #131). The `update_release_pr` path did not receive the same
fix and continued to read from the PR head branch. If that branch was created by an
older release-regent that wrote corrupted content (no `# Changelog` header, raw
`### feat`/`### fix` blocks, no historical version sections), every subsequent update
run would read the corrupted file, classify the raw section blocks as the file-level
header, skip the existing version section, and write back a file containing only the
current version — losing all history on every run.

## How
**Bug 1**: The one-line change from `fresh_pr.head.ref_name` to
`fresh_pr.base.ref_name` makes the update path symmetric with the create path. The
base branch is always the authoritative source of historical changelog data.
`build_changelog_file_content` already replaces the existing version section, so
reading from the base branch produces a correct accumulated file regardless of how
many update cycles have previously run.

**Bug 2**: The file-header guard was extended from `is_empty()` to
`is_empty() || !trim_start().starts_with("# ")`. This ensures that only proper
level-1 Markdown headings are preserved; any other content is replaced with a
freshly generated `# Changelog` header.

## Testing Evidence
- **Test Coverage:** Added 2 regression tests and extended the `TestGitHub` test
  double with a `rebased_batch_file_updates()` accessor to allow inspection of
  committed file contents:
  - `test_update_release_pr_reads_changelog_from_base_branch` — integration test
    that pre-loads corrupted content on the head branch and correct history on the
    base branch; asserts the committed `CHANGELOG.md` contains the history and
    starts with `# Changelog`.
  - `test_build_changelog_file_content_rejects_non_hash_prefix_as_file_header` —
    unit test that verifies raw `### feat`/`### fix` blocks are replaced by a
    generated header rather than preserved verbatim.
- **Test Results:** All 52 `release_orchestrator` tests passing; no regressions.
- **Manual Testing:** Reproduces the scenario described in the bug report
  (corrupted head branch, correct base branch) and confirms the committed file
  matches the base-branch history.

## Reviewer Guidance
- The core of Bug 1 is a single line change (`head` → `base`); verify it is
  consistent with the equivalent line in `create_release_branch_and_pr`.
- The Bug 2 guard uses `starts_with("# ")` (space after hash) to distinguish a
  level-1 heading from `##` / `###` markers — confirm this correctly handles all
  expected `# Changelog` header variants (e.g. `# Changelog\n\nSome description`).
- The `rebased_batch_file_updates` addition to `TestState` stores a `Vec<Vec<FileUpdate>>`
  alongside the existing `rebased_batch_commits`; verify the two vecs remain in sync
  for all call sites.
- No breaking changes; no migration steps required.