### PR TITLE
chore: Update renovate to only update once a week

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -18,20 +18,15 @@
   "internalChecksFilter": "strict",
   "packageRules": [
     {
-      "description": "Security patches bypass the 48h delay — merge fast but still require review",
+      "description": "Batch noisy minor/patch updates into one weekly PR instead of daily ratcheting",
       "matchUpdateTypes": [
         "minor",
         "patch"
       ],
-      "matchCategories": [
-        "security"
+      "schedule": [
+        "before 4am on monday"
       ],
-      "minimumReleaseAge": "0 hours",
-      "automerge": false,
-      "labels": [
-        "security",
-        "dependencies"
-      ]
+      "minimumReleaseAge": "1 day"
     },
     {
       "description": "Major version bumps need manual review and an extended stabilisation window",
@@ -52,6 +47,22 @@
       "groupName": "install-action",
       "schedule": [
         "on the first day of the month"
+      ]
+    },
+    {
+      "description": "Security patches bypass the 48h delay — merge fast but still require review",
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "matchCategories": [
+        "security"
+      ],
+      "minimumReleaseAge": "0 hours",
+      "automerge": false,
+      "labels": [
+        "security",
+        "dependencies"
       ]
     }
   ],

--- a/renovate.json
+++ b/renovate.json
@@ -24,7 +24,7 @@
         "patch"
       ],
       "schedule": [
-        "before 4am on monday"
+        "before 4am on Monday"
       ],
       "minimumReleaseAge": "1 day"
     },
@@ -59,6 +59,9 @@
         "security"
       ],
       "minimumReleaseAge": "0 hours",
+      "schedule": [
+        "at any time"
+      ],
       "automerge": false,
       "labels": [
         "security",


### PR DESCRIPTION
This should fix the issue where there is a 3 day minimum wait time for new versions but renovate updates daily thus meaning that we never get to the three day wait time.