### PR TITLE
fix(release-pr): expand all template variables in PR body

### DIFF
--- a/crates/core/src/release_orchestrator.rs
+++ b/crates/core/src/release_orchestrator.rs
@@ -214,6 +214,22 @@ pub fn extract_previous_version_sentinel(body: &str) -> Option<String> {
         .map(str::to_owned)
 }
 
+/// Remove all `<!-- release-regent: … -->` sentinel lines from a changelog string.
+///
+/// `render_body` appends a sentinel comment to the PR body so that the update
+/// path can round-trip `previous_version`.  When `${changelog}` is the last
+/// section in the body template `extract_changelog_from_body` returns the entire
+/// tail including that sentinel.  Stripping sentinel lines before passing the
+/// merged changelog back into `render_body` prevents sentinels from accumulating
+/// across successive updates.
+fn strip_sentinel_lines(changelog: &str) -> String {
+    changelog
+        .lines()
+        .filter(|l| !l.starts_with("<!-- release-regent:"))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
 impl Default for OrchestratorConfig {
     fn default() -> Self {
         let body_template = Self::DEFAULT_BODY_TEMPLATE.to_string();
@@ -669,8 +685,13 @@ impl<'a, G: GitHubOperations> ReleaseOrchestrator<'a, G> {
 
         let merged_changelog =
             self.merge_changelog_bodies(fresh_pr.body.as_deref().unwrap_or(""), new_changelog);
+        // Strip any sentinel lines that leaked into the extracted changelog section
+        // (happens when ${changelog} is the last section in the body template and
+        // extract_changelog_from_body returns the entire tail including the sentinel).
+        // Without this, each successive update would accumulate one more sentinel line.
+        let clean_changelog = strip_sentinel_lines(&merged_changelog);
         let new_body = self.render_body(&BodyRenderContext {
-            changelog: &merged_changelog,
+            changelog: &clean_changelog,
             version,
             date: Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string(),
             correlation_id,

--- a/crates/core/src/release_orchestrator.rs
+++ b/crates/core/src/release_orchestrator.rs
@@ -466,7 +466,7 @@ impl<'a, G: GitHubOperations> ReleaseOrchestrator<'a, G> {
         };
 
         let title = self.render_title(version);
-        let body = self.render_body(changelog);
+        let body = self.render_body(changelog, version);
 
         // Fetch the existing CHANGELOG.md from the base branch so we can
         // prepend the new version section rather than overwriting history.
@@ -569,7 +569,7 @@ impl<'a, G: GitHubOperations> ReleaseOrchestrator<'a, G> {
 
         let merged_changelog =
             self.merge_changelog_bodies(fresh_pr.body.as_deref().unwrap_or(""), new_changelog);
-        let new_body = self.render_body(&merged_changelog);
+        let new_body = self.render_body(&merged_changelog, version);
         let new_title = self.render_title(version);
 
         // Only send the title when it has actually changed; avoids a spurious
@@ -1046,10 +1046,31 @@ impl<'a, G: GitHubOperations> ReleaseOrchestrator<'a, G> {
             .replace("{version}", &version_str)
     }
 
-    /// Render the PR body by substituting `${changelog}` in the configured
-    /// body template with the current release's changelog entries.
-    fn render_body(&self, changelog: &str) -> String {
-        self.config.body_template.replace("${changelog}", changelog)
+    /// Render the PR body by substituting template variables in the configured
+    /// body template with the current release's values.
+    ///
+    /// Supported variables:
+    /// - `${changelog}` — the release changelog entries
+    /// - `${version}` — the version number (e.g. `"0.7.1"`)
+    /// - `${version_tag}` — the version tag (e.g. `"v0.7.1"`)
+    /// - `${date}` — today's date in `YYYY-MM-DD` format
+    /// - `${commit_count}` — number of changelog entries (lines starting with `- `)
+    fn render_body(&self, changelog: &str, version: &SemanticVersion) -> String {
+        let version_str = version.to_string();
+        let version_tag_str = format!("{}{version_str}", self.config.version_prefix);
+        let date_str = Utc::now().format("%Y-%m-%d").to_string();
+        let commit_count = changelog
+            .lines()
+            .filter(|l| l.trim_start().starts_with("- "))
+            .count()
+            .to_string();
+        self.config
+            .body_template
+            .replace("${version_tag}", &version_tag_str)
+            .replace("${version}", &version_str)
+            .replace("${date}", &date_str)
+            .replace("${commit_count}", &commit_count)
+            .replace("${changelog}", changelog)
     }
 
     /// Extract the changelog section from a PR body.

--- a/crates/core/src/release_orchestrator.rs
+++ b/crates/core/src/release_orchestrator.rs
@@ -85,9 +85,23 @@ pub struct OrchestratorConfig {
 
     /// Template for the release PR body.
     ///
-    /// Use `${changelog}` as a placeholder; it is replaced with the formatted
-    /// changelog entries for **this release only**.  Any text before or after the
-    /// placeholder (version badges, footers, etc.) is preserved verbatim.
+    /// Supports the following `${variable}` placeholders (both `${var}` and
+    /// the legacy `{var}` style are accepted for backward compatibility):
+    ///
+    /// | Variable              | Description                                          |
+    /// |-----------------------|------------------------------------------------------|
+    /// | `${changelog}`        | Formatted changelog entries for this release only   |
+    /// | `${version}`          | Semantic version without prefix (e.g. `"1.2.3"`)    |
+    /// | `${version_tag}`      | Version with configured prefix (e.g. `"v1.2.3"`)   |
+    /// | `${date}`             | Current date-time in ISO 8601 format                 |
+    /// | `${commit_count}`     | Approximate number of changelog entries              |
+    /// | `${correlation_id}`   | Unique request identifier for tracing                |
+    /// | `${previous_version}` | Previous release version (or `"initial release"`)   |
+    /// | `${repository}`       | Repository in `"owner/repo"` format                 |
+    /// | `${branch}`           | Target branch name                                   |
+    ///
+    /// Any text before or after the placeholders (version badges, footers, etc.)
+    /// is preserved verbatim.
     ///
     /// Defaults to `"## Changelog\n\n${changelog}"`.
     pub body_template: String,
@@ -247,6 +261,33 @@ pub enum OrchestratorResult {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// Internal helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// All context values needed to render a release PR body template.
+///
+/// Keeps [`ReleaseOrchestrator::render_body`] deterministic (the caller supplies
+/// the pre-formatted `date`) and makes it easy to add future variables without
+/// changing every call site individually.
+struct BodyRenderContext<'a> {
+    /// Formatted changelog entries for this release.
+    changelog: &'a str,
+    /// Semantic version being released.
+    version: &'a SemanticVersion,
+    /// Pre-formatted date-time string in ISO 8601 format (e.g. `"2025-07-19T10:30:00Z"`).
+    date: String,
+    /// Unique request identifier propagated from the triggering event.
+    correlation_id: &'a str,
+    /// Version string of the previous release, if known.  Rendered as
+    /// `"initial release"` when `None`.
+    previous_version: Option<String>,
+    /// Repository in `"owner/repo"` format.
+    repository: String,
+    /// Target (base) branch name.
+    branch: &'a str,
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // ReleaseOrchestrator
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -321,6 +362,8 @@ impl<'a, G: GitHubOperations> ReleaseOrchestrator<'a, G> {
                         changelog,
                         base_branch,
                         base_sha,
+                        correlation_id,
+                        None,
                     )
                     .await?;
                 Ok(OrchestratorResult::Created { pr, branch_name })
@@ -341,6 +384,8 @@ impl<'a, G: GitHubOperations> ReleaseOrchestrator<'a, G> {
                                 version,
                                 changelog,
                                 base_sha,
+                                correlation_id,
+                                None,
                             )
                             .await?;
                         Ok(OrchestratorResult::Updated { pr })
@@ -362,6 +407,8 @@ impl<'a, G: GitHubOperations> ReleaseOrchestrator<'a, G> {
                                 changelog,
                                 base_sha,
                                 base_branch,
+                                correlation_id,
+                                Some(existing_version.to_string()),
                             )
                             .await?;
                         Ok(OrchestratorResult::Renamed { pr })
@@ -428,6 +475,7 @@ impl<'a, G: GitHubOperations> ReleaseOrchestrator<'a, G> {
     /// explicit parent commit.  This guarantees the branch tip **never passes through
     /// a state where it equals `base_sha`**, which would cause GitHub to auto-close
     /// any open release PR (head == base → no diff to merge).
+    #[allow(clippy::too_many_arguments)] // owner/repo/version/changelog/branch/sha/correlation_id/previous_version is the minimal create surface
     async fn create_release_branch_and_pr(
         &self,
         owner: &str,
@@ -436,6 +484,8 @@ impl<'a, G: GitHubOperations> ReleaseOrchestrator<'a, G> {
         changelog: &str,
         base_branch: &str,
         base_sha: &str,
+        correlation_id: &str,
+        previous_version: Option<String>,
     ) -> CoreResult<(PullRequest, String)> {
         let branch_name = self.make_branch_name(version);
 
@@ -466,7 +516,15 @@ impl<'a, G: GitHubOperations> ReleaseOrchestrator<'a, G> {
         };
 
         let title = self.render_title(version);
-        let body = self.render_body(changelog, version);
+        let body = self.render_body(&BodyRenderContext {
+            changelog,
+            version,
+            date: Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string(),
+            correlation_id,
+            previous_version,
+            repository: format!("{owner}/{repo}"),
+            branch: base_branch,
+        });
 
         // Fetch the existing CHANGELOG.md from the base branch so we can
         // prepend the new version section rather than overwriting history.
@@ -560,6 +618,8 @@ impl<'a, G: GitHubOperations> ReleaseOrchestrator<'a, G> {
         version: &SemanticVersion,
         new_changelog: &str,
         base_sha: &str,
+        correlation_id: &str,
+        previous_version: Option<String>,
     ) -> CoreResult<PullRequest> {
         // Always re-fetch to get the latest body (ETag prep).
         let fresh_pr = self
@@ -569,7 +629,15 @@ impl<'a, G: GitHubOperations> ReleaseOrchestrator<'a, G> {
 
         let merged_changelog =
             self.merge_changelog_bodies(fresh_pr.body.as_deref().unwrap_or(""), new_changelog);
-        let new_body = self.render_body(&merged_changelog, version);
+        let new_body = self.render_body(&BodyRenderContext {
+            changelog: &merged_changelog,
+            version,
+            date: Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string(),
+            correlation_id,
+            previous_version,
+            repository: format!("{owner}/{repo}"),
+            branch: &fresh_pr.base.ref_name.clone(),
+        });
         let new_title = self.render_title(version);
 
         // Only send the title when it has actually changed; avoids a spurious
@@ -678,7 +746,7 @@ impl<'a, G: GitHubOperations> ReleaseOrchestrator<'a, G> {
     /// 2. Create new PR pointing to the new branch.
     /// 3. Close the old PR.
     /// 4. Delete the old branch (non-fatal if it fails — log and continue).
-    #[allow(clippy::too_many_arguments)] // owner/repo/old_pr/version/changelog/sha/branch is the minimal rename surface
+    #[allow(clippy::too_many_arguments)] // owner/repo/old_pr/version/changelog/sha/branch/correlation_id/previous_version is the minimal rename surface
     async fn rename_release_pr(
         &self,
         owner: &str,
@@ -688,10 +756,21 @@ impl<'a, G: GitHubOperations> ReleaseOrchestrator<'a, G> {
         changelog: &str,
         base_sha: &str,
         base_branch: &str,
+        correlation_id: &str,
+        previous_version: Option<String>,
     ) -> CoreResult<PullRequest> {
         // Create new branch + PR for the higher version.
         let (new_pr, new_branch) = self
-            .create_release_branch_and_pr(owner, repo, version, changelog, base_branch, base_sha)
+            .create_release_branch_and_pr(
+                owner,
+                repo,
+                version,
+                changelog,
+                base_branch,
+                base_sha,
+                correlation_id,
+                previous_version,
+            )
             .await?;
 
         // Close the superseded PR.
@@ -1035,6 +1114,40 @@ impl<'a, G: GitHubOperations> ReleaseOrchestrator<'a, G> {
     ///
     /// Supports both `${variable}` (config-file style) and `{variable}` (internal style)
     /// for `version` (e.g. `"0.2.0"`) and `version_tag` (e.g. `"v0.2.0"`).
+    fn render_body(&self, ctx: &BodyRenderContext<'_>) -> String {
+        let version_str = ctx.version.to_string();
+        let version_tag_str = format!("{}{version_str}", self.config.version_prefix);
+        let commit_count = ctx
+            .changelog
+            .lines()
+            .filter(|l| l.trim_start().starts_with("- "))
+            .count()
+            .to_string();
+        let previous_version_str = ctx.previous_version.as_deref().unwrap_or("initial release");
+        self.config
+            .body_template
+            // ${variable} style — canonical
+            .replace("${version_tag}", &version_tag_str)
+            .replace("${version}", &version_str)
+            .replace("${date}", &ctx.date)
+            .replace("${commit_count}", &commit_count)
+            .replace("${correlation_id}", ctx.correlation_id)
+            .replace("${previous_version}", previous_version_str)
+            .replace("${repository}", &ctx.repository)
+            .replace("${branch}", ctx.branch)
+            .replace("${changelog}", ctx.changelog)
+            // {variable} style — backward-compatible legacy syntax
+            .replace("{version_tag}", &version_tag_str)
+            .replace("{version}", &version_str)
+            .replace("{date}", &ctx.date)
+            .replace("{commit_count}", &commit_count)
+            .replace("{correlation_id}", ctx.correlation_id)
+            .replace("{previous_version}", previous_version_str)
+            .replace("{repository}", &ctx.repository)
+            .replace("{branch}", ctx.branch)
+            .replace("{changelog}", ctx.changelog)
+    }
+
     fn render_title(&self, version: &SemanticVersion) -> String {
         let version_str = version.to_string();
         let version_tag_str = format!("{}{version_str}", self.config.version_prefix);
@@ -1046,32 +1159,7 @@ impl<'a, G: GitHubOperations> ReleaseOrchestrator<'a, G> {
             .replace("{version}", &version_str)
     }
 
-    /// Render the PR body by substituting template variables in the configured
-    /// body template with the current release's values.
-    ///
-    /// Supported variables:
-    /// - `${changelog}` — the release changelog entries
-    /// - `${version}` — the version number (e.g. `"0.7.1"`)
-    /// - `${version_tag}` — the version tag (e.g. `"v0.7.1"`)
-    /// - `${date}` — today's date in `YYYY-MM-DD` format
-    /// - `${commit_count}` — number of changelog entries (lines starting with `- `)
-    fn render_body(&self, changelog: &str, version: &SemanticVersion) -> String {
-        let version_str = version.to_string();
-        let version_tag_str = format!("{}{version_str}", self.config.version_prefix);
-        let date_str = Utc::now().format("%Y-%m-%d").to_string();
-        let commit_count = changelog
-            .lines()
-            .filter(|l| l.trim_start().starts_with("- "))
-            .count()
-            .to_string();
-        self.config
-            .body_template
-            .replace("${version_tag}", &version_tag_str)
-            .replace("${version}", &version_str)
-            .replace("${date}", &date_str)
-            .replace("${commit_count}", &commit_count)
-            .replace("${changelog}", changelog)
-    }
+    /// Render the PR title from the configured template.
 
     /// Extract the changelog section from a PR body.
     ///

--- a/crates/core/src/release_orchestrator.rs
+++ b/crates/core/src/release_orchestrator.rs
@@ -181,6 +181,39 @@ pub fn extract_changelog_header(body_template: &str) -> String {
         .to_string()
 }
 
+/// Extract the `previous_version` value embedded by [`ReleaseOrchestrator::render_body`].
+///
+/// `render_body` appends a hidden HTML comment of the form
+/// `<!-- release-regent: previous-version=VALUE -->` to every rendered PR body.
+/// This function finds that comment and returns `VALUE` so that the update path
+/// can re-render the body with the same `previous_version` it was originally
+/// created with, without resorting to fragile template-output parsing.
+///
+/// Returns `None` when the sentinel is absent (e.g. a body produced by an older
+/// version of release-regent), in which case the caller falls back to
+/// `"initial release"`.
+///
+/// # Examples
+///
+/// ```
+/// use release_regent_core::release_orchestrator::extract_previous_version_sentinel;
+///
+/// let body = "## Changelog\n\n- fix: thing\n<!-- release-regent: previous-version=1.2.3 -->";
+/// assert_eq!(extract_previous_version_sentinel(body), Some("1.2.3".to_string()));
+///
+/// assert_eq!(extract_previous_version_sentinel("no sentinel here"), None);
+/// ```
+pub fn extract_previous_version_sentinel(body: &str) -> Option<String> {
+    const PREFIX: &str = "<!-- release-regent: previous-version=";
+    const SUFFIX: &str = " -->";
+    body.lines()
+        .find_map(|line| {
+            line.strip_prefix(PREFIX)
+                .and_then(|rest| rest.strip_suffix(SUFFIX))
+        })
+        .map(str::to_owned)
+}
+
 impl Default for OrchestratorConfig {
     fn default() -> Self {
         let body_template = Self::DEFAULT_BODY_TEMPLATE.to_string();
@@ -376,6 +409,13 @@ impl<'a, G: GitHubOperations> ReleaseOrchestrator<'a, G> {
                             pr_number = existing_pr.number,
                             "Existing PR has same version; merging changelogs"
                         );
+                        // Carry forward the previous_version that was embedded
+                        // in the existing body sentinel so re-rendering the
+                        // template does not overwrite it with "initial release".
+                        let previous_version = existing_pr
+                            .body
+                            .as_deref()
+                            .and_then(extract_previous_version_sentinel);
                         let pr = self
                             .update_release_pr(
                                 owner,
@@ -385,7 +425,7 @@ impl<'a, G: GitHubOperations> ReleaseOrchestrator<'a, G> {
                                 changelog,
                                 base_sha,
                                 correlation_id,
-                                None,
+                                previous_version,
                             )
                             .await?;
                         Ok(OrchestratorResult::Updated { pr })
@@ -1110,10 +1150,16 @@ impl<'a, G: GitHubOperations> ReleaseOrchestrator<'a, G> {
         }
     }
 
-    /// Render the PR title from the configured template.
+    /// Render the PR body by substituting template variables in the configured
+    /// body template with the current release's values.
     ///
-    /// Supports both `${variable}` (config-file style) and `{variable}` (internal style)
-    /// for `version` (e.g. `"0.2.0"`) and `version_tag` (e.g. `"v0.2.0"`).
+    /// All nine variables documented on [`OrchestratorConfig::body_template`] are
+    /// substituted.  Both `${variable}` (canonical) and `{variable}` (legacy)
+    /// syntaxes are accepted for backward compatibility.
+    ///
+    /// A hidden sentinel comment `<!-- release-regent: previous-version=… -->` is
+    /// appended so that the update path can round-trip the value without fragile
+    /// text parsing of the rendered template output.
     fn render_body(&self, ctx: &BodyRenderContext<'_>) -> String {
         let version_str = ctx.version.to_string();
         let version_tag_str = format!("{}{version_str}", self.config.version_prefix);
@@ -1124,7 +1170,8 @@ impl<'a, G: GitHubOperations> ReleaseOrchestrator<'a, G> {
             .count()
             .to_string();
         let previous_version_str = ctx.previous_version.as_deref().unwrap_or("initial release");
-        self.config
+        let rendered = self
+            .config
             .body_template
             // ${variable} style — canonical
             .replace("${version_tag}", &version_tag_str)
@@ -1145,9 +1192,16 @@ impl<'a, G: GitHubOperations> ReleaseOrchestrator<'a, G> {
             .replace("{previous_version}", previous_version_str)
             .replace("{repository}", &ctx.repository)
             .replace("{branch}", ctx.branch)
-            .replace("{changelog}", ctx.changelog)
+            .replace("{changelog}", ctx.changelog);
+        // Append a hidden sentinel so the update path can retrieve the
+        // previous_version value without parsing the rendered template text.
+        format!("{rendered}\n<!-- release-regent: previous-version={previous_version_str} -->")
     }
 
+    /// Render the PR title from the configured template.
+    ///
+    /// Supports both `${variable}` (config-file style) and `{variable}` (internal style)
+    /// for `version` (e.g. `"0.2.0"`) and `version_tag` (e.g. `"v0.2.0"`).
     fn render_title(&self, version: &SemanticVersion) -> String {
         let version_str = version.to_string();
         let version_tag_str = format!("{}{version_str}", self.config.version_prefix);
@@ -1158,8 +1212,6 @@ impl<'a, G: GitHubOperations> ReleaseOrchestrator<'a, G> {
             .replace("{version_tag}", &version_tag_str)
             .replace("{version}", &version_str)
     }
-
-    /// Render the PR title from the configured template.
 
     /// Extract the changelog section from a PR body.
     ///

--- a/crates/core/src/release_orchestrator_tests.rs
+++ b/crates/core/src/release_orchestrator_tests.rs
@@ -2609,3 +2609,345 @@ mod property_tests {
         }
     }
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// render_body template variable substitution
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// `${version}` in the body template is replaced with the plain version string.
+#[tokio::test]
+async fn test_body_template_version_variable_is_substituted() {
+    let config = OrchestratorConfig {
+        body_template: "Release ${version} is here.".to_string(),
+        ..OrchestratorConfig::default()
+    };
+    let github = TestGitHub::new();
+    let orchestrator = ReleaseOrchestrator::new(config, &github);
+
+    orchestrator
+        .orchestrate(
+            "testorg",
+            "testrepo",
+            &ver(2, 3, 4),
+            "- feat: something [ab12cd34ef5678901234abcdef12345678901234]",
+            "main",
+            "sha-rv-001",
+            "corr-rv-001",
+        )
+        .await
+        .expect("orchestrate should succeed");
+
+    let prs = github.created_prs().await;
+    let body = prs[0].body.as_deref().unwrap_or("");
+    assert!(
+        body.contains("Release 2.3.4 is here."),
+        "body must contain substituted version; body:\n{body}"
+    );
+}
+
+/// `${version_tag}` in the body template is replaced with the prefixed version.
+#[tokio::test]
+async fn test_body_template_version_tag_variable_is_substituted() {
+    let config = OrchestratorConfig {
+        body_template: "Tag: ${version_tag}".to_string(),
+        ..OrchestratorConfig::default()
+    };
+    let github = TestGitHub::new();
+    let orchestrator = ReleaseOrchestrator::new(config, &github);
+
+    orchestrator
+        .orchestrate(
+            "testorg",
+            "testrepo",
+            &ver(1, 0, 0),
+            "- feat: something [ab12cd34ef5678901234abcdef12345678901234]",
+            "main",
+            "sha-rvt-001",
+            "corr-rvt-001",
+        )
+        .await
+        .expect("orchestrate should succeed");
+
+    let prs = github.created_prs().await;
+    let body = prs[0].body.as_deref().unwrap_or("");
+    assert!(
+        body.contains("Tag: v1.0.0"),
+        "body must contain substituted version_tag; body:\n{body}"
+    );
+}
+
+/// `${date}` in the body template is replaced with a full ISO 8601 timestamp.
+#[tokio::test]
+async fn test_body_template_date_variable_is_iso8601_timestamp() {
+    let config = OrchestratorConfig {
+        body_template: "Generated: ${date}".to_string(),
+        ..OrchestratorConfig::default()
+    };
+    let github = TestGitHub::new();
+    let orchestrator = ReleaseOrchestrator::new(config, &github);
+
+    orchestrator
+        .orchestrate(
+            "testorg",
+            "testrepo",
+            &ver(1, 0, 0),
+            "- feat: something [ab12cd34ef5678901234abcdef12345678901234]",
+            "main",
+            "sha-date-001",
+            "corr-date-001",
+        )
+        .await
+        .expect("orchestrate should succeed");
+
+    let prs = github.created_prs().await;
+    let body = prs[0].body.as_deref().unwrap_or("");
+    // The date must follow ISO 8601 full format: YYYY-MM-DDTHH:MM:SSZ
+    let iso8601_pattern =
+        regex::Regex::new(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z").expect("valid regex");
+    assert!(
+        iso8601_pattern.is_match(body),
+        "body must contain a full ISO 8601 timestamp; body:\n{body}"
+    );
+}
+
+/// `${commit_count}` in the body template is replaced with the count of
+/// changelog entries (lines starting with `- `).
+#[tokio::test]
+async fn test_body_template_commit_count_variable_is_substituted() {
+    let changelog = "- feat: first [aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1]\n\
+                     - fix: second [aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa2]\n\
+                     - chore: third [aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa3]";
+    let config = OrchestratorConfig {
+        body_template: "Count: ${commit_count}".to_string(),
+        ..OrchestratorConfig::default()
+    };
+    let github = TestGitHub::new();
+    let orchestrator = ReleaseOrchestrator::new(config, &github);
+
+    orchestrator
+        .orchestrate(
+            "testorg",
+            "testrepo",
+            &ver(1, 0, 0),
+            changelog,
+            "main",
+            "sha-cc-001",
+            "corr-cc-001",
+        )
+        .await
+        .expect("orchestrate should succeed");
+
+    let prs = github.created_prs().await;
+    let body = prs[0].body.as_deref().unwrap_or("");
+    assert!(
+        body.contains("Count: 3"),
+        "body must contain commit count of 3; body:\n{body}"
+    );
+}
+
+/// `${correlation_id}` in the body template is replaced with the tracing ID
+/// passed to `orchestrate`.
+#[tokio::test]
+async fn test_body_template_correlation_id_variable_is_substituted() {
+    let config = OrchestratorConfig {
+        body_template: "Trace: ${correlation_id}".to_string(),
+        ..OrchestratorConfig::default()
+    };
+    let github = TestGitHub::new();
+    let orchestrator = ReleaseOrchestrator::new(config, &github);
+
+    orchestrator
+        .orchestrate(
+            "testorg",
+            "testrepo",
+            &ver(1, 0, 0),
+            "- feat: something [ab12cd34ef5678901234abcdef12345678901234]",
+            "main",
+            "sha-cid-001",
+            "trace-abc-123",
+        )
+        .await
+        .expect("orchestrate should succeed");
+
+    let prs = github.created_prs().await;
+    let body = prs[0].body.as_deref().unwrap_or("");
+    assert!(
+        body.contains("Trace: trace-abc-123"),
+        "body must contain correlation_id; body:\n{body}"
+    );
+}
+
+/// `${repository}` in the body template is replaced with `"owner/repo"`.
+#[tokio::test]
+async fn test_body_template_repository_variable_is_substituted() {
+    let config = OrchestratorConfig {
+        body_template: "Repo: ${repository}".to_string(),
+        ..OrchestratorConfig::default()
+    };
+    let github = TestGitHub::new();
+    let orchestrator = ReleaseOrchestrator::new(config, &github);
+
+    orchestrator
+        .orchestrate(
+            "myorg",
+            "myrepo",
+            &ver(1, 0, 0),
+            "- feat: something [ab12cd34ef5678901234abcdef12345678901234]",
+            "main",
+            "sha-repo-001",
+            "corr-repo-001",
+        )
+        .await
+        .expect("orchestrate should succeed");
+
+    let prs = github.created_prs().await;
+    let body = prs[0].body.as_deref().unwrap_or("");
+    assert!(
+        body.contains("Repo: myorg/myrepo"),
+        "body must contain owner/repo format; body:\n{body}"
+    );
+}
+
+/// `${branch}` in the body template is replaced with the base branch name.
+#[tokio::test]
+async fn test_body_template_branch_variable_is_substituted() {
+    let config = OrchestratorConfig {
+        body_template: "Branch: ${branch}".to_string(),
+        ..OrchestratorConfig::default()
+    };
+    let github = TestGitHub::new();
+    let orchestrator = ReleaseOrchestrator::new(config, &github);
+
+    orchestrator
+        .orchestrate(
+            "testorg",
+            "testrepo",
+            &ver(1, 0, 0),
+            "- feat: something [ab12cd34ef5678901234abcdef12345678901234]",
+            "develop",
+            "sha-branch-001",
+            "corr-branch-001",
+        )
+        .await
+        .expect("orchestrate should succeed");
+
+    let prs = github.created_prs().await;
+    let body = prs[0].body.as_deref().unwrap_or("");
+    assert!(
+        body.contains("Branch: develop"),
+        "body must contain branch name; body:\n{body}"
+    );
+}
+
+/// `${previous_version}` defaults to `"initial release"` when there is no
+/// prior release PR (create path).
+#[tokio::test]
+async fn test_body_template_previous_version_defaults_to_initial_release() {
+    let config = OrchestratorConfig {
+        body_template: "Previous: ${previous_version}".to_string(),
+        ..OrchestratorConfig::default()
+    };
+    let github = TestGitHub::new();
+    let orchestrator = ReleaseOrchestrator::new(config, &github);
+
+    orchestrator
+        .orchestrate(
+            "testorg",
+            "testrepo",
+            &ver(1, 0, 0),
+            "- feat: first [ab12cd34ef5678901234abcdef12345678901234]",
+            "main",
+            "sha-pv-none-001",
+            "corr-pv-none-001",
+        )
+        .await
+        .expect("orchestrate should succeed");
+
+    let prs = github.created_prs().await;
+    let body = prs[0].body.as_deref().unwrap_or("");
+    assert!(
+        body.contains("Previous: initial release"),
+        "body must show 'initial release' when no prior version; body:\n{body}"
+    );
+}
+
+/// `${previous_version}` is populated with the old PR's version when an
+/// existing lower-version PR is renamed (rename path).
+#[tokio::test]
+async fn test_body_template_previous_version_set_when_renaming_existing_pr() {
+    let config = OrchestratorConfig {
+        body_template: "Previous: ${previous_version}".to_string(),
+        ..OrchestratorConfig::default()
+    };
+
+    // Existing PR at v1.0.0 — lower than the incoming v2.0.0.
+    let old_pr = make_open_release_pr(10, "release/v1.0.0", None);
+
+    let github = TestGitHub::new()
+        .with_search_results(vec![old_pr.clone()])
+        .await;
+
+    let orchestrator = ReleaseOrchestrator::new(config, &github);
+
+    let result = orchestrator
+        .orchestrate(
+            "testorg",
+            "testrepo",
+            &ver(2, 0, 0),
+            "- feat: big feature [ab12cd34ef5678901234abcdef12345678901234]",
+            "main",
+            "sha-pv-rename-001",
+            "corr-pv-rename-001",
+        )
+        .await
+        .expect("orchestrate should succeed");
+
+    assert!(
+        matches!(result, OrchestratorResult::Renamed { .. }),
+        "expected Renamed result; got {result:?}"
+    );
+
+    let prs = github.created_prs().await;
+    assert_eq!(prs.len(), 1, "one new PR should be created for v2.0.0");
+    let body = prs[0].body.as_deref().unwrap_or("");
+    assert!(
+        body.contains("Previous: 1.0.0"),
+        "body must show the old version as previous_version; body:\n{body}"
+    );
+}
+
+/// Legacy `{variable}` syntax (without the `$` prefix) in the body template is
+/// expanded for backward compatibility, matching the behaviour of `render_title`.
+#[tokio::test]
+async fn test_body_template_legacy_brace_syntax_is_substituted() {
+    let config = OrchestratorConfig {
+        body_template: "Tag: {version_tag} | Repo: {repository}".to_string(),
+        ..OrchestratorConfig::default()
+    };
+    let github = TestGitHub::new();
+    let orchestrator = ReleaseOrchestrator::new(config, &github);
+
+    orchestrator
+        .orchestrate(
+            "acme",
+            "widget",
+            &ver(3, 0, 0),
+            "- feat: something [ab12cd34ef5678901234abcdef12345678901234]",
+            "main",
+            "sha-legacy-001",
+            "corr-legacy-001",
+        )
+        .await
+        .expect("orchestrate should succeed");
+
+    let prs = github.created_prs().await;
+    let body = prs[0].body.as_deref().unwrap_or("");
+    assert!(
+        body.contains("Tag: v3.0.0"),
+        "legacy {{version_tag}} must be substituted; body:\n{body}"
+    );
+    assert!(
+        body.contains("Repo: acme/widget"),
+        "legacy {{repository}} must be substituted; body:\n{body}"
+    );
+}

--- a/crates/core/src/release_orchestrator_tests.rs
+++ b/crates/core/src/release_orchestrator_tests.rs
@@ -1235,7 +1235,7 @@ async fn test_body_template_is_used_in_pr_body() {
             "template prefix missing; body:\n{body}"
         );
         assert!(
-            body.ends_with("---\n*auto-generated*"),
+            body.contains("---\n*auto-generated*"),
             "template suffix missing; body:\n{body}"
         );
         // Only current-release entries are present.
@@ -2949,5 +2949,120 @@ async fn test_body_template_legacy_brace_syntax_is_substituted() {
     assert!(
         body.contains("Repo: acme/widget"),
         "legacy {{repository}} must be substituted; body:\n{body}"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// render_body sentinel — round-trip tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// `render_body` appends an HTML sentinel comment so the update path can
+/// recover the original `previous_version` without parsing the template output.
+#[tokio::test]
+async fn test_render_body_appends_previous_version_sentinel() {
+    let config = OrchestratorConfig {
+        body_template: "## Release ${version}\n\n${changelog}".to_string(),
+        ..OrchestratorConfig::default()
+    };
+    let github = TestGitHub::new();
+    let orchestrator = ReleaseOrchestrator::new(config, &github);
+
+    orchestrator
+        .orchestrate(
+            "testorg",
+            "testrepo",
+            &ver(2, 0, 0),
+            "- feat: thing [ab12cd34ef5678901234abcdef12345678901234]",
+            "main",
+            "sha-sentinel-001",
+            "corr-sentinel-001",
+        )
+        .await
+        .expect("orchestrate should succeed");
+
+    let prs = github.created_prs().await;
+    let body = prs[0].body.as_deref().unwrap_or("");
+    // The sentinel must be present.
+    assert!(
+        body.contains("<!-- release-regent: previous-version=initial release -->"),
+        "sentinel must be appended on the create path; body:\n{body}"
+    );
+    // The visible template content must still be present.
+    assert!(
+        body.contains("## Release 2.0.0"),
+        "template content missing; body:\n{body}"
+    );
+}
+
+/// `extract_previous_version_sentinel` returns `Some` when the sentinel is present.
+#[test]
+fn test_extract_previous_version_sentinel_returns_value_when_present() {
+    let body = "## Changelog\n\n- fix: thing\n<!-- release-regent: previous-version=1.2.3 -->";
+    assert_eq!(
+        super::extract_previous_version_sentinel(body),
+        Some("1.2.3".to_string())
+    );
+}
+
+/// `extract_previous_version_sentinel` returns `None` when the sentinel is absent.
+#[test]
+fn test_extract_previous_version_sentinel_returns_none_when_absent() {
+    assert_eq!(
+        super::extract_previous_version_sentinel("no sentinel here"),
+        None
+    );
+    assert_eq!(super::extract_previous_version_sentinel(""), None);
+}
+
+/// On the update (equal-version) path, `${previous_version}` in the re-rendered
+/// body must preserve the value from the existing PR body sentinel rather than
+/// resetting to `"initial release"`.
+#[tokio::test]
+async fn test_update_release_pr_preserves_previous_version_from_sentinel() {
+    // The existing PR was created via a rename v1.0.0 → v2.0.0, so its body
+    // contains the sentinel with "1.0.0".
+    let existing_body = concat!(
+        "Previous: 1.0.0\n## Changelog\n\n",
+        "- feat: first [aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1]\n",
+        "<!-- release-regent: previous-version=1.0.0 -->",
+    );
+    let config = OrchestratorConfig {
+        body_template: "Previous: ${previous_version}\n## Changelog\n\n${changelog}".to_string(),
+        ..OrchestratorConfig::default()
+    };
+
+    let existing_pr = make_open_release_pr(20, "release/v2.0.0", Some(existing_body));
+    let github = TestGitHub::new()
+        .with_search_results(vec![existing_pr.clone()])
+        .await
+        .with_pr_by_number(existing_pr)
+        .await;
+
+    let orchestrator = ReleaseOrchestrator::new(config, &github);
+
+    // Incoming version is the same (v2.0.0) → equal-version update path.
+    orchestrator
+        .orchestrate(
+            "testorg",
+            "testrepo",
+            &ver(2, 0, 0),
+            "- feat: second [aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa2]",
+            "main",
+            "sha-pv-update-001",
+            "corr-pv-update-001",
+        )
+        .await
+        .expect("orchestrate should succeed");
+
+    let updates = github.updated_prs().await;
+    assert_eq!(updates.len(), 1);
+    let new_body = updates[0].2.as_deref().unwrap_or("");
+    assert!(
+        new_body.contains("Previous: 1.0.0"),
+        "previous_version must be preserved from sentinel on update path; body:\n{new_body}"
+    );
+    assert!(
+        !new_body.contains("Previous: initial release"),
+        "must not regress to 'initial release' on update path; body:\n{new_body}"
     );
 }

--- a/crates/core/src/release_orchestrator_tests.rs
+++ b/crates/core/src/release_orchestrator_tests.rs
@@ -3066,3 +3066,69 @@ async fn test_update_release_pr_preserves_previous_version_from_sentinel() {
         "must not regress to 'initial release' on update path; body:\n{new_body}"
     );
 }
+
+/// Two successive equal-version updates must not accumulate sentinel lines.
+///
+/// Regression guard for the bug where the sentinel appended by `render_body`
+/// leaks into the extracted changelog section (when `${changelog}` is the last
+/// section), survives `merge_changelog_sections` verbatim, and is then re-passed
+/// as `ctx.changelog` so that each update appends one more sentinel.
+#[tokio::test]
+async fn test_successive_updates_do_not_accumulate_sentinels() {
+    // Build a PR body that already went through one render_body call:
+    // it contains the sentinel once (as produced by the previous update).
+    let sha1 = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1";
+    let existing_body = format!(
+        concat!(
+            "## Changelog\n\n",
+            "- feat: first [{sha1}]\n",
+            "<!-- release-regent: previous-version=initial release -->"
+        ),
+        sha1 = sha1
+    );
+
+    let existing_pr = make_open_release_pr(30, "release/v1.0.0", Some(&existing_body));
+    let github = TestGitHub::new()
+        .with_search_results(vec![existing_pr.clone()])
+        .await
+        .with_pr_by_number(existing_pr)
+        .await;
+
+    let sha2 = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb2";
+    let orchestrator = ReleaseOrchestrator::new(default_config(), &github);
+
+    // Second update — same version, adds a new commit.
+    orchestrator
+        .orchestrate(
+            "testorg",
+            "testrepo",
+            &ver(1, 0, 0),
+            &format!("- feat: second [{sha2}]"),
+            "main",
+            "sha-accum-001",
+            "corr-accum-001",
+        )
+        .await
+        .expect("orchestrate should succeed");
+
+    let updates = github.updated_prs().await;
+    assert_eq!(updates.len(), 1, "expected exactly one PR update");
+    let new_body = updates[0].2.as_deref().unwrap_or("");
+
+    // The sentinel must appear exactly once.
+    let sentinel = "<!-- release-regent: previous-version=";
+    assert_eq!(
+        new_body.matches(sentinel).count(),
+        1,
+        "sentinel must appear exactly once after two updates; body:\n{new_body}"
+    );
+    // Both changelog entries must be present.
+    assert!(
+        new_body.contains("first"),
+        "first entry must be preserved; body:\n{new_body}"
+    );
+    assert!(
+        new_body.contains("second"),
+        "second entry must be present; body:\n{new_body}"
+    );
+}


### PR DESCRIPTION
## Summary

Release PR descriptions contained unexpanded template placeholders (e.g. \, \, \, \) because \ender_body\ only substituted \\\.

## Changes

- \ender_body\ now accepts a \SemanticVersion\ parameter and substitutes all supported template variables:
  - \\\ → version with configured prefix (e.g. \0.7.1\)
  - \\\ → bare version string (e.g. \