### PR TITLE
chore(deps): update Rust dependencies and toolchain to 1.96

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -246,9 +246,9 @@ dependencies = [
 
 [[package]]
 name = "azure_core"
-version = "0.35.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9966f75417a6779ea221531960d9d46fe630879606501aa5277312ad4ae38587"
+checksum = "fe6a26a7d374b440015cbbcbf2d9d8be5a133aa940599f5e5dc569504baa262e"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -267,9 +267,9 @@ dependencies = [
 
 [[package]]
 name = "azure_core_macros"
-version = "0.8.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70066e34b8db2c3f0b852c56a99333bd25fdedfb8850cd95dddf930928b47b80"
+checksum = "b9b52dba6a345f3ad2d42ff8d0d63df9d0994cfa29657bf18ffdbf149f78a4f5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -279,9 +279,9 @@ dependencies = [
 
 [[package]]
 name = "azure_identity"
-version = "0.35.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385e4426c01965149a002a72c54c43d6f1b9d2244179e70647df48e3b28f8c32"
+checksum = "32edf96b356ca7c51d7590c4925cc36efc3947a5da4468e8e0b25c56ecbb3de5"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -297,9 +297,9 @@ dependencies = [
 
 [[package]]
 name = "azure_security_keyvault_secrets"
-version = "0.14.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c1feb5088b6865b7681e0012e71ae3d14b456a45b7ef0de85ca94a58633746"
+checksum = "e96b370d75ebb8807cc1ccfc6fe647b1e61e13052cba2e800b95f0cf0bd27d9a"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -1325,7 +1325,7 @@ dependencies = [
  "config",
  "dyn-clone",
  "etcetera",
- "git-conventional",
+ "git-conventional 0.12.9",
  "git2",
  "glob",
  "indexmap",
@@ -1355,6 +1355,16 @@ dependencies = [
  "serde",
  "unicase",
  "winnow 0.7.15",
+]
+
+[[package]]
+name = "git-conventional"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7079e0e98895b810e042ef90b667d8d0a28c172fb3212e777b2d279ec2b29f25"
+dependencies = [
+ "unicase",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -2234,7 +2244,7 @@ version = "0.2.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc89399c10a3de3a18971b961e9fea788eb252d887c1c2f740f351a907088d0c"
 dependencies = [
- "git-conventional",
+ "git-conventional 0.12.9",
  "regex",
  "semver",
 ]
@@ -3037,7 +3047,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-test",
- "toml 0.9.12+spec-1.1.0",
+ "toml 1.1.2+spec-1.1.0",
  "tracing",
  "tracing-subscriber",
  "uuid",
@@ -3051,7 +3061,7 @@ dependencies = [
  "chrono",
  "futures",
  "git-cliff-core",
- "git-conventional",
+ "git-conventional 1.1.0",
  "proptest",
  "regex",
  "release_regent_testing",
@@ -3061,7 +3071,7 @@ dependencies = [
  "tokio",
  "tokio-test",
  "tokio-util",
- "toml 0.9.12+spec-1.1.0",
+ "toml 1.1.2+spec-1.1.0",
  "toml_edit",
  "tracing",
  "tracing-test",
@@ -3107,7 +3117,7 @@ dependencies = [
  "release_regent_config_provider",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "thiserror 2.0.18",
  "tokio",
  "tokio-test",
@@ -3132,7 +3142,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-test",
- "toml 0.9.12+spec-1.1.0",
+ "toml 1.1.2+spec-1.1.0",
  "tracing",
  "tracing-test",
  "walkdir",
@@ -3147,7 +3157,7 @@ dependencies = [
  "chrono",
  "http",
  "pretty_assertions",
- "rand 0.9.4",
+ "rand 0.10.1",
  "release-regent-core",
  "reqwest",
  "serde",
@@ -3428,15 +3438,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scc"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
-dependencies = [
- "sdd",
-]
-
-[[package]]
 name = "schannel"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3450,12 +3451,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "sdd"
-version = "3.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "sec1"
@@ -3597,23 +3592,23 @@ dependencies = [
 
 [[package]]
 name = "serial_test"
-version = "3.2.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b258109f244e1d6891bf1053a55d63a5cd4f8f4c30cf9a1280989f80e7a1fa9"
+checksum = "699f4197115b8a7e7ff19c9a315a4bd6fffec26cc4626ef45ecaea389e081c6d"
 dependencies = [
- "futures",
+ "futures-executor",
+ "futures-util",
  "log",
  "once_cell",
  "parking_lot",
- "scc",
  "serial_test_derive",
 ]
 
 [[package]]
 name = "serial_test_derive"
-version = "3.2.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d69265a08751de7844521fd15003ae0a888e035773ba05695c5c759a6f89eef"
+checksum = "94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4114,18 +4109,14 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
+ "indexmap",
  "serde_core",
  "serde_spanned",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
+ "toml_writer",
  "winnow 1.0.3",
 ]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 
 [[package]]
 name = "toml_datetime"
@@ -4147,14 +4138,15 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.27"
+version = "0.25.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
 dependencies = [
  "indexmap",
- "toml_datetime 0.6.11",
- "toml_write",
- "winnow 0.7.15",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -4165,12 +4157,6 @@ checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow 1.0.3",
 ]
-
-[[package]]
-name = "toml_write"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
@@ -4327,9 +4313,9 @@ checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "typespec"
-version = "0.14.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "247afbeabe0c383f630d0fdcb4fb92818c31cd3fe5d293335daff8cac79d4e0f"
+checksum = "21666a31293beab8f41d38c2849ddbc342cd9c7cb4d71a9818868287a8934e53"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -4341,9 +4327,9 @@ dependencies = [
 
 [[package]]
 name = "typespec_client_core"
-version = "0.14.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4714a935f6aa74724775f07291390e8f07df0a1804544cd4106ac3b75c0478d2"
+checksum = "924f0c734e0ac3b881ab99d032bd28fcc969d2bb73ef1b8dd4772fd8e518a382"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4366,9 +4352,9 @@ dependencies = [
 
 [[package]]
 name = "typespec_macros"
-version = "0.13.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d17153fde258b3c862cecffad95e185c0eb83e619e76542c4b3ed9828af840f0"
+checksum = "2c608f4427943f8adb211abc95c87672b1b98847152783507d54e3246e502f60"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,12 +35,12 @@ thiserror = "2.0"
 # Serialization
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-toml = "0.9"
-toml_edit = "0.22"
+toml = "1.0"
+toml_edit = "0.25"
 
 # GitHub integration
 github-bot-sdk = "0.2.0"
-octocrab = "0.49"
+octocrab = "0.53"
 reqwest = { version = "0.13", features = ["json", "rustls"] }
 
 # Crypto and security
@@ -53,13 +53,12 @@ uuid = { version = "1.20", features = ["v4", "serde"] }
 clap = { version = "4.4", features = ["derive"] }
 
 # Observability
-opentelemetry = "0.30"
-opentelemetry-jaeger = "0.22"
-opentelemetry_sdk = "0.30"
+opentelemetry = "0.32"
+opentelemetry_sdk = "0.32"
 
 # Azure
-azure_identity = "0.35"
-azure_security_keyvault_secrets = "0.14"
+azure_identity = "1.0"
+azure_security_keyvault_secrets = "1.0"
 
 # Test dependencies
 tempfile = "3.27"
@@ -67,11 +66,11 @@ tracing-test = "0.2"
 tokio-test = "0.4"
 mockall = "0.14"
 pretty_assertions = "=1.4.1"
-serial_test = "=3.2.0"
+serial_test = "=3.5.0"
 wiremock = "0.6"
 hmac = "0.13"
 proptest = "1.7"
-sha2 = "0.10"
+sha2 = "0.11"
 hex = "0.4"
 
 # Additional utilities
@@ -81,12 +80,12 @@ walkdir = "2.5"
 jsonschema = "0.46"
 once_cell = "1.21"
 regex = "1.12"
-rand = "0.9"
+rand = "0.10"
 http = "1"
 bytes = "1.11"
 
 # Version calculation
-git-conventional = "0.12"
+git-conventional = "1.0"
 
 # Web framework
 axum = "0.8"

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,8 +33,8 @@
 # =============================================================================
 # Pin to a specific Rust release so that builds on different days produce
 # identical binaries.  Update this together with rust-version in Cargo.toml
-# when raising the MSRV.  Current stable at the time of writing: 1.95.
-FROM rust:1.95-slim@sha256:e14e87345b4d5964ddcc3491d27ee046a0f23820f340c3c1e24da6880141f7c0 AS deps
+# when raising the MSRV.  Current stable at the time of writing: 1.96.
+FROM rust:1.96-slim@sha256:3b05f7c617a200c41c3506097f0d15fc193a1c93bfd8f141007b47cac8f95d3c AS deps
 
 # TARGETARCH is injected by BuildKit (values: amd64, arm64, etc.).
 # cmake, clang, pkg-config are required on all platforms by aws-lc-sys.
@@ -114,7 +114,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 #
 # Must use the same Debian release as the builder image so that the compiled
 # binary and the glibc version in the runtime layer match.
-# rust:1.95-slim is based on Debian trixie (glibc 2.41).
+# rust:1.96-slim is based on Debian trixie (glibc 2.41).
 # bookworm-slim only ships glibc 2.36 and would fail with a version-not-found
 # error at startup.  Keep this in sync with the FROM in the deps stage.
 # =============================================================================

--- a/crates/server/src/handler_tests.rs
+++ b/crates/server/src/handler_tests.rs
@@ -17,7 +17,7 @@ use tokio::sync::mpsc;
 /// Compute the HMAC-SHA256 of `payload` with `secret`, formatted as
 /// `sha256=<hex>` to match the `X-Hub-Signature-256` header.
 fn compute_signature(payload: &[u8], secret: &str) -> String {
-    use hmac::{Hmac, Mac};
+    use hmac::{Hmac, KeyInit, Mac};
     use sha2::Sha256;
 
     type HmacSha256 = Hmac<Sha256>;

--- a/crates/testing/src/builders/mod.rs
+++ b/crates/testing/src/builders/mod.rs
@@ -45,7 +45,7 @@ pub trait TestDataBuilder<T> {
 /// Helper functions for generating realistic test data
 pub mod helpers {
     use chrono::{DateTime, Utc};
-    use rand::Rng;
+    use rand::RngExt;
 
     /// Generate a realistic Git SHA
     ///

--- a/crates/testing/src/mocks/mod.rs
+++ b/crates/testing/src/mocks/mod.rs
@@ -170,7 +170,7 @@ impl MockState {
     /// Determine if this call should simulate a failure
     #[must_use]
     pub fn should_simulate_failure(&self) -> bool {
-        use rand::Rng;
+        use rand::RngExt;
 
         if !self.config.simulate_failures {
             return false;


### PR DESCRIPTION
## Summary

- Updates 11 workspace Rust dependencies from their Renovate branches, including major-version bumps for `git-conventional` (0.12→1.0), `toml` (0.9→1.0), `azure_identity` (0.35→1.0), and `azure_security_keyvault_secrets` (0.14→1.0)
- Updates the Dockerfile base image from `rust:1.95-slim` to `rust:1.96-slim`
- Removes the deprecated `opentelemetry-jaeger` workspace dependency (archived upstream, no compatible release for opentelemetry 0.32)

## Dependency changes

| Dependency | Before | After |
|---|---|---|
| `git-conventional` | 0.12 | 1.0 |
| `toml` | 0.9 | 1.0 |
| `toml_edit` | 0.22 | 0.25 |
| `octocrab` | 0.49 | 0.53 |
| `opentelemetry` | 0.30 | 0.32 |
| `opentelemetry_sdk` | 0.30 | 0.32 |
| `azure_identity` | 0.35 | 1.0 |
| `azure_security_keyvault_secrets` | 0.14 | 1.0 |
| `rand` | 0.9 | 0.10 |
| `serial_test` | =3.2.0 | =3.5.0 |
| `sha2` | 0.10 | 0.11 |
| Rust toolchain (Dockerfile) | 1.95 | 1.96 |

## Code changes required by API breaks

- **rand 0.10**: `random_range`/`random` moved from `Rng` to `RngExt` — updated imports in `crates/testing/src/builders/mod.rs` and `crates/testing/src/mocks/mod.rs`
- **sha2 0.11 + hmac 0.13**: `KeyInit` must now be explicitly imported for `new_from_slice` — added to import in `crates/server/src/handler_tests.rs`

## Test plan

- [x] `cargo build` passes with no errors
- [x] `cargo test` passes — 844 tests pass, 21 ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)