### PR TITLE
docs: document per-org metadata repository and configuration hierarchy

### DIFF
--- a/docs/user/explanation/configuration-hierarchy.md
+++ b/docs/user/explanation/configuration-hierarchy.md
@@ -1,0 +1,250 @@
+---
+title: Configuration hierarchy
+description: How Release Regent merges five configuration levels, how the per-org metadata
+  repository works, and how platform teams can enforce organisation-wide policy
+---
+
+# Configuration hierarchy
+
+Release Regent resolves configuration by merging up to five sources in a fixed order. Each
+level can override unlocked fields from the level above. Understanding the hierarchy helps you
+decide where to place a setting and how policy enforcement works across a large organisation.
+
+## The five levels
+
+```
+Built-in defaults
+      ↓
+App-level config         CONFIG_DIR/release-regent.toml  (local disk)
+      ↓
+Global policy            {org}/.release-regent/global.toml  (metadata repo)
+      ↓
+Group policy             {org}/.release-regent/groups/{group}.toml  (metadata repo)
+      ↓
+Repository config        .release-regent.toml  (target repository root)
+```
+
+| Level | Source | Required? |
+| :--- | :--- | :--- |
+| Built-in defaults | Hard-coded in the binary | Always present |
+| App-level | `CONFIG_DIR/release-regent.toml` on local disk | Required |
+| Global policy | `{org}/.release-regent/global.toml` — metadata repository | Optional |
+| Group policy | `{org}/.release-regent/groups/{group}.toml` — metadata repository | Optional |
+| Repository config | `.release-regent.toml` in target repository root | Optional |
+
+A missing level is silently skipped. A present but invalid level (parse or schema error) is a
+hard failure for that event.
+
+### Built-in defaults
+
+`ReleaseRegentConfig::default()` provides sensible baseline values for every field. You never
+need to configure these explicitly unless you want to change them.
+
+### App-level config
+
+The operator places a `release-regent.toml` file in `CONFIG_DIR` (set via environment
+variable). This is the only level that is always active and serves as both the bootstrap
+configuration for the server process and the fallback if no metadata repository exists.
+
+### Global policy (metadata repository)
+
+An org-wide `global.toml` stored in the metadata repository (see below) provides defaults
+and policy enforcement that apply to every repository in the organisation. Platform teams
+use this level to set non-negotiable settings and field locks without modifying individual
+repository dotfiles.
+
+### Group policy (metadata repository)
+
+A group config file in the metadata repository applies defaults and locks to a subset of
+repositories that self-declare membership by setting `group = "name"` in their dotfile. This
+is useful for common settings that apply to a class of repositories (for example, all backend
+services or all mobile apps) without requiring each repository to duplicate the same config.
+
+### Repository config
+
+The `.release-regent.toml` file at the root of each repository is the per-repo level.
+Repository owners control all unlocked fields here. See the
+[Configuration file reference](../reference/configuration.md) for the full list of available
+settings.
+
+---
+
+## The metadata repository
+
+The metadata repository is a GitHub repository named `.release-regent` within the same
+organisation (or user account) as the repositories Release Regent manages.
+
+For an event from `myorg/platform-api`, Release Regent auto-discovers the metadata
+repository at `myorg/.release-regent`.
+
+### Layout
+
+```
+myorg/.release-regent/
+  global.toml          ← org-wide defaults and field locks
+  groups/
+    backend.toml       ← applied to repos that declare group = "backend"
+    mobile.toml
+    data-platform.toml
+```
+
+### How the GitHub App finds it
+
+Release Regent uses the GitHub App installation API to discover whether the App is installed
+on `{org}/.release-regent`. The installation ID is cached permanently for the lifetime of the
+process (installation IDs are stable for the lifetime of a GitHub App installation).
+
+The GitHub App must be installed **at the organisation level** (not scoped to individual
+repositories) so that the installation can read any repository within the org. If the
+installation is repository-scoped, policy file fetches will fail with `403`.
+
+### Fallback when the metadata repository is absent
+
+If the metadata repository does not exist, the App is not installed on it, or it is
+temporarily unreachable due to a network error, Release Regent:
+
+1. Emits a `warn!` log identifying the org and the reason.
+2. Skips the global and group levels.
+3. Uses the app-level config as the effective top of the hierarchy.
+4. Continues processing the event normally.
+
+The event is **not** failed. This means existing deployments without a metadata repository
+continue to work without any changes.
+
+---
+
+## Group membership
+
+A repository declares its group in its dotfile using a top-level `group` field:
+
+```toml
+# .release-regent.toml in myorg/platform-api
+group = "backend"
+
+[versioning]
+strategy = "conventional"
+```
+
+When Release Regent processes an event for this repository, it:
+
+1. Reads the `group` field from the repository dotfile.
+2. Fetches `{org}/.release-regent/groups/backend.toml` from the metadata repository.
+3. Merges the group policy over the global policy for unlocked fields.
+4. Merges the repository dotfile over the group policy for unlocked fields.
+
+If the group file does not exist in the metadata repository, Release Regent emits a `warn!`
+and skips the group level. This is not an error — it is common during initial rollout.
+
+The `group` field is meaningful **only** in repository dotfiles. If it appears in
+`global.toml` or a group policy file, it is silently ignored with a `warn!`.
+
+---
+
+## Per-field locks
+
+Global and group policy files may include a `locked_fields` array. Each entry is a dotted
+field path. Lower levels cannot override a locked field.
+
+```toml
+# global.toml — enforce conventional commits and disable overrides org-wide
+locked_fields = ["versioning.strategy", "versioning.allow_override"]
+
+[versioning]
+strategy = "conventional"
+allow_override = false
+```
+
+```toml
+# groups/backend.toml — additionally lock draft releases for backend services
+locked_fields = ["releases.draft"]
+
+[releases]
+draft = false
+```
+
+### Lockable fields
+
+Only the following fields may appear in `locked_fields`:
+
+| Field path | Description |
+| :--- | :--- |
+| `versioning.strategy` | Versioning algorithm |
+| `versioning.allow_override` | Whether PR comment override commands are permitted |
+| `releases.draft` | Whether GitHub releases are created as drafts |
+| `releases.prerelease` | Whether GitHub releases are marked pre-release |
+| `releases.generate_notes` | Whether GitHub auto-generates release notes |
+| `core.branches.main` | Name of the default/main branch |
+| `core.version_prefix` | Prefix prepended to version tags |
+| `error_handling.max_retries` | Maximum retry count |
+| `error_handling.backoff_multiplier` | Exponential backoff multiplier |
+| `error_handling.initial_delay_ms` | Initial retry delay |
+
+The following fields are **never lockable** — they are always user-customisable at the
+repository level:
+
+- All `release_pr.*` fields (title template, body template, manifest files, auto-detect)
+- All `notifications.*` fields
+
+### Lock accumulation
+
+Locks accumulate downward through the hierarchy. A group policy can add new locks on top of
+global locks, but cannot remove a lock that global already set. Repository dotfiles cannot
+add or remove locks.
+
+### Lock conflict handling
+
+When a lower-level config supplies a value for a locked field, Release Regent:
+
+1. Keeps the locked (higher-level) value.
+2. Emits a `warn!` identifying the field, the locked value, and the attempted override.
+3. Continues processing the event normally — it is **not** failed.
+
+This prevents immediate workflow disruption when a new lock is added centrally. Repository
+owners can clean up their dotfiles at their own pace.
+
+---
+
+## Caching
+
+Release Regent caches configuration to reduce GitHub API calls for high-traffic
+organisations:
+
+| Level | Cache key | TTL |
+| :--- | :--- | :--- |
+| Global policy | Organisation name | 600 seconds (10 min) |
+| Group policy | `{org}/{group}` | 300 seconds (5 min) |
+| Repository config | `{owner}/{repo}` | 300 seconds (5 min) |
+| Metadata installation ID | Organisation name | Permanent (process lifetime) |
+
+A parse or validation error at any level immediately evicts the corresponding cache entry.
+The corrected file is picked up on the next event without a server restart.
+
+---
+
+## Failure behaviour summary
+
+| Condition | Behaviour |
+| :--- | :--- |
+| Metadata repository absent or App not installed | Warn and skip global + group levels; continue |
+| Metadata repository unreachable (transient network error) | Warn and skip global + group levels; continue |
+| `global.toml` absent | Skip global level; continue |
+| `global.toml` present but invalid | Hard-fail all events for this org |
+| Group declared but group file absent | Warn and skip group level; continue |
+| Group file present but invalid | Hard-fail events for repos in that group |
+| Repository dotfile absent | Skip repo level; continue |
+| Repository dotfile present but invalid | Hard-fail that event only |
+
+The asymmetry between "absent → skip silently" and "present but invalid → hard fail" is
+intentional: absence is a valid operational state (not yet configured), while an invalid file
+is a configuration error that must be fixed.
+
+---
+
+## See also
+
+- [Set up the metadata repository](../how-to/setup/metadata-repository.md) — step-by-step
+  instructions for platform teams
+- [Configuration file reference](../reference/configuration.md) — all settings available in a
+  repository dotfile
+- [ADR-007: Enterprise configuration hierarchy](../../adr/ADR-007-enterprise-config-hierarchy.md)
+  — the architectural decision record that introduced this design

--- a/docs/user/explanation/configuration-hierarchy.md
+++ b/docs/user/explanation/configuration-hierarchy.md
@@ -118,7 +118,7 @@ continue to work without any changes.
 A repository declares its group in its dotfile using a top-level `group` field:
 
 ```toml
-# .release-regent.toml in myorg/platform-api
+# myorg/platform-api/release-regent.toml
 group = "backend"
 
 [versioning]
@@ -191,6 +191,11 @@ Locks accumulate downward through the hierarchy. A group policy can add new lock
 global locks, but cannot remove a lock that global already set. Repository dotfiles cannot
 add or remove locks.
 
+If a group policy lists a field in `locked_fields` that global has already locked, the entry
+is a no-op (the field remains locked) and a `warn!` is emitted. Platform teams should expect
+this log noise when global and group policies overlap and can safely remove the duplicate
+entry from the group file.
+
 ### Lock conflict handling
 
 When a lower-level config supplies a value for a locked field, Release Regent:
@@ -233,10 +238,17 @@ The corrected file is picked up on the next event without a server restart.
 | Group file present but invalid | Hard-fail events for repos in that group |
 | Repository dotfile absent | Skip repo level; continue |
 | Repository dotfile present but invalid | Hard-fail that event only |
+| Repository dotfile API error (503, network timeout) | Hard-fail that event only |
 
 The asymmetry between "absent → skip silently" and "present but invalid → hard fail" is
 intentional: absence is a valid operational state (not yet configured), while an invalid file
 is a configuration error that must be fixed.
+
+Note the second asymmetry: transient API errors on the **metadata repository** are skipped
+with a warn (the org-level policy is optional infrastructure), but transient errors on the
+**repository dotfile** hard-fail the event. The repo dotfile is the primary per-repository
+config source, and silently skipping a transient failure there could produce a release with
+incorrect settings.
 
 ---
 

--- a/docs/user/explanation/index.md
+++ b/docs/user/explanation/index.md
@@ -21,3 +21,5 @@ effectively and make better decisions.
   ownership of `release/v*` branches and what that means for your workflow
 - [Architecture](architecture.md) — how the crates fit together and what deployment shapes are
   possible
+- [Configuration hierarchy](configuration-hierarchy.md) — how the five configuration levels
+  merge, how the per-org metadata repository works, and how platform teams enforce policy

--- a/docs/user/how-to/setup/configure-multiple-repos.md
+++ b/docs/user/how-to/setup/configure-multiple-repos.md
@@ -36,17 +36,26 @@ in `ALLOWED_REPOS` (or `ALLOWED_REPOS` is `*`).
 ## Per-repository configuration
 
 Release Regent reads configuration from a `.release-regent.toml` file at the root of each
-repository. There is no global configuration file that applies to all repositories — each
-repository controls its own versioning rules, changelog format, and PR templates.
+repository. Each repository controls its own versioning rules, changelog format, and PR
+templates for any settings that have not been locked by a higher level.
 
-The server finds configuration files using the `CONFIG_DIR` environment variable as the base
-path, combined with the repository name. If `CONFIG_DIR` is unset, the server looks in the
-current working directory.
+The server finds the app-level baseline configuration using the `CONFIG_DIR` environment
+variable. If `CONFIG_DIR` is unset, the server looks in the current working directory.
+
+## Organisation-wide policy (metadata repository)
+
+For larger deployments you can enforce settings across every repository in your organisation
+without modifying individual dotfiles. Create a repository named `.release-regent` in your
+GitHub organisation and add a `global.toml` file. Release Regent auto-discovers this
+repository and merges its settings over the app-level config for every event in the org.
+
+You can also apply per-group defaults by adding files under `groups/` and having repositories
+declare `group = "name"` in their dotfiles.
 
 !!! tip
-    If you want every repository to start from the same baseline, create a shared
-    `.release-regent.toml` template in your organisation's documentation and ask teams to
-    copy it into their repository and customise it.
+    See [Set up the metadata repository](metadata-repository.md) for step-by-step
+    instructions and [Configuration hierarchy](../../explanation/configuration-hierarchy.md)
+    for the full mental model.
 
 ## Webhook routing
 

--- a/docs/user/how-to/setup/metadata-repository.md
+++ b/docs/user/how-to/setup/metadata-repository.md
@@ -1,0 +1,199 @@
+---
+title: Set up the metadata repository
+description: How platform teams create and maintain the per-org metadata repository to
+  enforce organisation-wide Release Regent policy
+---
+
+# Set up the metadata repository
+
+The metadata repository is a GitHub repository named `.release-regent` within your GitHub
+organisation. Platform teams use it to enforce organisation-wide policy and group-level
+defaults without modifying individual repository dotfiles.
+
+This guide is for **platform or DevOps teams**. Individual repository owners do not need to
+read this page.
+
+## Prerequisites
+
+- A GitHub organisation (or personal account) with at least one repository already using
+  Release Regent.
+- Admin access to the organisation to install GitHub Apps.
+- The Release Regent GitHub App installed at the organisation level (see
+  [Set up the GitHub App](github-app-setup.md)).
+
+!!! important "Organisation-level App installation required"
+    The GitHub App must be installed at the **organisation level** — not scoped to individual
+    repositories. A repository-scoped installation cannot read the metadata repository from
+    the context of other repositories' events and will cause `403` errors when fetching policy
+    files.
+
+---
+
+## Step 1 — Create the repository
+
+Create a new GitHub repository named exactly `.release-regent` in your organisation:
+
+1. Go to **GitHub → Your organisation → Repositories → New**.
+2. Set the repository name to `.release-regent`.
+3. Choose **Private** (recommended — policy files may contain sensitive settings).
+4. Do **not** initialise with a README; you will add files manually.
+5. Click **Create repository**.
+
+---
+
+## Step 2 — Install the GitHub App on the metadata repository
+
+1. Go to **GitHub → Settings → Installations → \<your app\> → Configure**.
+2. Under **Repository access**, ensure **All repositories** is selected, or add
+   `.release-regent` explicitly.
+3. Click **Save**.
+
+Release Regent discovers the App installation automatically when it processes the first event
+for a repository in your organisation.
+
+---
+
+## Step 3 — Add global policy
+
+Create a `global.toml` file at the root of the metadata repository. This file applies to
+every repository in your organisation.
+
+```toml
+# myorg/.release-regent/global.toml
+
+# Prevent any repository from switching to an external versioning script.
+locked_fields = ["versioning.strategy"]
+
+[versioning]
+strategy = "conventional"
+```
+
+Commit and push to the default branch.
+
+!!! tip "Start with no locks"
+    It is safer to start with an unlocked `global.toml` that sets default values only, then
+    add `locked_fields` once you are confident in the policy. An invalid `global.toml` causes
+    a hard failure for **all events** in your organisation until it is corrected.
+
+---
+
+## Step 4 — Add group policies (optional)
+
+If you want different defaults for subsets of repositories, create group policy files under
+`groups/`.
+
+```
+myorg/.release-regent/
+  global.toml
+  groups/
+    backend.toml
+    mobile.toml
+```
+
+Example group file:
+
+```toml
+# myorg/.release-regent/groups/backend.toml
+
+# Lock draft so that backend services never accidentally publish non-draft releases.
+locked_fields = ["releases.draft"]
+
+[releases]
+draft = true
+
+[release_pr]
+title_template = "chore(release): ${version} [backend]"
+```
+
+Repositories opt in to a group by adding a `group` field to their own dotfile:
+
+```toml
+# myorg/platform-api/.release-regent.toml
+group = "backend"
+
+[versioning]
+excluded_pr_authors = ["dependabot[bot]"]
+```
+
+---
+
+## Step 5 — Verify the configuration is picked up
+
+After pushing the policy files, trigger a Release Regent event in one of the managed
+repositories (for example, open a pull request). Check the server logs for entries such as:
+
+```
+INFO  release_regent::config: loaded global policy from myorg/.release-regent/global.toml
+INFO  release_regent::config: loaded group policy from myorg/.release-regent/groups/backend.toml
+```
+
+If the metadata repository is unreachable or the App is not installed correctly, you will see
+a `WARN` entry and the global and group levels will be skipped.
+
+---
+
+## Managing policy files over time
+
+### Branch protection and CODEOWNERS
+
+Treat the metadata repository like any other production configuration repository:
+
+- Enable branch protection on the default branch (require PR reviews, status checks).
+- Add a `CODEOWNERS` file to require review from the platform team for all policy changes.
+
+```
+# myorg/.release-regent/.github/CODEOWNERS
+* @myorg/platform-team
+```
+
+Release Regent does not validate who made changes to the metadata repository — that
+responsibility belongs to branch protection rules and CODEOWNERS.
+
+### Cache TTL considerations
+
+Release Regent caches policy files to reduce API calls:
+
+| Level | TTL |
+| :--- | :--- |
+| Global policy | 10 minutes |
+| Group policy | 5 minutes |
+
+After pushing a policy change, allow up to one TTL window before all running server instances
+pick up the new values. A server restart clears all caches immediately.
+
+### Error handling for invalid files
+
+If a policy file is pushed with a TOML syntax error or an invalid field value:
+
+- **`global.toml` invalid** — all events for every repository in the organisation hard-fail
+  until the file is corrected. Fix the file and push the correction; the cache entry is
+  evicted on the next event attempt.
+- **Group file invalid** — events for repositories in that group hard-fail. Repositories
+  not in the group are unaffected.
+
+---
+
+## Repository layout reference
+
+```
+{org}/.release-regent/
+  global.toml                     ← org-wide defaults and locks
+  groups/
+    {group-name}.toml             ← per-group defaults and locks
+```
+
+Both files use the same TOML schema as a repository dotfile, with two additions:
+
+| Field | Valid in | Description |
+| :--- | :--- | :--- |
+| `locked_fields` | `global.toml`, group files | List of dotted field paths that lower levels cannot override |
+| `group` | Repository dotfile only | Declares which group policy applies to this repository |
+
+---
+
+## Next steps
+
+- [Configuration hierarchy explained](../../explanation/configuration-hierarchy.md) — detailed
+  mental model of the five levels, locking rules, and caching
+- [Configuration file reference](../../reference/configuration.md) — all settings available in
+  a repository dotfile, including `group` and `locked_fields`

--- a/docs/user/how-to/setup/metadata-repository.md
+++ b/docs/user/how-to/setup/metadata-repository.md
@@ -44,9 +44,13 @@ Create a new GitHub repository named exactly `.release-regent` in your organisat
 ## Step 2 — Install the GitHub App on the metadata repository
 
 1. Go to **GitHub → Settings → Installations → \<your app\> → Configure**.
-2. Under **Repository access**, ensure **All repositories** is selected, or add
-   `.release-regent` explicitly.
+2. Under **Repository access**, ensure **All repositories** is selected.
 3. Click **Save**.
+
+!!! warning "Do not use a repository-scoped installation"
+    Do not restrict the installation to only the `.release-regent` repository. Release Regent
+    uses the metadata-repo installation to fetch dotfiles from *other* repositories in the
+    org. A repository-scoped installation will return `403` for those fetches.
 
 Release Regent discovers the App installation automatically when it processes the first event
 for a repository in your organisation.
@@ -108,7 +112,7 @@ title_template = "chore(release): ${version} [backend]"
 Repositories opt in to a group by adding a `group` field to their own dotfile:
 
 ```toml
-# myorg/platform-api/.release-regent.toml
+# myorg/platform-api/release-regent.toml
 group = "backend"
 
 [versioning]

--- a/docs/user/reference/configuration.md
+++ b/docs/user/reference/configuration.md
@@ -81,6 +81,28 @@ main = "main"
 
 ---
 
+## `group` — group membership
+
+**Type**: string
+**Default**: *(absent)*
+
+Declares the [configuration group](../explanation/configuration-hierarchy.md#group-membership)
+this repository belongs to. When set, Release Regent fetches
+`{org}/.release-regent/groups/{group}.toml` from the metadata repository and merges it as an
+additional policy layer above the global policy.
+
+This field is meaningful **only** in repository dotfiles. If it appears in `global.toml` or a
+group policy file it is silently ignored.
+
+```toml
+group = "backend"
+```
+
+See [Set up the metadata repository](../how-to/setup/metadata-repository.md) for how platform
+teams create group policy files.
+
+---
+
 ## `versioning` — version calculation
 
 ### `versioning.strategy`
@@ -442,6 +464,46 @@ strategy = "slack"
 webhook_url = "https://hooks.slack.com/services/T00/B00/xxx"
 channel = "#releases"
 ```
+
+---
+
+## `locked_fields` — policy locks
+
+**Type**: list of strings
+**Default**: `[]`
+**Valid in**: `global.toml` and group policy files in the metadata repository only
+
+A list of dotted field paths that lower configuration levels cannot override. Repository
+dotfiles cannot set this field — if present, the field is silently ignored with a `warn!`.
+
+```toml
+# global.toml — lock versioning strategy and PR overrides org-wide
+locked_fields = ["versioning.strategy", "versioning.allow_override"]
+
+[versioning]
+strategy = "conventional"
+allow_override = false
+```
+
+The following fields may be locked:
+
+| Field path | Description |
+| :--- | :--- |
+| `versioning.strategy` | Versioning algorithm |
+| `versioning.allow_override` | Whether PR comment override commands are permitted |
+| `releases.draft` | Whether GitHub releases are created as drafts |
+| `releases.prerelease` | Whether GitHub releases are marked pre-release |
+| `releases.generate_notes` | Whether GitHub auto-generates release notes |
+| `core.branches.main` | Name of the default/main branch |
+| `core.version_prefix` | Prefix prepended to version tags |
+| `error_handling.max_retries` | Maximum retry count |
+| `error_handling.backoff_multiplier` | Exponential backoff multiplier |
+| `error_handling.initial_delay_ms` | Initial retry delay |
+
+All `release_pr.*` and `notifications.*` fields are never lockable.
+
+For the full rules on lock accumulation and conflict handling, see
+[Configuration hierarchy — per-field locks](../explanation/configuration-hierarchy.md#per-field-locks).
 
 ---
 

--- a/docs/user/reference/configuration.md
+++ b/docs/user/reference/configuration.md
@@ -30,6 +30,9 @@ Release Regent searches for configuration files in the following order:
 ## File structure
 
 ```toml
+# group = "name"       # Optional: group policy membership (repo dotfile only)
+# locked_fields = []   # Optional: field locks (global.toml / group files only)
+
 [core]
 # Version prefix and branch settings
 

--- a/docs/user/reference/configuration.md
+++ b/docs/user/reference/configuration.md
@@ -10,7 +10,12 @@ optional — the tool works with sensible defaults if the file is absent.
 
 ## Supported file names
 
-Release Regent searches for configuration files in the following order:
+Release Regent uses configuration files in two different ways depending on how you deploy it.
+
+### Local file discovery (CLI and app-level config)
+
+When the CLI or the server reads configuration from the local file system, it searches for
+files in the following order inside `CONFIG_DIR` (or the current directory):
 
 | File name | Format |
 | :--- | :--- |
@@ -20,11 +25,24 @@ Release Regent searches for configuration files in the following order:
 
 **`rr init` creates `release-regent.toml` by default.**
 
+### Repository dotfile (server, fetched via GitHub API)
+
+When the server processes a webhook event, it fetches the per-repository dotfile from the
+target repository over the GitHub API. The server probes exactly one path:
+
+| File name | Format |
+| :--- | :--- |
+| `.release-regent.toml` (leading dot) | TOML |
+
+This filename with a leading dot is the convention for repository-level dotfiles fetched
+from GitHub. It is **not** part of the local file discovery list above.
+
 !!! note "Migrating from YAML"
     Previous versions of Release Regent also accepted `.release-regent.yml` and related YAML
     file names. YAML support has been removed. If your repository uses a `.release-regent.yml`
-    file, rename it to `.release-regent.toml` and convert the contents to TOML syntax before
-    upgrading. See [Migrating from YAML configuration](../how-to/configuration/migrate-from-yaml.md)
+    file, rename it to `.release-regent.toml` (keeping the leading dot — this is the
+    GitHub-fetched dotfile) and convert the contents to TOML syntax before upgrading.
+    See [Migrating from YAML configuration](../how-to/configuration/migrate-from-yaml.md)
     for step-by-step instructions.
 
 ## File structure
@@ -95,7 +113,7 @@ this repository belongs to. When set, Release Regent fetches
 additional policy layer above the global policy.
 
 This field is meaningful **only** in repository dotfiles. If it appears in `global.toml` or a
-group policy file it is silently ignored.
+group policy file it is silently ignored with a `warn!` log entry.
 
 ```toml
 group = "backend"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -76,6 +76,7 @@ nav:
           - Deploy the server: how-to/setup/install-server.md
           - Set up the GitHub App: how-to/setup/github-app-setup.md
           - Configure multiple repositories: how-to/setup/configure-multiple-repos.md
+          - Set up the metadata repository: how-to/setup/metadata-repository.md
       - Manage releases:
           - Override the version: how-to/releases/override-version.md
           - Trigger a release manually: how-to/releases/trigger-release-manually.md
@@ -101,6 +102,7 @@ nav:
       - GitHub App authentication: explanation/github-app-model.md
       - Release branch ownership: explanation/release-branch-ownership.md
       - Architecture: explanation/architecture.md
+      - Configuration hierarchy: explanation/configuration-hierarchy.md
 
 extra:
   social:


### PR DESCRIPTION
Add user-facing documentation for the five-level configuration hierarchy and the per-org metadata repository introduced in ADR-007.

Changes:
- Add explanation/configuration-hierarchy.md covering the five levels, metadata repo auto-discovery, group membership, per-field locks, caching, and failure-behaviour table
- Add how-to/setup/metadata-repository.md with step-by-step instructions for platform teams to create and maintain the metadata repository
- Add group and locked_fields fields to reference/configuration.md
- Fix configure-multiple-repos.md which incorrectly stated there is no global configuration file
- Update explanation/index.md to list the new article
- Update mkdocs.yml nav to include both new pages
