### PR TITLE
chore: Changing the VSCode window title to include the repository name

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,3 @@
-// .vscode/settings.json  (inside the worktree folder, e.g. myrepo/feature-x/)
 {
     "window.title": "release-regent - ${activeRepositoryBranchName}${separator}${activeEditorShort}${dirty}"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+// .vscode/settings.json  (inside the worktree folder, e.g. myrepo/feature-x/)
+{
+    "window.title": "release-regent - ${activeRepositoryBranchName}${separator}${activeEditorShort}${dirty}"
+}


### PR DESCRIPTION
So that it is possible to recognize where you are when the repository workspace is a worktree environment