### PR TITLE
fix(core): correct release-PR merge routing and label cleanup

### DIFF
--- a/crates/core/src/changelog.rs
+++ b/crates/core/src/changelog.rs
@@ -30,10 +30,11 @@ use git_cliff_core::{
 /// env_vars = { GIT_CLIFF_CONFIG = "/path/to/cliff.toml" }
 /// timeout_ms = 30000
 /// ```
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum ChangelogStrategy {
     /// Built-in template renderer.
+    #[default]
     Internal,
     /// Delegate to git-cliff-core for advanced Tera-based templating.
     GitCliff,
@@ -71,12 +72,6 @@ fn default_section_template() -> String {
 
 fn default_commit_template() -> String {
     "- {description} [{sha}]".to_string()
-}
-
-impl Default for ChangelogStrategy {
-    fn default() -> Self {
-        Self::Internal
-    }
 }
 
 /// Configuration for changelog generation.

--- a/crates/core/src/comment_command_processor.rs
+++ b/crates/core/src/comment_command_processor.rs
@@ -540,6 +540,12 @@ impl<'a, G: GitHubOperations + Send + Sync> CommentCommandProcessor<'a, G> {
                 "NoBumpNeeded cannot be returned by orchestrate() from a \
                  !set-version command path"
             ),
+            // TaggedRelease is produced by the release-PR merge path and is
+            // never returned by `ReleaseOrchestrator::orchestrate()`.
+            OrchestratorResult::TaggedRelease => unreachable!(
+                "TaggedRelease cannot be returned by orchestrate() from a \
+                 !set-version command path"
+            ),
         }
     }
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -359,6 +359,15 @@ where
         {
             Ok(result) => {
                 tracing::info!(result = ?result, "Release automation completed");
+                // Clear stale rr:override-* labels from open feature PRs now that
+                // a new release has been published.
+                self.clear_stale_override_labels_after_release(
+                    owner,
+                    repo,
+                    event.installation_id,
+                    correlation_id,
+                )
+                .await;
                 self.try_refresh_feature_pr_status_comments(
                     owner,
                     repo,
@@ -1025,11 +1034,8 @@ where
                 repo,
                 installation_id,
                 correlation_id,
-                &orchestrator,
-                &calc_result.next_version,
-                &changelog,
-                &base_branch,
-                &base_sha,
+                &repo_config,
+                event,
             )
             .await
         } else {
@@ -1159,46 +1165,54 @@ where
         })
     }
 
-    /// Handle the release-PR path after a merged pull request.
+    /// Handle the release-PR path when a merged pull request is identified as a
+    /// release PR.
     ///
-    /// Orchestrates the next release cycle and clears stale bump-override labels
-    /// from open feature PRs that were scoped to the completed release.
-    #[allow(clippy::too_many_arguments)] // owner/repo/installation_id/correlation/orchestrator/version/changelog/branch/sha is the minimal surface
+    /// This path is taken when `handle_merged_pull_request` (the inherent method)
+    /// detects that the merged PR head branch starts with the configured release
+    /// prefix — typically because the webhook event was classified as
+    /// `PullRequestMerged` rather than `ReleasePrMerged` (the two differ when
+    /// the server's default `version_prefix` does not match the repository's
+    /// configured prefix).
+    ///
+    /// Invokes [`release_automator::ReleaseAutomator`] to create the annotated
+    /// git tag and GitHub release, then clears stale bump-override labels from
+    /// any open feature PRs.
     async fn process_release_pr_merged(
         &self,
         owner: &str,
         repo: &str,
         installation_id: u64,
         correlation_id: &str,
-        orchestrator: &release_orchestrator::ReleaseOrchestrator<'_, G>,
-        version: &versioning::SemanticVersion,
-        changelog: &str,
-        base_branch: &str,
-        base_sha: &str,
+        repo_config: &config::ReleaseRegentConfig,
+        event: &traits::event_source::ProcessingEvent,
     ) -> CoreResult<release_orchestrator::OrchestratorResult> {
+        use release_automator::{AutomatorConfig, ReleaseAutomator};
+
         tracing::info!(
             owner = %owner,
             repo = %repo,
-            version = %version,
-            base_branch = %base_branch,
             correlation_id = %correlation_id,
-            "Orchestrating for merged release PR"
+            "Handling merged release PR via automator \
+             (arrived as PullRequestMerged; head branch matches release prefix)"
         );
 
-        let orch_result = orchestrator
-            .orchestrate(
-                owner,
-                repo,
-                version,
-                changelog,
-                base_branch,
-                base_sha,
-                correlation_id,
-            )
+        let default_orch = release_orchestrator::OrchestratorConfig::default();
+        let config = AutomatorConfig {
+            branch_prefix: default_orch.branch_prefix,
+            changelog_header: release_orchestrator::extract_changelog_header(
+                &repo_config.release_pr.body_template,
+            ),
+            version_prefix: repo_config.core.version_prefix.clone(),
+            generate_release_notes: repo_config.releases.generate_notes,
+        };
+
+        ReleaseAutomator::new(config, &self.github_operations.scoped_to(installation_id))
+            .automate(owner, repo, event, correlation_id)
             .await?;
 
-        // After a release is published, clear stale rr:override-* labels from
-        // any open feature PRs. Overrides were scoped to this release cycle.
+        // After the release is published, clear stale rr:override-* labels from
+        // any open feature PRs.  These overrides were scoped to this release cycle.
         self.clear_stale_override_labels_after_release(
             owner,
             repo,
@@ -1207,10 +1221,24 @@ where
         )
         .await;
 
-        Ok(orch_result)
+        Ok(release_orchestrator::OrchestratorResult::TaggedRelease)
     }
 
     /// Clear stale bump-override labels from open feature PRs after a release.
+    ///
+    /// Enumerates all currently-open PRs via `list_pull_requests`, then
+    /// inspects each one's actual labels via `list_pr_labels`.  Only PRs that
+    /// carry at least one `rr:override-*` label are processed; all others are
+    /// skipped without any API calls.
+    ///
+    /// For each qualifying PR:
+    /// 1. Every `rr:override-*` label present is removed.
+    /// 2. Exactly **one** notification comment is posted (regardless of how many
+    ///    labels were removed), explaining that the override has been cleared
+    ///    because a new release was published.
+    ///
+    /// All errors are logged as warnings and the loop continues; this function
+    /// is intentionally best-effort and never propagates failures to callers.
     async fn clear_stale_override_labels_after_release(
         &self,
         owner: &str,
@@ -1219,60 +1247,100 @@ where
         correlation_id: &str,
     ) {
         use comment_command_processor::ALL_OVERRIDE_LABELS;
+        use std::collections::HashSet;
 
         let scoped_github = self.github_operations.scoped_to(installation_id);
 
-        for &label_name in ALL_OVERRIDE_LABELS {
-            let query = format!("is:open label:{label_name}");
-            match scoped_github
-                .search_pull_requests(owner, repo, &query)
-                .await
-            {
-                Ok(stale_prs) => {
-                    for stale_pr in stale_prs {
-                        if let Err(e) = scoped_github
-                            .remove_label(owner, repo, stale_pr.number, label_name)
-                            .await
-                        {
-                            tracing::warn!(
-                                error = %e,
-                                pr = stale_pr.number,
-                                label = label_name,
-                                correlation_id = %correlation_id,
-                                "Failed to remove stale override label; continuing"
-                            );
-                        }
-                        let kind_str = label_name
-                            .strip_prefix("rr:override-")
-                            .unwrap_or(label_name);
-                        let cleanup_body = format!(
-                            "ℹ️ **Release Regent**: The `!release {kind_str}` override on \
-                             this PR has been cleared because a new release was published \
-                             before this PR merged. If the work in this PR still warrants \
-                             a minimum bump for the next release, please re-post your \
-                             `!release` command."
-                        );
-                        if let Err(e) = scoped_github
-                            .create_issue_comment(owner, repo, stale_pr.number, &cleanup_body)
-                            .await
-                        {
-                            tracing::warn!(
-                                error = %e,
-                                pr = stale_pr.number,
-                                correlation_id = %correlation_id,
-                                "Failed to post stale-override cleanup comment; continuing"
-                            );
-                        }
-                    }
-                }
+        // The GitHubClient implementation of search_pull_requests does not
+        // filter by the `label:` qualifier (only `is:`, `head:`, and `base:`
+        // are parsed).  Using list_pull_requests + per-PR list_pr_labels
+        // guarantees we only act on PRs that actually carry override labels.
+        let open_prs = match scoped_github
+            .list_pull_requests(owner, repo, Some("open"), None, None, None, None)
+            .await
+        {
+            Ok(prs) => prs,
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    owner,
+                    repo,
+                    correlation_id = %correlation_id,
+                    "Failed to list open PRs for override-label cleanup; skipping"
+                );
+                return;
+            }
+        };
+
+        let override_label_set: HashSet<&str> = ALL_OVERRIDE_LABELS.iter().copied().collect();
+
+        for pr in &open_prs {
+            // Fetch the actual labels on this PR.
+            let pr_labels = match scoped_github.list_pr_labels(owner, repo, pr.number).await {
+                Ok(labels) => labels,
                 Err(e) => {
                     tracing::warn!(
                         error = %e,
-                        label = label_name,
+                        pr = pr.number,
                         correlation_id = %correlation_id,
-                        "Failed to search for PRs with stale override label; continuing"
+                        "Failed to list labels for PR during override cleanup; skipping"
+                    );
+                    continue;
+                }
+            };
+
+            // Collect override labels that are actually present on this PR.
+            let stale_overrides: Vec<String> = pr_labels
+                .iter()
+                .filter(|l| override_label_set.contains(l.name.as_str()))
+                .map(|l| l.name.clone())
+                .collect();
+
+            if stale_overrides.is_empty() {
+                continue;
+            }
+
+            // Remove each stale override label.
+            for label_name in &stale_overrides {
+                if let Err(e) = scoped_github
+                    .remove_label(owner, repo, pr.number, label_name)
+                    .await
+                {
+                    tracing::warn!(
+                        error = %e,
+                        pr = pr.number,
+                        label = %label_name,
+                        correlation_id = %correlation_id,
+                        "Failed to remove stale override label; continuing"
                     );
                 }
+            }
+
+            // Post exactly one cleanup comment per PR, listing every kind that
+            // was removed.  This avoids duplicate comments when a PR carried
+            // more than one override label.
+            let kind_list = stale_overrides
+                .iter()
+                .filter_map(|l| l.strip_prefix("rr:override-"))
+                .collect::<Vec<_>>()
+                .join(", ");
+            let cleanup_body = format!(
+                "ℹ️ **Release Regent**: The `!release {kind_list}` override on \
+                 this PR has been cleared because a new release was published \
+                 before this PR merged. If the work in this PR still warrants \
+                 a minimum bump for the next release, please re-post your \
+                 `!release` command."
+            );
+            if let Err(e) = scoped_github
+                .create_issue_comment(owner, repo, pr.number, &cleanup_body)
+                .await
+            {
+                tracing::warn!(
+                    error = %e,
+                    pr = pr.number,
+                    correlation_id = %correlation_id,
+                    "Failed to post stale-override cleanup comment; continuing"
+                );
             }
         }
     }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1454,6 +1454,9 @@ where
             // NoBumpNeeded is returned before the orchestrator is called, so
             // there is no release PR to post the audit comment on.
             release_orchestrator::OrchestratorResult::NoBumpNeeded => None,
+            // TaggedRelease is produced by the release-PR merge path, not by the
+            // orchestrator, so there is no open release PR to comment on.
+            release_orchestrator::OrchestratorResult::TaggedRelease => None,
         };
         let Some(release_pr) = release_pr_number else {
             return;

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -338,9 +338,9 @@ where
             )
             .await?;
 
-        let default_orch = release_orchestrator::OrchestratorConfig::default();
         let config = AutomatorConfig {
-            branch_prefix: default_orch.branch_prefix,
+            branch_prefix: release_orchestrator::OrchestratorConfig::DEFAULT_BRANCH_PREFIX
+                .to_string(),
             changelog_header: release_orchestrator::extract_changelog_header(
                 &repo_config.release_pr.body_template,
             ),
@@ -949,9 +949,57 @@ where
             .unwrap_or(&event.repository.default_branch)
             .to_string();
 
-        // The merge commit SHA is required: it is the head of the base branch
-        // immediately after the merge and serves as the branch point for the
-        // new release branch.
+        // Check the merged PR's head branch early to avoid running the expensive
+        // calculate_version_for_merge (tag fetching + version calculation +
+        // changelog generation) when this is a release PR merge.  We need only
+        // the repository config on that path — not the full version pipeline.
+        let merged_pr_head_ref = event
+            .payload
+            .get("pull_request")
+            .and_then(|pr| pr.get("head"))
+            .and_then(|h| h.get("ref"))
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .to_string();
+        let release_branch_prefix = format!(
+            "{}/",
+            release_orchestrator::OrchestratorConfig::DEFAULT_BRANCH_PREFIX
+        );
+        if merged_pr_head_ref.starts_with(&release_branch_prefix) {
+            use traits::configuration_provider::LoadOptions;
+            let installation_id = self.resolve_installation_id(owner, repo).await?;
+            let repo_config = self
+                .configuration_provider
+                .get_merged_config(
+                    owner,
+                    repo,
+                    LoadOptions {
+                        installation_id: Some(installation_id),
+                        default_branch: Some(base_branch.clone()),
+                        ..Default::default()
+                    },
+                )
+                .await?;
+            if release_automator::is_release_pr_branch(
+                &merged_pr_head_ref,
+                release_orchestrator::OrchestratorConfig::DEFAULT_BRANCH_PREFIX,
+                &repo_config.core.version_prefix,
+            ) {
+                return self
+                    .process_release_pr_merged(
+                        owner,
+                        repo,
+                        installation_id,
+                        correlation_id,
+                        &repo_config,
+                        event,
+                    )
+                    .await;
+            }
+        }
+
+        // Feature PR path: the merge commit SHA is required as the branch
+        // point for the new release branch.
         let base_sha = event
             .payload
             .get("pull_request")
@@ -999,24 +1047,8 @@ where
             auto_detect_manifests: repo_config.release_pr.auto_detect_manifests,
         };
 
-        // Determine whether the merged PR is itself a release PR by checking
-        // whether its head branch starts with the configured release prefix.
-        let merged_pr_head_ref = event
-            .payload
-            .get("pull_request")
-            .and_then(|pr| pr.get("head"))
-            .and_then(|h| h.get("ref"))
-            .and_then(|v| v.as_str())
-            .unwrap_or_default()
-            .to_string();
-        let is_release_pr = release_automator::is_release_pr_branch(
-            &merged_pr_head_ref,
-            &orch_config.branch_prefix,
-            &orch_config.version_prefix,
-        );
-
         // Resolve the merged PR number (needed to read override labels on the
-        // feature-PR path, and logged for diagnostics on the release-PR path).
+        // feature-PR path).
         let merged_pr_number: u64 = event
             .payload
             .get("pull_request")
@@ -1028,32 +1060,20 @@ where
         let orchestrator =
             release_orchestrator::ReleaseOrchestrator::new(orch_config, &scoped_github);
 
-        if is_release_pr {
-            self.process_release_pr_merged(
-                owner,
-                repo,
-                installation_id,
-                correlation_id,
-                &repo_config,
-                event,
-            )
-            .await
-        } else {
-            self.process_feature_pr_merged(
-                owner,
-                repo,
-                installation_id,
-                merged_pr_number,
-                correlation_id,
-                &orchestrator,
-                current_version.as_ref(),
-                &calc_result,
-                &changelog,
-                &base_branch,
-                &base_sha,
-            )
-            .await
-        }
+        self.process_feature_pr_merged(
+            owner,
+            repo,
+            installation_id,
+            merged_pr_number,
+            correlation_id,
+            &orchestrator,
+            current_version.as_ref(),
+            &calc_result,
+            &changelog,
+            &base_branch,
+            &base_sha,
+        )
+        .await
     }
 
     /// Load configuration and calculate the next version for a merge event.
@@ -1197,9 +1217,9 @@ where
              (arrived as PullRequestMerged; head branch matches release prefix)"
         );
 
-        let default_orch = release_orchestrator::OrchestratorConfig::default();
         let config = AutomatorConfig {
-            branch_prefix: default_orch.branch_prefix,
+            branch_prefix: release_orchestrator::OrchestratorConfig::DEFAULT_BRANCH_PREFIX
+                .to_string(),
             changelog_header: release_orchestrator::extract_changelog_header(
                 &repo_config.release_pr.body_template,
             ),
@@ -1318,19 +1338,35 @@ where
 
             // Post exactly one cleanup comment per PR, listing every kind that
             // was removed.  This avoids duplicate comments when a PR carried
-            // more than one override label.
-            let kind_list = stale_overrides
-                .iter()
-                .filter_map(|l| l.strip_prefix("rr:override-"))
-                .collect::<Vec<_>>()
-                .join(", ");
-            let cleanup_body = format!(
-                "ℹ️ **Release Regent**: The `!release {kind_list}` override on \
-                 this PR has been cleared because a new release was published \
-                 before this PR merged. If the work in this PR still warrants \
-                 a minimum bump for the next release, please re-post your \
-                 `!release` command."
-            );
+            // more than one override label.  Use the plural form and list each
+            // command individually when multiple labels were removed so the
+            // copy is grammatically correct and each label is a valid command.
+            let cleanup_body = if stale_overrides.len() == 1 {
+                let kind = stale_overrides[0]
+                    .strip_prefix("rr:override-")
+                    .unwrap_or(&stale_overrides[0]);
+                format!(
+                    "ℹ️ **Release Regent**: The `!release {kind}` override on \
+                     this PR has been cleared because a new release was published \
+                     before this PR merged. If the work in this PR still warrants \
+                     a minimum bump for the next release, please re-post your \
+                     `!release` command."
+                )
+            } else {
+                let commands = stale_overrides
+                    .iter()
+                    .filter_map(|l| l.strip_prefix("rr:override-"))
+                    .map(|kind| format!("`!release {kind}`"))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                format!(
+                    "ℹ️ **Release Regent**: The {commands} overrides on \
+                     this PR have been cleared because a new release was published \
+                     before this PR merged. If the work in this PR still warrants \
+                     a minimum bump for the next release, please re-post your \
+                     `!release` command."
+                )
+            };
             if let Err(e) = scoped_github
                 .create_issue_comment(owner, repo, pr.number, &cleanup_body)
                 .await

--- a/crates/core/src/lib_tests.rs
+++ b/crates/core/src/lib_tests.rs
@@ -901,13 +901,19 @@ impl GitHubOperations for TestGitHubForLib {
         &self,
         _owner: &str,
         _repo: &str,
-        _state: Option<&str>,
+        state: Option<&str>,
         _head: Option<&str>,
         _base: Option<&str>,
         _per_page: Option<u8>,
         _page: Option<u32>,
     ) -> CoreResult<Vec<PullRequest>> {
-        Ok(self.existing_prs.clone())
+        // All seeded test PRs are considered open.  Honour the `state` filter
+        // so that callers requesting "closed" (or any other non-open state)
+        // receive an empty list rather than a misleading result.
+        match state {
+            Some(s) if s != "open" => Ok(vec![]),
+            _ => Ok(self.existing_prs.clone()),
+        }
     }
 
     async fn search_pull_requests(

--- a/crates/core/src/lib_tests.rs
+++ b/crates/core/src/lib_tests.rs
@@ -690,6 +690,11 @@ impl TestGitHubForLib {
         self
     }
 
+    fn with_existing_prs(mut self, prs: Vec<PullRequest>) -> Self {
+        self.existing_prs = prs;
+        self
+    }
+
     fn with_pr_labels(mut self, pr_number: u64, labels: Vec<Label>) -> Self {
         self.pr_labels.insert(pr_number, labels);
         self
@@ -816,9 +821,26 @@ impl GitHubOperations for TestGitHubForLib {
         &self,
         _owner: &str,
         _repo: &str,
-        _params: CreateReleaseParams,
+        params: CreateReleaseParams,
     ) -> CoreResult<Release> {
-        Err(CoreError::not_found("release"))
+        Ok(Release {
+            id: 1,
+            tag_name: params.tag_name,
+            target_commitish: params
+                .target_commitish
+                .unwrap_or_else(|| "main".to_string()),
+            name: params.name,
+            body: params.body,
+            draft: params.draft,
+            prerelease: params.prerelease,
+            created_at: Utc::now(),
+            published_at: if params.draft { None } else { Some(Utc::now()) },
+            author: GitUser {
+                name: "release-regent[bot]".to_string(),
+                email: "release-regent@users.noreply.github.com".to_string(),
+                login: Some("release-regent[bot]".to_string()),
+            },
+        })
     }
 
     async fn create_tag(
@@ -1872,12 +1894,22 @@ async fn test_handle_merged_feature_pr_without_override_label_uses_calculated_ve
 #[tokio::test]
 async fn test_handle_merged_release_pr_clears_stale_override_labels_from_open_prs() {
     // Feature PR #99 has a stale rr:override-major label from a previous
-    // !release command.  It will appear in search results for all three label
-    // queries (the stub returns `search_results` regardless of the query, which
-    // exercises the cleanup loop for all three label names).
+    // !release command.  After a release PR is merged, only the labels that
+    // actually exist on the PR should be removed, and exactly one cleanup
+    // comment should be posted regardless of how many labels are removed.
     let stale_pr = make_pr(99, "feat/stale-feature", "feat: stale work");
+    let override_major = Label {
+        id: 10,
+        name: "rr:override-major".to_string(),
+        color: "b60205".to_string(),
+        description: None,
+    };
 
-    let github = TestGitHubForLib::new_empty().with_search_results(vec![stale_pr]);
+    let github = TestGitHubForLib::new_empty()
+        // list_pull_requests returns this PR as an open PR.
+        .with_existing_prs(vec![stale_pr])
+        // list_pr_labels for PR #99 returns only rr:override-major.
+        .with_pr_labels(99, vec![override_major]);
     let config = TestConfigForLib;
     let version_calc = TestVersionCalcForLib::returning("1.1.0");
 
@@ -1906,50 +1938,253 @@ async fn test_handle_merged_release_pr_clears_stale_override_labels_from_open_pr
         installation_id: 0,
     };
 
-    processor.handle_merged_pull_request(&event).await.unwrap();
+    let result = processor.handle_merged_pull_request(&event).await.unwrap();
 
-    // remove_label should have been called once per override label constant
-    // (major, minor, patch), each time on PR #99.
+    // The result must be TaggedRelease — the automator ran, not the orchestrator.
+    assert!(
+        matches!(
+            result,
+            release_orchestrator::OrchestratorResult::TaggedRelease
+        ),
+        "expected TaggedRelease (automator path), got: {result:?}"
+    );
+
+    // Only rr:override-major should be removed — not minor or patch, which are
+    // not present on PR #99.
     let removed = github.removed_labels.lock().await;
     assert_eq!(
         removed.len(),
-        3,
-        "expected 3 remove_label calls (one per override label), got: {removed:?}"
+        1,
+        "expected 1 remove_label call (only for rr:override-major), got: {removed:?}"
+    );
+    assert_eq!(
+        removed[0],
+        (99, "rr:override-major".to_string()),
+        "removal should target PR #99 / rr:override-major"
+    );
+
+    // Exactly one cleanup comment should be posted — not one per label type.
+    let comments = github.issue_comments.lock().await;
+    let cleanup_comments: Vec<_> = comments
+        .iter()
+        .filter(|(pr, body)| {
+            *pr == 99 && body.contains("cleared because a new release was published")
+        })
+        .collect();
+    assert_eq!(
+        cleanup_comments.len(),
+        1,
+        "expected exactly 1 cleanup comment on PR #99, got: {cleanup_comments:?}"
+    );
+}
+
+/// After a release PR merges the processor must invoke the release automator
+/// (creating a tag + GitHub release) instead of the release orchestrator
+/// (which would create a new release branch and PR).
+///
+/// Regression test for Bug 1: `process_release_pr_merged` was calling
+/// `orchestrator.orchestrate()` instead of `ReleaseAutomator::automate()`.
+#[tokio::test]
+async fn test_merged_release_pr_creates_tag_not_new_release_branch() {
+    let github = TestGitHubForLib::new_empty();
+    let config = TestConfigForLib;
+    let version_calc = TestVersionCalcForLib::returning("1.0.0");
+
+    let processor = ReleaseRegentProcessor::new(github.clone(), config, version_calc);
+
+    let event = ProcessingEvent {
+        event_id: "evt-release-pr".into(),
+        correlation_id: "corr-release-pr".into(),
+        event_type: EventType::PullRequestMerged,
+        repository: RepositoryInfo {
+            owner: "acme".into(),
+            name: "app".into(),
+            default_branch: "main".into(),
+        },
+        payload: serde_json::json!({
+            "pull_request": {
+                "head": { "ref": "release/v1.0.0" },
+                "base": { "ref": "main" },
+                "number": 50,
+                "merge_commit_sha": "e".repeat(40)
+            }
+        }),
+        received_at: Utc::now(),
+        source: EventSourceKind::Webhook,
+        installation_id: 0,
+    };
+
+    let result = processor.handle_merged_pull_request(&event).await.unwrap();
+
+    // The automator path must be taken, not the orchestrator.
+    assert!(
+        matches!(
+            result,
+            release_orchestrator::OrchestratorResult::TaggedRelease
+        ),
+        "expected TaggedRelease (automator created tag), got: {result:?}"
+    );
+
+    // No new release PR should have been opened.
+    let created_prs = github.created_prs.lock().await;
+    assert!(
+        created_prs.is_empty(),
+        "expected no new PRs to be created (automator, not orchestrator), got: {created_prs:?}"
+    );
+
+    // No new branch should have been created.
+    let created_branches = github.create_branch_calls.lock().await;
+    assert!(
+        created_branches.is_empty(),
+        "expected no new branches (automator does not create branches), got: {created_branches:?}"
+    );
+}
+
+/// Open PRs that carry no override labels must not receive a cleanup comment
+/// after a release.
+///
+/// Regression test for Bug 3: `search_pull_requests` with a `label:` qualifier
+/// was returning all open PRs (the GitHubClient ignores the qualifier), causing
+/// spurious comments on PRs that had no override label.
+#[tokio::test]
+async fn test_clear_stale_labels_skips_prs_without_override_labels() {
+    let pr_no_label = make_pr(77, "feat/clean-pr", "feat: clean work");
+
+    let github = TestGitHubForLib::new_empty()
+        // PR #77 is open but has no override labels.
+        .with_existing_prs(vec![pr_no_label]);
+    // pr_labels map is empty → list_pr_labels returns [] for PR #77.
+
+    let config = TestConfigForLib;
+    let version_calc = TestVersionCalcForLib::returning("2.0.0");
+    let processor = ReleaseRegentProcessor::new(github.clone(), config, version_calc);
+
+    let event = ProcessingEvent {
+        event_id: "evt-no-labels".into(),
+        correlation_id: "corr-no-labels".into(),
+        event_type: EventType::PullRequestMerged,
+        repository: RepositoryInfo {
+            owner: "acme".into(),
+            name: "app".into(),
+            default_branch: "main".into(),
+        },
+        payload: serde_json::json!({
+            "pull_request": {
+                "head": { "ref": "release/v2.0.0" },
+                "base": { "ref": "main" },
+                "number": 80,
+                "merge_commit_sha": "f".repeat(40)
+            }
+        }),
+        received_at: Utc::now(),
+        source: EventSourceKind::Webhook,
+        installation_id: 0,
+    };
+
+    processor.handle_merged_pull_request(&event).await.unwrap();
+
+    // No labels should be removed from PR #77.
+    let removed = github.removed_labels.lock().await;
+    assert!(
+        removed.is_empty(),
+        "expected no label removals for a PR with no override labels, got: {removed:?}"
+    );
+
+    // No cleanup comment should be posted.
+    let comments = github.issue_comments.lock().await;
+    let cleanup_comments: Vec<_> = comments
+        .iter()
+        .filter(|(_, body)| body.contains("cleared because a new release was published"))
+        .collect();
+    assert!(
+        cleanup_comments.is_empty(),
+        "expected no cleanup comments for a PR with no override labels, got: {cleanup_comments:?}"
+    );
+}
+
+/// A PR with multiple override labels must have all of them removed but still
+/// receive only a single cleanup comment.
+///
+/// Regression test for Bug 2: the old per-label loop posted one comment per
+/// label type, so a PR with three override labels received three identical
+/// comments.
+#[tokio::test]
+async fn test_clear_stale_labels_posts_one_comment_per_pr_regardless_of_label_count() {
+    let multi_label_pr = make_pr(55, "feat/multi-override", "feat: multi-override work");
+    let label_major = Label {
+        id: 1,
+        name: "rr:override-major".to_string(),
+        color: "b60205".to_string(),
+        description: None,
+    };
+    let label_minor = Label {
+        id: 2,
+        name: "rr:override-minor".to_string(),
+        color: "0075ca".to_string(),
+        description: None,
+    };
+
+    let github = TestGitHubForLib::new_empty()
+        .with_existing_prs(vec![multi_label_pr])
+        .with_pr_labels(55, vec![label_major, label_minor]);
+
+    let config = TestConfigForLib;
+    let version_calc = TestVersionCalcForLib::returning("3.0.0");
+    let processor = ReleaseRegentProcessor::new(github.clone(), config, version_calc);
+
+    let event = ProcessingEvent {
+        event_id: "evt-multi-label".into(),
+        correlation_id: "corr-multi-label".into(),
+        event_type: EventType::PullRequestMerged,
+        repository: RepositoryInfo {
+            owner: "acme".into(),
+            name: "app".into(),
+            default_branch: "main".into(),
+        },
+        payload: serde_json::json!({
+            "pull_request": {
+                "head": { "ref": "release/v3.0.0" },
+                "base": { "ref": "main" },
+                "number": 60,
+                "merge_commit_sha": "a".repeat(40)
+            }
+        }),
+        received_at: Utc::now(),
+        source: EventSourceKind::Webhook,
+        installation_id: 0,
+    };
+
+    processor.handle_merged_pull_request(&event).await.unwrap();
+
+    // Both override labels must be removed from PR #55.
+    let removed = github.removed_labels.lock().await;
+    assert_eq!(
+        removed.len(),
+        2,
+        "expected 2 remove_label calls (major + minor), got: {removed:?}"
     );
     let removed_names: Vec<&str> = removed.iter().map(|(_, n)| n.as_str()).collect();
     assert!(
         removed_names.contains(&"rr:override-major"),
-        "expected rr:override-major to be removed"
+        "expected rr:override-major removal"
     );
     assert!(
         removed_names.contains(&"rr:override-minor"),
-        "expected rr:override-minor to be removed"
-    );
-    assert!(
-        removed_names.contains(&"rr:override-patch"),
-        "expected rr:override-patch to be removed"
-    );
-    assert!(
-        removed.iter().all(|(pr, _)| *pr == 99),
-        "all removals should target PR #99"
+        "expected rr:override-minor removal"
     );
 
-    // A cleanup comment should have been posted for each removal.
+    // Despite two labels being removed, only one cleanup comment must be posted.
     let comments = github.issue_comments.lock().await;
+    let cleanup_comments: Vec<_> = comments
+        .iter()
+        .filter(|(pr, body)| {
+            *pr == 55 && body.contains("cleared because a new release was published")
+        })
+        .collect();
     assert_eq!(
-        comments.len(),
-        3,
-        "expected 3 cleanup comments (one per override label), got: {comments:?}"
-    );
-    assert!(
-        comments.iter().all(|(pr, _)| *pr == 99),
-        "all cleanup comments should target PR #99"
-    );
-    assert!(
-        comments
-            .iter()
-            .any(|(_, body)| body.contains("cleared because a new release was published")),
-        "cleanup comment should explain why the label was cleared"
+        cleanup_comments.len(),
+        1,
+        "expected exactly 1 cleanup comment even with 2 override labels, got: {cleanup_comments:?}"
     );
 }
 
@@ -2117,25 +2352,32 @@ async fn test_handle_merged_feature_pr_with_patch_floor_no_effect_when_calculate
 // handle_merged_pull_request — release-PR path error tests (spec §9 Minor #5)
 // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-/// When `search_pull_requests` fails for one override label (e.g., `rr:override-major`),
-/// a warning is logged and the cleanup for the remaining labels still proceeds.
-/// The overall event must succeed.
+/// When `list_pr_labels` fails for one open PR, a warning is logged and the
+/// cleanup loop continues for the remaining PRs.  The overall event must succeed.
 #[tokio::test]
-async fn test_handle_merged_release_pr_search_failure_for_one_label_continues() {
-    // search_results contains PR #99 which will be found for override-minor and
-    // override-patch, but the search for override-major will fail.
-    let stale_pr = make_pr(99, "feat/stale-feature", "feat: stale work");
+async fn test_handle_merged_release_pr_list_labels_failure_for_one_pr_continues() {
+    // PR #99: list_pr_labels will fail → must be skipped.
+    // PR #88: has rr:override-minor → must be cleaned up normally.
+    let pr_a = make_pr(99, "feat/pr-a", "feat: pr a");
+    let pr_b = make_pr(88, "feat/pr-b", "feat: pr b");
+    let override_minor = Label {
+        id: 20,
+        name: "rr:override-minor".to_string(),
+        color: "0075ca".to_string(),
+        description: None,
+    };
     let github = TestGitHubForLib::new_empty()
-        .with_search_results(vec![stale_pr])
-        .with_fail_search_for_label("rr:override-major");
+        .with_existing_prs(vec![pr_a, pr_b])
+        .with_pr_labels(88, vec![override_minor])
+        .with_fail_list_labels_for_pr(99);
 
     let config = TestConfigForLib;
     let version_calc = TestVersionCalcForLib::returning("1.1.0");
     let processor = ReleaseRegentProcessor::new(github.clone(), config, version_calc);
 
     let event = ProcessingEvent {
-        event_id: "evt-search-fail".into(),
-        correlation_id: "corr-search-fail".into(),
+        event_id: "evt-label-list-fail".into(),
+        correlation_id: "corr-label-list-fail".into(),
         event_type: EventType::PullRequestMerged,
         repository: RepositoryInfo {
             owner: "acme".into(),
@@ -2155,26 +2397,24 @@ async fn test_handle_merged_release_pr_search_failure_for_one_label_continues() 
         installation_id: 0,
     };
 
-    // Event must succeed despite the partial search failure.
+    // Event must succeed despite the partial failure.
     let result = processor.handle_merged_pull_request(&event).await;
     assert!(
         result.is_ok(),
-        "expected Ok when one search fails, got: {result:?}"
+        "expected Ok when list_pr_labels fails for one PR, got: {result:?}"
     );
 
-    // override-minor and override-patch searches succeeded → PR #99 was processed
-    // for at least 2 labels.  override-major search failed → no remove for that label.
+    // PR #88 must have been cleaned up normally.
     let removed = github.removed_labels.lock().await;
-    assert!(
-        removed.len() >= 2,
-        "expected at least 2 label removals (minor + patch), got: {removed:?}"
+    assert_eq!(
+        removed.len(),
+        1,
+        "expected 1 removal (rr:override-minor from PR #88), got: {removed:?}"
     );
-    let has_major_removal = removed
-        .iter()
-        .any(|(_, label)| label == "rr:override-major");
-    assert!(
-        !has_major_removal,
-        "should NOT have removed override-major (search failed), got: {removed:?}"
+    assert_eq!(
+        removed[0],
+        (88, "rr:override-minor".to_string()),
+        "removal must target PR #88 / rr:override-minor"
     );
 }
 
@@ -2183,8 +2423,15 @@ async fn test_handle_merged_release_pr_search_failure_for_one_label_continues() 
 #[tokio::test]
 async fn test_handle_merged_release_pr_remove_label_failure_still_posts_cleanup_comment() {
     let stale_pr = make_pr(99, "feat/stale-feature", "feat: stale work");
+    let override_major = Label {
+        id: 11,
+        name: "rr:override-major".to_string(),
+        color: "b60205".to_string(),
+        description: None,
+    };
     let github = TestGitHubForLib::new_empty()
-        .with_search_results(vec![stale_pr])
+        .with_existing_prs(vec![stale_pr])
+        .with_pr_labels(99, vec![override_major])
         .with_fail_remove_label_for_pr(99); // remove_label on PR #99 will fail
 
     let config = TestConfigForLib;
@@ -2220,12 +2467,17 @@ async fn test_handle_merged_release_pr_remove_label_failure_still_posts_cleanup_
         "expected Ok when remove_label fails, got: {result:?}"
     );
 
-    // Cleanup comments must still be posted on PR #99 even though remove_label failed.
+    // Cleanup comment must still be posted on PR #99 even though remove_label failed.
     let comments = github.issue_comments.lock().await;
-    let cleanup_comments: Vec<_> = comments.iter().filter(|(pr, _)| *pr == 99).collect();
+    let cleanup_comments: Vec<_> = comments
+        .iter()
+        .filter(|(pr, body)| {
+            *pr == 99 && body.contains("cleared because a new release was published")
+        })
+        .collect();
     assert!(
         !cleanup_comments.is_empty(),
-        "cleanup comments should still be posted even when remove_label fails, got: {comments:?}"
+        "cleanup comment should still be posted even when remove_label fails, got: {comments:?}"
     );
 }
 
@@ -2234,8 +2486,15 @@ async fn test_handle_merged_release_pr_remove_label_failure_still_posts_cleanup_
 #[tokio::test]
 async fn test_handle_merged_release_pr_cleanup_comment_failure_event_still_succeeds() {
     let stale_pr = make_pr(99, "feat/stale-feature", "feat: stale work");
+    let override_patch = Label {
+        id: 12,
+        name: "rr:override-patch".to_string(),
+        color: "e4e669".to_string(),
+        description: None,
+    };
     let github = TestGitHubForLib::new_empty()
-        .with_search_results(vec![stale_pr])
+        .with_existing_prs(vec![stale_pr])
+        .with_pr_labels(99, vec![override_patch])
         .with_fail_comment_for_pr(99); // comment on PR #99 will fail
 
     let config = TestConfigForLib;

--- a/crates/core/src/release_orchestrator.rs
+++ b/crates/core/src/release_orchestrator.rs
@@ -233,6 +233,16 @@ pub enum OrchestratorResult {
     ///
     /// No new release PR is opened on this path; the next release cycle
     /// begins when the next feature PR merges.
+    ///
+    /// # Design note
+    ///
+    /// `TaggedRelease` is placed in `OrchestratorResult` as a pragmatic
+    /// shortcut so that `handle_merged_pull_request` can share a single
+    /// `CoreResult<OrchestratorResult>` return type across both paths.  A
+    /// cleaner long-term design would introduce a dedicated `ProcessorResult`
+    /// sum type as the return type of `handle_merged_pull_request`, removing
+    /// the `unreachable!()` guards that exhaustive matches on
+    /// `OrchestratorResult` must carry for this variant.
     TaggedRelease,
 }
 

--- a/crates/core/src/release_orchestrator.rs
+++ b/crates/core/src/release_orchestrator.rs
@@ -223,6 +223,17 @@ pub enum OrchestratorResult {
     /// outcome when a `chore:`, `docs:`, or other non-bumping PR is merged
     /// immediately after a release.
     NoBumpNeeded,
+
+    /// A merged pull request was identified as a release PR by the
+    /// [`crate::ReleaseRegentProcessor`] even though it arrived via the
+    /// `PullRequestMerged` event (misclassified by the server when its
+    /// `version_prefix` default does not match the repository's configured
+    /// prefix).  A git tag and GitHub release were created, and the release
+    /// branch was deleted.
+    ///
+    /// No new release PR is opened on this path; the next release cycle
+    /// begins when the next feature PR merges.
+    TaggedRelease,
 }
 
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Fixes three bugs introduced in the 0.6.0 release cycle that together caused
a merged release PR to create a duplicate release branch/PR instead of a git
tag, and caused spurious override-label cleanup comments to be posted on
every open PR.

closes #145
closes #146
closes #147

## What Changed

- `process_release_pr_merged` (inherent helper called when a `PullRequestMerged`
  event is detected as a release PR by head-branch prefix) now invokes
  `ReleaseAutomator::automate()` instead of `ReleaseOrchestrator::orchestrate()`.
  Returns the new `OrchestratorResult::TaggedRelease` variant.
- `handle_release_pr_merged` (correctly-routed `ReleasePrMerged` path) now calls
  `clear_stale_override_labels_after_release`, which was previously missing from
  that code path.
- `clear_stale_override_labels_after_release` redesigned: uses
  `list_pull_requests(state=open)` + per-PR `list_pr_labels` instead of
  `search_pull_requests` with a `label:` qualifier. Posts exactly one cleanup
  comment per qualifying PR regardless of how many override labels it carries.
- Added `OrchestratorResult::TaggedRelease` variant to `release_orchestrator.rs`
  and exhaustive match arms in `comment_command_processor.rs` and `lib.rs`.

## Why

**Bug 1:** When a `PullRequestMerged` event arrives for a release PR (which
happens when the server's default `version_prefix = "v"` does not match the
repository's configured `version_prefix = ""`), the code correctly detected the
release-PR head branch but then called `orchestrator.orchestrate()`, which
creates a new release branch and PR instead of a git tag and GitHub release. On
2026-05-19 this produced duplicate PR #260 and no tag for `merge_warden 0.6.0`.

**Bug 2:** The cleanup loop iterated over 3 label types and posted a comment
inside the inner PR loop. A PR appearing in all 3 result sets received 3
identical comments. Observed on 10+ PRs during the 0.6.0 merge event.

**Bug 3:** `GitHubClient::search_pull_requests` does not implement the `label:`
qualifier (only `is:`, `head:`, `base:` are parsed). All three label searches
returned the same 11 open PRs. All 33 `remove_label` calls failed with 404 —
none of those PRs actually had override labels.

## How

Bug 1 is fixed by giving `process_release_pr_merged` the same automator setup
that `handle_release_pr_merged` already uses: build `AutomatorConfig` from
`repo_config`, construct `ReleaseAutomator`, call `automate()`. The call site
in `handle_merged_pull_request` (inherent) passes `repo_config + event` instead
of the pre-computed orchestrator/version/changelog arguments.

Bugs 2 and 3 are fixed together by restructuring `clear_stale_override_labels_after_release`:
1. Call `list_pull_requests(state="open")` — avoids the broken `label:` filter.
2. For each PR, call `list_pr_labels` to get the PR's actual labels.
3. Skip any PR with no `rr:override-*` labels (fixes Bug 3 false positives).
4. Remove all matching labels, then post exactly one comment per PR (fixes Bug 2 duplicates).

## Testing Evidence

- **Test Coverage:** Rewrote `test_handle_merged_release_pr_clears_stale_override_labels_from_open_prs`
  to use `with_existing_prs` + `with_pr_labels` and assert 1 removal and 1 comment.
  Added `test_merged_release_pr_creates_tag_not_new_release_branch` (Bug 1),
  `test_clear_stale_labels_skips_prs_without_override_labels` (Bug 3),
  `test_clear_stale_labels_posts_one_comment_per_pr_regardless_of_label_count` (Bug 2).
  Rewrote 3 error-path tests to inject failures via `list_pr_labels` / `list_pull_requests`
  instead of the now-unused `search_pull_requests` path.
  Added `with_existing_prs()` builder to `TestGitHubForLib`; fixed `create_release`
  test double to return `Ok` (automator path requires it).
- **Test Results:** All 430 unit tests passing; no regressions across the full workspace.
- **Manual Testing:** Reviewed against Azure Container Apps log trace from the 2026-05-19
  0.6.0 incident; the new execution path matches the expected sequence (automate → tag →
  cleanup per PR, one comment per qualifying PR).

## Reviewer Guidance

- The key behavioural change is in `process_release_pr_merged`: verify the
  `AutomatorConfig` construction mirrors what `handle_release_pr_merged` already
  does so the two paths are equivalent.
- `clear_stale_override_labels_after_release` now makes O(n) `list_pr_labels`
  calls where n = number of open PRs. In a repository with many open PRs this
  increases API usage vs. the old (broken) search approach; confirm this is
  acceptable given typical PR counts.
- `OrchestratorResult::TaggedRelease` is a new public enum variant — no existing
  callers are affected but any downstream code that exhaustively matches on this
  enum will now require a new arm.
- No breaking changes to public API surface; all changes are internal to the
  `release-regent-core` crate.