### PR TITLE
docs: add sample config files for all four configuration levels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2793,9 +2793,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",

--- a/docs/user/explanation/configuration-hierarchy.md
+++ b/docs/user/explanation/configuration-hierarchy.md
@@ -260,3 +260,15 @@ incorrect settings.
   repository dotfile
 - [ADR-007: Enterprise configuration hierarchy](../../adr/ADR-007-enterprise-config-hierarchy.md)
   — the architectural decision record that introduced this design
+
+### Sample files
+
+Ready-to-copy example files for each level are in the
+[`samples/config/`](../../../samples/config/) directory:
+
+| Level | Sample file |
+| :---- | :---------- |
+| 2 — App-level | [`samples/config/release-regent.toml`](../../../samples/config/release-regent.toml) |
+| 3 — Global policy | [`samples/config/global.toml`](../../../samples/config/global.toml) |
+| 4 — Group policy | [`samples/config/groups/backend.toml`](../../../samples/config/groups/backend.toml), [`samples/config/groups/mobile.toml`](../../../samples/config/groups/mobile.toml) |
+| 5 — Repository dotfile | [`samples/config/.release-regent.toml`](../../../samples/config/.release-regent.toml) |

--- a/docs/user/how-to/setup/metadata-repository.md
+++ b/docs/user/how-to/setup/metadata-repository.md
@@ -62,6 +62,11 @@ for a repository in your organisation.
 Create a `global.toml` file at the root of the metadata repository. This file applies to
 every repository in your organisation.
 
+Copy [`samples/config/global.toml`](../../../../samples/config/global.toml) as a starting
+point, then adjust the locked fields and defaults for your organisation.
+
+Minimal example to get started:
+
 ```toml
 # myorg/.release-regent/global.toml
 
@@ -94,7 +99,14 @@ myorg/.release-regent/
     mobile.toml
 ```
 
-Example group file:
+Copy the sample group files as a starting point:
+
+- [`samples/config/groups/backend.toml`](../../../../samples/config/groups/backend.toml) —
+  example for backend services (draft releases, Slack notifications)
+- [`samples/config/groups/mobile.toml`](../../../../samples/config/groups/mobile.toml) —
+  example for mobile apps (pre-release flag, store submission checklist)
+
+Minimal example group file:
 
 ```toml
 # myorg/.release-regent/groups/backend.toml
@@ -109,10 +121,12 @@ draft = true
 title_template = "chore(release): ${version} [backend]"
 ```
 
-Repositories opt in to a group by adding a `group` field to their own dotfile:
+Repositories opt in to a group by adding a `group` field to their own dotfile. Use
+[`samples/config/.release-regent.toml`](../../../../samples/config/.release-regent.toml)
+as a starting point for the repository dotfile:
 
 ```toml
-# myorg/platform-api/release-regent.toml
+# myorg/platform-api/.release-regent.toml
 group = "backend"
 
 [versioning]

--- a/docs/user/reference/configuration.md
+++ b/docs/user/reference/configuration.md
@@ -528,6 +528,23 @@ For the full rules on lock accumulation and conflict handling, see
 
 ---
 
+## Sample files
+
+Ready-to-copy example files for each configuration level are in the
+[`samples/config/`](../../../samples/config/) directory:
+
+| Level | Sample file |
+| :---- | :---------- |
+| 2 — App-level | [`samples/config/release-regent.toml`](../../../samples/config/release-regent.toml) |
+| 3 — Global policy | [`samples/config/global.toml`](../../../samples/config/global.toml) |
+| 4 — Group policy | [`samples/config/groups/backend.toml`](../../../samples/config/groups/backend.toml), [`samples/config/groups/mobile.toml`](../../../samples/config/groups/mobile.toml) |
+| 5 — Repository dotfile | [`samples/config/.release-regent.toml`](../../../samples/config/.release-regent.toml) |
+
+See the [configuration hierarchy](../explanation/configuration-hierarchy.md) for how these
+levels interact and where each file is deployed.
+
+---
+
 ## Complete example
 
 ```toml

--- a/samples/README.md
+++ b/samples/README.md
@@ -279,6 +279,21 @@ samples/
   create-test-repo.ps1       Test repository generator
   .env.example               Credential template (copy to .env and fill in values)
   config/
-    release-regent.toml      Sample server configuration mounted into Docker
+    release-regent.toml      Level 2 — app-level config (mounted into Docker at /config)
+    global.toml              Level 3 — org-wide global policy sample (metadata repo root)
+    groups/
+      backend.toml           Level 4 — group policy sample for backend services
+      mobile.toml            Level 4 — group policy sample for mobile apps
+    .release-regent.toml     Level 5 — repository dotfile sample (repo root)
   README.md                  This file
 ```
+
+The four config sample files correspond to the four configurable levels of the
+[configuration hierarchy](../docs/user/explanation/configuration-hierarchy.md):
+
+| Level | Sample file | Deployed location |
+| :---- | :---------- | :---------------- |
+| 2 — App-level | `config/release-regent.toml` | `CONFIG_DIR/release-regent.toml` on the server host |
+| 3 — Global policy | `config/global.toml` | `{org}/.release-regent/global.toml` in the metadata repository |
+| 4 — Group policy | `config/groups/backend.toml`, `config/groups/mobile.toml` | `{org}/.release-regent/groups/{group}.toml` in the metadata repository |
+| 5 — Repository dotfile | `config/.release-regent.toml` | `.release-regent.toml` at each repository root |

--- a/samples/config/.release-regent.toml
+++ b/samples/config/.release-regent.toml
@@ -1,0 +1,175 @@
+# =============================================================================
+# Release Regent — repository dotfile (Level 5 of 5 in the hierarchy)
+# =============================================================================
+# This file lives at the root of each repository as .release-regent.toml
+# (note the leading dot).
+#
+# This is the highest-priority configuration level — it overrides app-level,
+# global policy, and group policy for any field that is not locked by a
+# higher level.
+#
+# All settings are optional. If this file is absent, Release Regent uses
+# whatever the lower levels resolved to.
+#
+# Full reference: docs/user/reference/configuration.md
+# Hierarchy guide: docs/user/explanation/configuration-hierarchy.md
+# =============================================================================
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Group membership (optional)
+# ─────────────────────────────────────────────────────────────────────────────
+# Declare which group policy applies to this repository.
+# Release Regent fetches {org}/.release-regent/groups/{group}.toml and merges
+# it between global policy and this dotfile.
+# Remove or comment out if this repo does not belong to a group.
+#
+# group = "backend"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Core settings
+# ─────────────────────────────────────────────────────────────────────────────
+
+[core]
+# Prefix prepended to version numbers in tags and PR titles.
+# Common values: "v" (tags like v1.2.3), "" (bare numbers), "release-"
+version_prefix = "v"
+
+[core.branches]
+# The default branch of this repository.
+main = "main"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Versioning
+# ─────────────────────────────────────────────────────────────────────────────
+
+[versioning]
+# Calculate the next version from conventional commit messages.
+strategy = "conventional"
+
+# Allow contributors to override the calculated bump with a PR comment
+# (e.g. /override-bump minor).
+allow_override = true
+
+# Suppress version comments for bots that open dependency PRs.
+excluded_pr_authors = ["dependabot[bot]", "renovate[bot]"]
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Release pull request
+# ─────────────────────────────────────────────────────────────────────────────
+
+[release_pr]
+# Placeholders available: ${version}, ${version_tag}, ${changelog},
+# ${commit_count}, ${date}
+title_template = "chore(release): ${version}"
+
+body_template = """
+## Release ${version_tag}
+
+### Changes
+
+${changelog}
+
+### Release information
+
+- **Version**: ${version}
+- **Commits**: ${commit_count} commits since last release
+- **Date**: ${date}
+"""
+
+# Create the release PR as a draft PR.
+draft = false
+
+# Automatically detect and update Cargo.toml, package.json, pyproject.toml,
+# and composer.json at the repository root.
+auto_detect_manifests = true
+
+# Explicit manifest files to update (processed in addition to auto-detected ones).
+# Uncomment and adjust as needed.
+#
+# [[release_pr.manifest_files]]
+# path = "Cargo.toml"
+# format = "toml"
+# version_key = "package.version"
+#
+# [[release_pr.manifest_files]]
+# path = "package.json"
+# format = "json"
+# version_key = "version"
+#
+# [[release_pr.manifest_files]]
+# path = "VERSION"
+# format = "plain_text"
+# version_key = "^([0-9]+\\.[0-9]+\\.[0-9]+)$"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# GitHub releases
+# ─────────────────────────────────────────────────────────────────────────────
+
+[releases]
+# Publish releases immediately (set true to require manual publish).
+draft = false
+
+# Mark as pre-release in the GitHub UI.
+prerelease = false
+
+# Include GitHub's auto-generated notes alongside the changelog.
+generate_notes = true
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Changelog
+# ─────────────────────────────────────────────────────────────────────────────
+
+[changelog]
+# Strategy: "internal" (default) | "git_cliff" | external command (see below)
+strategy = "internal"
+
+include_authors = true
+include_shas = true
+include_links = true
+
+section_template = "### {title}\n\n{entries}\n"
+commit_template = "- {description} [{sha}]"
+
+# Override the remote URL used for link generation (auto-detected if blank).
+# remote_url = "https://github.com/myorg/myrepo"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Error handling / retries
+# ─────────────────────────────────────────────────────────────────────────────
+
+[error_handling]
+max_retries = 5
+backoff_multiplier = 2.0
+initial_delay_ms = 1000
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Notifications
+# ─────────────────────────────────────────────────────────────────────────────
+
+[notifications]
+enabled = true
+
+# Options: "github_issue" | "webhook" | "slack" | "none"
+strategy = "github_issue"
+
+[notifications.github_issue]
+labels = ["release-regent", "bug"]
+assignees = []
+
+# Webhook notification (uncomment to use instead of github_issue)
+# [notifications]
+# strategy = "webhook"
+#
+# [notifications.webhook]
+# url = "https://hooks.example.com/release-regent"
+#
+# [notifications.webhook.headers]
+# Authorization = "Bearer mytoken"
+
+# Slack notification (uncomment to use instead of github_issue)
+# [notifications]
+# strategy = "slack"
+#
+# [notifications.slack]
+# webhook_url = "https://hooks.slack.com/services/T00/B00/xxx"
+# channel = "#releases"

--- a/samples/config/global.toml
+++ b/samples/config/global.toml
@@ -1,0 +1,114 @@
+# =============================================================================
+# Release Regent — org-wide global policy (Level 3 of 5 in the hierarchy)
+# =============================================================================
+# This file lives at the root of the metadata repository:
+#
+#   {org}/.release-regent/global.toml
+#
+# Settings here apply to EVERY repository in the organisation.
+# This level overrides the app-level config (Level 2) for unlocked fields,
+# and is itself overridden by group policy (Level 4) and each repository's
+# own dotfile (Level 5).
+#
+# Fields listed in locked_fields cannot be changed by any lower level.
+# An invalid global.toml hard-fails ALL events in the org — review carefully
+# and prefer locking only what is truly non-negotiable.
+#
+# Full reference: docs/user/reference/configuration.md
+# Hierarchy guide: docs/user/explanation/configuration-hierarchy.md
+# =============================================================================
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Locked fields
+# ─────────────────────────────────────────────────────────────────────────────
+# These field paths cannot be overridden by group policy or repository dotfiles.
+# Start with an empty list and add locks only when you are confident in the
+# policy — a lock cannot be softened without editing this file.
+
+locked_fields = [
+  # Enforce conventional commits org-wide; no external version scripts allowed.
+  "versioning.strategy",
+  # Prevent individual repos from disabling PR override commands.
+  # Remove this if teams need autonomy over bump overrides.
+  # "versioning.allow_override",
+]
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Core settings
+# ─────────────────────────────────────────────────────────────────────────────
+
+[core]
+# Standard "v" prefix for all org releases (e.g. v1.2.3).
+version_prefix = "v"
+
+[core.branches]
+# Almost all repositories in this org use "main" as the default branch.
+# Repositories that use a different name (e.g. "master") override this in
+# their own dotfile (not locked, so they can).
+main = "main"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Versioning
+# ─────────────────────────────────────────────────────────────────────────────
+
+[versioning]
+# conventional is the only permitted strategy (see locked_fields above).
+strategy = "conventional"
+
+# Allow contributors to bump via PR comment by default; individual repos may
+# disable this if not locked.
+allow_override = true
+
+# Suppress version comments for common bot accounts.
+excluded_pr_authors = ["dependabot[bot]", "renovate[bot]"]
+
+# ─────────────────────────────────────────────────────────────────────────────
+# GitHub releases
+# ─────────────────────────────────────────────────────────────────────────────
+
+[releases]
+# Publish releases immediately (not as drafts).
+draft = false
+
+# No pre-release marker by default; groups or repos can override if needed.
+prerelease = false
+
+# Include GitHub's auto-generated notes alongside our changelog.
+generate_notes = true
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Release pull request
+# ─────────────────────────────────────────────────────────────────────────────
+# release_pr fields are never lockable — each repository can always customise
+# its PR title and body without platform-team intervention.
+
+[release_pr]
+title_template = "chore(release): ${version}"
+body_template = """
+## Changelog
+
+${changelog}
+"""
+draft = false
+auto_detect_manifests = true
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Error handling / retries
+# ─────────────────────────────────────────────────────────────────────────────
+
+[error_handling]
+max_retries = 5
+backoff_multiplier = 2.0
+initial_delay_ms = 1000
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Notifications
+# ─────────────────────────────────────────────────────────────────────────────
+
+[notifications]
+enabled = true
+strategy = "github_issue"
+
+[notifications.github_issue]
+labels = ["release-regent", "bug"]
+assignees = []

--- a/samples/config/groups/backend.toml
+++ b/samples/config/groups/backend.toml
@@ -1,0 +1,109 @@
+# =============================================================================
+# Release Regent — group policy: backend services (Level 4 of 5)
+# =============================================================================
+# This file lives in the metadata repository at:
+#
+#   {org}/.release-regent/groups/backend.toml
+#
+# It applies to every repository that declares:
+#
+#   group = "backend"
+#
+# in its own .release-regent.toml dotfile.
+#
+# This level overrides global policy (Level 3) for unlocked fields and is
+# itself overridden by each repository's own dotfile (Level 5).
+# Locks added here accumulate on top of global locks; they cannot remove
+# a lock already set by global.toml.
+#
+# Full reference: docs/user/reference/configuration.md
+# Hierarchy guide: docs/user/explanation/configuration-hierarchy.md
+# =============================================================================
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Locked fields (backend-specific additions)
+# ─────────────────────────────────────────────────────────────────────────────
+# These add to any locks already declared in global.toml.
+
+locked_fields = [
+  # Backend services must never publish a release directly — always draft
+  # so the on-call engineer can review before going public.
+  "releases.draft",
+  # Pre-release flag is controlled here, not by individual service teams.
+  "releases.prerelease",
+]
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Core settings
+# ─────────────────────────────────────────────────────────────────────────────
+
+[core]
+# Backend repos follow the org default; listed here for explicitness.
+version_prefix = "v"
+
+[core.branches]
+main = "main"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Versioning
+# ─────────────────────────────────────────────────────────────────────────────
+
+[versioning]
+# Inherited from global policy (and locked there); listed for readability.
+strategy = "conventional"
+allow_override = true
+excluded_pr_authors = ["dependabot[bot]", "renovate[bot]"]
+
+# ─────────────────────────────────────────────────────────────────────────────
+# GitHub releases
+# ─────────────────────────────────────────────────────────────────────────────
+
+[releases]
+# Locked above — backend releases are always draft until manually published.
+draft = true
+prerelease = false
+generate_notes = true
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Release pull request
+# ─────────────────────────────────────────────────────────────────────────────
+
+[release_pr]
+# Tag backend releases in the PR title so they are easy to identify in
+# cross-repo PR lists and Slack notifications.
+title_template = "chore(release): ${version} [backend]"
+body_template = """
+## Changelog
+
+${changelog}
+
+---
+*Backend service release — draft GitHub release will be published by on-call after review.*
+"""
+draft = false
+auto_detect_manifests = true
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Error handling / retries
+# ─────────────────────────────────────────────────────────────────────────────
+# Backend services run in a higher-reliability environment; use more aggressive
+# retry settings than the global default.
+
+[error_handling]
+max_retries = 8
+backoff_multiplier = 2.0
+initial_delay_ms = 500
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Notifications
+# ─────────────────────────────────────────────────────────────────────────────
+# Backend teams use Slack for incident response; route errors there instead of
+# opening GitHub issues (which are for product bugs, not tooling errors).
+
+[notifications]
+enabled = true
+strategy = "slack"
+
+[notifications.slack]
+webhook_url = "https://hooks.slack.com/services/YOUR_WORKSPACE_ID/YOUR_CHANNEL_ID/YOUR_TOKEN"
+channel = "#backend-releases"

--- a/samples/config/groups/mobile.toml
+++ b/samples/config/groups/mobile.toml
@@ -1,0 +1,100 @@
+# =============================================================================
+# Release Regent — group policy: mobile apps (Level 4 of 5)
+# =============================================================================
+# This file lives in the metadata repository at:
+#
+#   {org}/.release-regent/groups/mobile.toml
+#
+# It applies to every repository that declares:
+#
+#   group = "mobile"
+#
+# in its own .release-regent.toml dotfile.
+#
+# Full reference: docs/user/reference/configuration.md
+# Hierarchy guide: docs/user/explanation/configuration-hierarchy.md
+# =============================================================================
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Locked fields (mobile-specific additions)
+# ─────────────────────────────────────────────────────────────────────────────
+
+locked_fields = [
+  # Mobile releases go through the store review process, so all GitHub releases
+  # must be pre-releases until the app is approved.
+  "releases.prerelease",
+]
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Core settings
+# ─────────────────────────────────────────────────────────────────────────────
+
+[core]
+# Mobile apps use a numeric-only version for store compatibility (e.g. 1.2.3).
+version_prefix = ""
+
+[core.branches]
+main = "main"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Versioning
+# ─────────────────────────────────────────────────────────────────────────────
+
+[versioning]
+strategy = "conventional"
+allow_override = true
+excluded_pr_authors = ["dependabot[bot]", "renovate[bot]"]
+
+# ─────────────────────────────────────────────────────────────────────────────
+# GitHub releases
+# ─────────────────────────────────────────────────────────────────────────────
+
+[releases]
+draft = false
+# Locked above — all mobile releases are marked pre-release until store approval.
+prerelease = true
+generate_notes = true
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Release pull request
+# ─────────────────────────────────────────────────────────────────────────────
+
+[release_pr]
+title_template = "chore(release): ${version} [mobile]"
+body_template = """
+## Release ${version}
+
+### Changes
+
+${changelog}
+
+### Store submission checklist
+
+- [ ] Screenshots updated for all supported screen sizes
+- [ ] Release notes written in all supported languages
+- [ ] Version number updated in App Store Connect / Google Play Console
+- [ ] Build submitted for review
+"""
+draft = false
+auto_detect_manifests = true
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Error handling / retries
+# ─────────────────────────────────────────────────────────────────────────────
+
+[error_handling]
+max_retries = 5
+backoff_multiplier = 2.0
+initial_delay_ms = 1000
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Notifications
+# ─────────────────────────────────────────────────────────────────────────────
+
+[notifications]
+enabled = true
+strategy = "slack"
+
+[notifications.slack]
+webhook_url = "https://hooks.slack.com/services/YOUR_WORKSPACE_ID/YOUR_CHANNEL_ID/YOUR_TOKEN"
+channel = "#mobile-releases"


### PR DESCRIPTION
## Summary

- Add `samples/config/global.toml` — annotated org-wide global policy example (level 3)
- Add `samples/config/groups/backend.toml` and `groups/mobile.toml` — annotated group policy examples (level 4)
- Add `samples/config/.release-regent.toml` — clean generic repository dotfile example (level 5)
- Update `samples/README.md` with a full file reference table mapping each sample to its deployed location
- Update `docs/user/explanation/configuration-hierarchy.md`, `docs/user/how-to/setup/metadata-repository.md`, and `docs/user/reference/configuration.md` to link to the new sample files

## Test plan

- [ ] Verify all four sample files are valid TOML (`taplo check` or equivalent)
- [ ] Confirm links in the three updated doc files resolve correctly
- [ ] Check that `samples/README.md` file reference table matches the actual directory layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)