### PR TITLE
fix(automator): honour releases.generate_notes config when creating GitHub releases

### DIFF
--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -249,7 +249,7 @@ pub struct ReleasesConfig {
 }
 
 fn default_generate_notes() -> bool {
-    true
+    false
 }
 
 impl Default for ReleasesConfig {

--- a/crates/core/src/config_tests.rs
+++ b/crates/core/src/config_tests.rs
@@ -81,7 +81,7 @@ fn test_default_configuration() {
     assert_eq!(config.core.branches.main, "main");
     assert!(!config.release_pr.draft);
     assert!(!config.releases.draft);
-    assert!(config.releases.generate_notes);
+    assert!(!config.releases.generate_notes);
     assert_eq!(config.error_handling.max_retries, 5);
     assert!(config.notifications.enabled);
     assert!(matches!(

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -345,6 +345,7 @@ where
                 &repo_config.release_pr.body_template,
             ),
             version_prefix: repo_config.core.version_prefix.clone(),
+            generate_release_notes: repo_config.releases.generate_notes,
         };
 
         match ReleaseAutomator::new(

--- a/crates/core/src/release_automator.rs
+++ b/crates/core/src/release_automator.rs
@@ -85,6 +85,17 @@ pub struct AutomatorConfig {
     ///
     /// Defaults to `"v"`.
     pub version_prefix: String,
+
+    /// Whether to ask GitHub to auto-generate release notes from commits and
+    /// pull requests when creating the GitHub release.
+    ///
+    /// When `true` the `generate_release_notes` flag in the GitHub API
+    /// request is set, causing GitHub to append its own notes to the body.
+    /// When `false` (the default) only the changelog extracted from the PR
+    /// body is used.
+    ///
+    /// Defaults to `false`.
+    pub generate_release_notes: bool,
 }
 
 impl Default for AutomatorConfig {
@@ -93,6 +104,7 @@ impl Default for AutomatorConfig {
             branch_prefix: "release".to_string(),
             changelog_header: "## Changelog".to_string(),
             version_prefix: "v".to_string(),
+            generate_release_notes: false,
         }
     }
 }
@@ -211,7 +223,7 @@ impl<'a, G: GitHubOperations + Send + Sync> ReleaseAutomator<'a, G> {
                     body: Some(changelog),
                     draft: false,
                     prerelease: is_prerelease,
-                    generate_release_notes: false,
+                    generate_release_notes: self.config.generate_release_notes,
                     target_commitish: Some(merge_sha),
                 },
             )

--- a/crates/core/src/release_automator_tests.rs
+++ b/crates/core/src/release_automator_tests.rs
@@ -1407,3 +1407,67 @@ async fn test_automate_custom_version_prefix_creates_tag_with_prefix() {
     assert_eq!(tags.len(), 1);
     assert_eq!(tags[0].0, "release-1.2.3");
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// generate_release_notes config tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_automate_generate_release_notes_true_sets_flag_in_api_call() {
+    // When AutomatorConfig::generate_release_notes is true, the API request
+    // must pass generate_release_notes: true so GitHub generates release notes.
+    let github = TestGitHub::new();
+    let config = AutomatorConfig {
+        generate_release_notes: true,
+        ..AutomatorConfig::default()
+    };
+    let automator = ReleaseAutomator::new(config, &github);
+
+    let event = make_release_pr_event(
+        "release/v1.2.3",
+        "deadbeef1234567890deadbeef1234567890abcd",
+        "## Changelog\n\n- feat: add widget [abc123def456789012345678901234567890abcd]\n",
+    );
+
+    automator
+        .automate("testorg", "testrepo", &event, "corr-001")
+        .await
+        .unwrap();
+
+    let releases = github.created_releases().await;
+    assert_eq!(releases.len(), 1);
+    assert!(
+        releases[0].generate_release_notes,
+        "generate_release_notes must be true when configured as true"
+    );
+}
+
+#[tokio::test]
+async fn test_automate_generate_release_notes_false_clears_flag_in_api_call() {
+    // When AutomatorConfig::generate_release_notes is false (the default),
+    // the API request must pass generate_release_notes: false.
+    let github = TestGitHub::new();
+    let config = AutomatorConfig {
+        generate_release_notes: false,
+        ..AutomatorConfig::default()
+    };
+    let automator = ReleaseAutomator::new(config, &github);
+
+    let event = make_release_pr_event(
+        "release/v1.2.3",
+        "deadbeef1234567890deadbeef1234567890abcd",
+        "## Changelog\n\n- feat: add widget [abc123def456789012345678901234567890abcd]\n",
+    );
+
+    automator
+        .automate("testorg", "testrepo", &event, "corr-001")
+        .await
+        .unwrap();
+
+    let releases = github.created_releases().await;
+    assert_eq!(releases.len(), 1);
+    assert!(
+        !releases[0].generate_release_notes,
+        "generate_release_notes must be false when configured as false"
+    );
+}

--- a/docs/specs/operations/configuration.md
+++ b/docs/specs/operations/configuration.md
@@ -97,7 +97,7 @@ assignees = []
 [releases]
 draft = false
 prerelease = false
-generate_notes = true
+generate_notes = false  # Opt in to GitHub-generated notes; default is false so the custom changelog is used
 cleanup_branches = true
 
 # Versioning strategy
@@ -518,7 +518,7 @@ labels = ["release", "automated"]
 [releases]
 draft = false
 prerelease = false
-generate_notes = true
+generate_notes = false  # Opt in to GitHub-generated notes; default is false so the custom changelog is used
 cleanup_branches = true
 
 [versioning]


### PR DESCRIPTION
Fixes a silent bug where release-regent always passed generate_release_notes: false
to the GitHub API regardless of the releases.generate_notes setting in
release-regent.toml, making the documented default of true have no effect at runtime.

closes #141

## What Changed
- Added `generate_release_notes: bool` field to `AutomatorConfig` (default `false`,
  preserving existing runtime behaviour).
- Replaced the hardcoded `false` literal in `CreateReleaseParams` inside
  `ReleaseAutomator::automate()` with `self.config.generate_release_notes`.
- Threaded `repo_config.releases.generate_notes` into `AutomatorConfig` in
  `lib.rs::handle_release_pr_merged` so the value flows from config file to API call.
- Changed `default_generate_notes()` in `config.rs` from `true` to `false` so the
  schema default matches the runtime default, eliminating the contradiction.

## Why
`AutomatorConfig` had no field for this setting, so there was no path from the
`releases.generate_notes` config key to the GitHub API call. Users who relied on the
documented default (`true`) or who explicitly set `generate_notes = true` would never
get GitHub's auto-generated release notes. Users who set `false` got the same behaviour
as users who set `true`, making the config key entirely inert.

## How
The fix follows the existing pattern for other `AutomatorConfig` fields: add the field
to the struct, supply a sensible default, and set it from `repo_config` at the
construction site in `handle_release_pr_merged`. No new abstractions were introduced.

## Testing Evidence
- **Test Coverage:** Added two new async tests in `release_automator_tests.rs`:
  `test_automate_generate_release_notes_true_sets_flag_in_api_call` and
  `test_automate_generate_release_notes_false_clears_flag_in_api_call`. Both inspect
  the `CreateReleaseParams` recorded by the test double to assert the correct flag value.
- **Test Results:** All 39 `release_automator` tests pass; no regressions.
- **Manual Testing:** Not applicable — the fix is fully covered by the unit test double.

## Reviewer Guidance
- Confirm the new default (`false`) is the right choice; users who previously relied on
  the (broken) documented default of `true` will now need to set `generate_notes = true`
  explicitly in their config — consider whether a changelog note or migration hint is warranted.
- The `releases.generate_notes` field in `ReleasesConfig` and the new
  `AutomatorConfig::generate_release_notes` field are intentionally separate: one is
  the user-facing config type, the other is the internal automator config.
- No breaking changes to public API; `AutomatorConfig::default()` behaviour is unchanged
  (`generate_release_notes: false`).